### PR TITLE
feat : CI — GitHub Actions workflow for tests on PR/main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Boot Docker stack
+        run: docker compose up -d --build
+
+      - name: Smoke test (wait for PHP + DB)
+        run: ./docker/smoke_test.sh
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install Python deps
+        run: pip install -r requirements.txt
+
+      - name: Install Playwright Chromium
+        run: playwright install --with-deps chromium
+
+      - name: Run pytest
+        run: pytest tests/ -v
+
+      - name: Capture docker logs on failure
+        if: failure()
+        run: docker compose logs --tail=200

--- a/README_setup_windows.md
+++ b/README_setup_windows.md
@@ -79,7 +79,7 @@ On success prints `=== PASS: Docker setup is healthy ===`.
 Install Python dependencies (one-time):
 
 ```bash
-python3 -m pip install --user pytest pymysql pytest-playwright playwright
+python3 -m pip install --user -r requirements.txt
 playwright install chromium
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pymysql
+pytest-playwright
+playwright


### PR DESCRIPTION
## Summary
  - Adds `.github/workflows/test.yml`: boots Docker stack → smoke test → install Python deps + Playwright Chromium → `pytest tests/ -v`. Dumps docker logs on failure.
  - Triggers on PRs to `main` and pushes to `main`. 20-min timeout.                                                                                                   
  - Extracts test deps to `requirements.txt` so CI and `README_setup_windows.md` share one source.                                                                                                                 
                                                                                                                                                                                                                   
  Linked to issue #1 (Add unit tests).