### PR TITLE
feat : Issue #2 — test-system upgrades: close partial-coverage gaps + trivial housekeeping

### DIFF
--- a/controllers/management.php
+++ b/controllers/management.php
@@ -1,6 +1,4 @@
 <?php
-session_start();
-
 $pageName = 'Controller Management';
 
 require_once '../base/basePHP.php';

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -548,3 +548,53 @@ def ui_controller_counters(page: Page, lastname: str, base_url: str = None):
         "turn_recruited_workers": _as_int(_cell("turn_recruited_workers")),
         "turn_firstcome_workers": _as_int(_cell("turn_firstcome_workers")),
     }
+
+
+def ui_faction_sections(page: Page, controller_lastname: str, base_url: str = None):
+    """Return the 4 workers/viewAll.php sections for a given controller.
+
+    Switches session to the controller via
+    base/accueil.php?controller_id=X&chosir=Choisir, then loads
+    workers/viewAll.php and classifies each rendered worker-short card
+    by the h3 heading of its parent box:
+
+      'live'      — "Nos Agents :"          (active, we primarily control)
+      'doubles'   — "Nos Agents doubles :"  (active, we don't primarily control)
+      'prisoners' — "Nos Prisonniers :"     (captured by us)
+      'ancients'  — "Nos Anciens agents :"  (dead / our captured-by-others / traces)
+
+    Returns {section_key: set(lastname, ...)} for all 4 keys (empty sets
+    if a section has no workers or is not rendered).
+
+    Lastname is extracted from the anchor text inside div.worker-short,
+    which renders as "{firstname} {lastname}" (see showWorkerShort in
+    workers/functions.php).
+    """
+    url = base_url or PHP_BASE_URL
+    ctrl_id = ui_controller_id(page, controller_lastname, base_url=url)
+    page.goto(f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    page.wait_for_load_state("networkidle")
+    page.goto(f"{url}/workers/viewAll.php")
+    page.wait_for_load_state("load")
+
+    heading_to_key = {
+        'Nos Agents :': 'live',
+        'Nos Agents doubles :': 'doubles',
+        'Nos Prisonniers :': 'prisoners',
+        'Nos Anciens agents :': 'ancients',
+    }
+    result = {'live': set(), 'doubles': set(), 'prisoners': set(), 'ancients': set()}
+    for box in page.locator('div.box').all():
+        h3_texts = box.locator('h3').all_inner_texts()
+        key = None
+        for ht in h3_texts:
+            if ht.strip() in heading_to_key:
+                key = heading_to_key[ht.strip()]
+                break
+        if key is None:
+            continue
+        for a in box.locator('div.worker-short a.has-text-weight-semibold').all():
+            parts = (a.inner_text() or '').strip().split()
+            if parts:
+                result[key].add(parts[-1])
+    return result

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -56,7 +56,7 @@ from helpers import (
     DB_AVAILABLE, get_db_connection as get_db,
     end_turn, load_minimal_data,
     ui_all_workers, ui_controller_id, ui_worker_id, ui_worker_controller_id,
-    ui_workers_by_lastname, ui_faction_sections,
+    ui_workers_by_lastname, ui_faction_sections, ui_zone_id,
 )
 
 
@@ -192,6 +192,22 @@ def _ui_claim(page, lastname, claim_controller_lastname):
     page.wait_for_load_state("load")
 
 
+def _ui_move(page, lastname, zone_name):
+    """Move worker to another zone via workers/action.php URL endpoint.
+
+    moveWorker (workers/functions.php) is IMMEDIATE: it updates
+    workers.zone_id right away AND forcibly changes the current turn's
+    action_choice to 'passive' (replacing whatever was queued).
+    """
+    wid = _cached_wid(page, lastname)
+    zid = ui_zone_id(page, zone_name)
+    page.goto(
+        f"{PHP_BASE_URL}/workers/action.php"
+        f"?worker_id={wid}&zone_id={zid}&move=1"
+    )
+    page.wait_for_load_state("load")
+
+
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +281,13 @@ def combat_scenario(browser):
     _ui_attack(page, 'Claim_Atk_2', 'Claim_Def_2')
     _ui_claim(page, 'Claim_Def_1', 'Beta')
     _ui_claim(page, 'Claim_Def_2', 'Delta')
+
+    # Cross-zone attack: Runner flees to Delta-Disputed, but Hunter's
+    # queued attack still lands. With LIMIT_ATTACK_BY_ZONE=0 (TestConfig
+    # default) the attack-pair SQL has no zone filter. moveWorker()
+    # clobbers Runner's action to 'passive' but doesn't touch Hunter's.
+    _ui_move(page, 'Runner_Cross', 'Delta-Disputed')
+    _ui_attack(page, 'Hunter_Cross', 'Runner_Cross')
 
     # End turn 1 → 2 (combat resolves)
     end_turn(page)
@@ -656,3 +679,57 @@ class TestActionBlockedByCombat:
             f"Beta-Combat should remain unclaimed in zones management UI, "
             f"but holder_id select has value={selected_value!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests: cross-zone attack (LIMIT_ATTACK_BY_ZONE=0 default behavior)
+# ---------------------------------------------------------------------------
+
+class TestCrossZoneAttack:
+    """Issue #2: 'Agent attack of another agent that has moved'.
+
+    Setup (combat_scenario fixture):
+      - Hunter_Cross (Alpha, Beta-Combat) action=investigate on turn 0.
+        Powers: Eagle Scout|Patrol Warden → enq=6, atk=4, def=4.
+      - Runner_Cross (Beta, Beta-Combat)  action=passive     on turn 0.
+        Powers: Blank Slate|Common Folk → enq=3, atk=3, def=3.
+      - End turn 0 → 1: Hunter detects Runner (adds a known_enemies row).
+      - Between turns 1 and 2:
+          * Runner moves to Delta-Disputed (moveWorker forces Runner's
+            current-turn action to 'passive' and updates workers.zone_id).
+          * Hunter queues worker-scope attack on Runner.
+      - End turn 1 → 2: attack resolves. With LIMIT_ATTACK_BY_ZONE=0
+        (TestConfig inherits the default from minimalData.sql) the
+        attack-pair SQL has no zone filter, so the attack lands
+        cross-zone. Hunter atk=4 vs Runner def=3 → attack_difference=1
+        → ATTACKDIFF0 met, ATTACKDIFF1 not met → KILL (not capture).
+    """
+
+    def test_runner_moved_to_delta(self, page: Page, base_url):
+        """Runner_Cross's moveWorker call updated workers.zone_id to
+        Delta-Disputed — verified via /workers/management_workers.php
+        (which renders each worker's current zone_name).
+        """
+        ensure_gm_login(page, base_url)
+        workers = ui_all_workers(page, base_url=base_url)
+        runner = next((w for w in workers if w['lastname'] == 'Runner_Cross'), None)
+        assert runner is not None, "Runner_Cross should exist in workers list"
+        assert runner['zone_name'] == 'Delta-Disputed', \
+            f"Runner_Cross should be in Delta-Disputed after move, got {runner['zone_name']!r}"
+
+    def test_runner_is_dead(self, page: Page, base_url):
+        """Runner_Cross should be dead after the cross-zone kill.
+
+        UI: Runner's own view.php page shows 'A disparu' (txt_ps_dead)
+        and no action form."""
+        assert _ui_worker_is_downed(page, 'Runner_Cross'), \
+            "Runner_Cross should be dead after cross-zone attack from Hunter_Cross"
+
+    def test_hunter_report_mentions_kill(self, page: Page, base_url):
+        """Hunter's worker-view report should reference Runner by name —
+        either 'succeeded' (kill text) or 'Captured' depending on the
+        exact attack_difference. We only assert the target is named,
+        keeping the assertion robust to template wording."""
+        html = _worker_report_html(page, 'Hunter_Cross')
+        assert 'Runner_Cross' in html, \
+            "Hunter_Cross's page should reference Runner_Cross in the attack report"

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -56,7 +56,7 @@ from helpers import (
     DB_AVAILABLE, get_db_connection as get_db,
     end_turn, load_minimal_data,
     ui_all_workers, ui_controller_id, ui_worker_id, ui_worker_controller_id,
-    ui_workers_by_lastname,
+    ui_workers_by_lastname, ui_faction_sections,
 )
 
 
@@ -493,6 +493,36 @@ class TestChainAttack:
         non_trace = [r for r in rows if r['action_choice'] != 'trace']
         assert non_trace and non_trace[0]['action_choice'] in ('captured', 'prisoner', 'dead'), \
             f"Chain_B original should be captured/prisoner/dead, got: {non_trace}"
+
+    def test_captor_faction_view_has_chain_b_as_prisoner(self, page: Page, base_url):
+        """Captor Alpha's faction view (workers/viewAll.php) should show
+        Chain_B in 'Nos Prisonniers' (captured worker's row has
+        controller_id=Alpha, action='captured', is_primary_controller=1).
+
+        Chain_B must NOT appear in 'Nos Agents' (that section is for
+        active workers the controller primarily owns)."""
+        ensure_gm_login(page, base_url)
+        sections = ui_faction_sections(page, 'Alpha', base_url=base_url)
+        assert 'Chain_B' in sections['prisoners'], \
+            f"Alpha should see Chain_B in Nos Prisonniers; got {sections}"
+        assert 'Chain_B' not in sections['live'], \
+            f"Alpha should NOT see Chain_B in Nos Agents; got live={sections['live']}"
+
+    def test_origin_faction_view_has_chain_b_trace_as_ancient(self, page: Page, base_url):
+        """Original owner Beta's faction view should show Chain_B as a
+        trace in 'Nos Anciens agents' (the trace row has controller_id=
+        Beta, action='trace', is_primary_controller=1 — action 'trace'
+        is in INACTIVE_ACTIONS but not 'captured', so workers/viewAll.php
+        puts it in the 'ancients' section).
+
+        Chain_B must NOT appear in 'Nos Agents' — the original (now
+        captured) row was moved to Alpha."""
+        ensure_gm_login(page, base_url)
+        sections = ui_faction_sections(page, 'Beta', base_url=base_url)
+        assert 'Chain_B' in sections['ancients'], \
+            f"Beta should see Chain_B trace in Nos Anciens agents; got {sections}"
+        assert 'Chain_B' not in sections['live'], \
+            f"Beta should NOT see Chain_B in Nos Agents; got live={sections['live']}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -91,38 +91,6 @@ def base_url():
     return PHP_BASE_URL
 
 
-# ---------------------------------------------------------------------------
-# Helpers: DB lookups
-# ---------------------------------------------------------------------------
-
-def _worker_status(lastname, turn=1):
-    """Return action_choice for a worker at a given turn."""
-    conn = get_db()
-    cursor = conn.cursor()
-    cursor.execute(f"""
-        SELECT wa.action_choice FROM `{GAME_PREFIX}worker_actions` wa
-        JOIN `{GAME_PREFIX}workers` w ON w.id = wa.worker_id
-        WHERE w.lastname = %s AND wa.turn_number = %s
-    """, (lastname, turn))
-    row = cursor.fetchone()
-    conn.close()
-    return row['action_choice'] if row else None
-
-
-def _worker_report_db(lastname, turn=1):
-    """Return the report JSON string for a worker at a given turn."""
-    conn = get_db()
-    cursor = conn.cursor()
-    cursor.execute(f"""
-        SELECT wa.report FROM `{GAME_PREFIX}worker_actions` wa
-        JOIN `{GAME_PREFIX}workers` w ON w.id = wa.worker_id
-        WHERE w.lastname = %s AND wa.turn_number = %s
-    """, (lastname, turn))
-    row = cursor.fetchone()
-    conn.close()
-    return str(row['report'] or '') if row else ''
-
-
 def _ensure_controller_session(page):
     """Ensure the gm is logged in and has a controller selected."""
     ensure_gm_login(page, PHP_BASE_URL)

--- a/tests/test_agent_detection_e2e.py
+++ b/tests/test_agent_detection_e2e.py
@@ -571,6 +571,37 @@ class TestLocationDetection:
         page.wait_for_load_state("networkidle")
         assert "Location A" not in page.content()
 
+    # --- Artefact visibility (requires enquete_difference >= LOCATIONARTEFACTSDIFF=2) ---
+
+    def test_artefact_visible_at_secret_level(self, page: Page, base_url):
+        """Finder_1 (Charlie, enq=7, diff=3) has enquete_difference >=
+        LOCATIONARTEFACTSDIFF (2), so their secrets_report lists the
+        artefact linked to Location A (Artefact Alpha, loaded from
+        setupTestConfig_artefacts.csv)."""
+        html = _worker_report_html(page, 'Finder_1', base_url)
+        assert 'Location A' in html, "Prerequisite: Finder_1 must see Location A"
+        assert 'Artefact Alpha' in html, \
+            "Finder_1 at enquete_difference=3 should see the artefact name in report"
+
+    def test_artefact_not_visible_at_desc_level(self, page: Page, base_url):
+        """Finder_4 (Foxtrot, enq=5, diff=1) sees NAME + DESCRIPTION but
+        enquete_difference=1 < LOCATIONARTEFACTSDIFF (2), so the
+        artefact name must NOT appear in their report."""
+        html = _worker_report_html(page, 'Finder_4', base_url)
+        assert 'Location A' in html, "Prerequisite: Finder_4 must still see Location A"
+        assert 'test location' in html.lower(), \
+            "Prerequisite: Finder_4 must see the description"
+        assert 'Artefact Alpha' not in html, \
+            "Finder_4 at enquete_difference=1 must NOT see the artefact"
+
+    def test_artefact_not_visible_at_name_only_level(self, page: Page, base_url):
+        """Finder_5 (Golf, enq=4, diff=0) sees only the location NAME;
+        artefact visibility requires enquete_difference >= 2 so it must
+        not appear."""
+        html = _worker_report_html(page, 'Finder_5', base_url)
+        assert 'Artefact Alpha' not in html, \
+            "Finder_5 at enquete_difference=0 must NOT see the artefact"
+
 
 # ---------------------------------------------------------------------------
 # Test: worker view page renders report correctly

--- a/tests/test_csv_features_e2e.py
+++ b/tests/test_csv_features_e2e.py
@@ -271,13 +271,13 @@ class TestLoadWorkersCSV:
     """
 
     def test_workers_table_populated(self, page: Page, base_url):
-        """Exactly 26 workers should exist.
+        """Exactly 28 workers should exist (7 detection + 19 combat + 2 cross).
 
         Counts rows on /workers/management_workers.php — UI-runnable.
         """
         ensure_gm_login(page, base_url)
         count = ui_worker_count(page, base_url=base_url)
-        assert count == 26, f"Expected 26 workers, got {count}"
+        assert count == 28, f"Expected 28 workers, got {count}"
 
     @pytest.mark.db
     def test_all_workers_have_origin_and_zone(self):
@@ -365,6 +365,8 @@ class TestLoadWorkersCSV:
             # Blocked claim (Beta-Combat zone)
             'Claim_Atk_1': 'Echo', 'Claim_Def_1': 'Beta',
             'Claim_Atk_2': 'Charlie', 'Claim_Def_2': 'Delta',
+            # Cross-zone attack (Beta-Combat → Delta-Disputed)
+            'Hunter_Cross': 'Alpha', 'Runner_Cross': 'Beta',
         }
         assert mapping == expected, f"Worker-controller mapping wrong: got {mapping}"
 
@@ -378,10 +380,16 @@ class TestLoadWorkersCSV:
             f"Searcher_1 action_choice should be 'investigate', got {workers['Searcher_1']}"
 
     def test_other_agents_have_passive_action(self, page: Page, base_url):
-        """All other agents should have action_choice='passive' at turn 0."""
+        """All other agents should have action_choice='passive' at turn 0.
+
+        Exceptions (CSV-seeded with a non-passive action):
+          - Searcher_1 (detection): action='investigate'
+          - Hunter_Cross (cross-zone scenario): action='investigate'
+        """
         ensure_gm_login(page, base_url)
+        investigate_agents = {'Searcher_1', 'Hunter_Cross'}
         for w in ui_all_workers(page, base_url=base_url):
-            if w['lastname'] == 'Searcher_1':
+            if w['lastname'] in investigate_agents:
                 continue
             assert w['action_choice'] == 'passive', \
                 f"Worker '{w['lastname']}' has action '{w['action_choice']}', expected 'passive'"

--- a/tests/test_empty_scenario_e2e.py
+++ b/tests/test_empty_scenario_e2e.py
@@ -60,9 +60,11 @@ def load_empty_scenario(browser):
     page.wait_for_timeout(5000)
     page.wait_for_load_state("load", timeout=90000)
 
-    # Remove all locations so locationSearchMechanic finds nothing
+    # Remove all locations so locationSearchMechanic finds nothing.
+    # Artefacts FK-reference locations, so delete them first.
     conn = get_db_connection()
     cursor = conn.cursor()
+    cursor.execute(f"DELETE FROM `{GAME_PREFIX}artefacts`")
     cursor.execute(f"DELETE FROM `{GAME_PREFIX}locations`")
     # Move all agents to the same controller so investigateMechanic finds no enemies
     # Must update both controller_worker AND worker_actions.controller_id

--- a/tests/test_parallel_games_e2e.py
+++ b/tests/test_parallel_games_e2e.py
@@ -186,13 +186,13 @@ class TestBothGamesLoaded:
         assert count == 9, f"Expected 9 Shikoku workers, got {count}"
 
     def test_primary_has_workers(self, page: Page, base_url):
-        """TestConfig in primary loaded 26 workers (detection + combat + recruitment).
+        """TestConfig in primary loaded 28 workers (7 detection + 19 combat + 2 cross).
 
         Counts rows on /workers/management_workers.php on the primary URL.
         """
         login_as(page, base_url, "gm", "orga")
         count = ui_worker_count(page, base_url=base_url)
-        assert count == 26, f"Expected 26 TestConfig workers, got {count}"
+        assert count == 28, f"Expected 28 TestConfig workers, got {count}"
 
     def test_secondary_has_shikoku_zones(self, page: Page, base_url):
         """Secondary has Shikoku zones (11 total). Counted via management_zones."""

--- a/var/csv/setupTestConfig_advanced.csv
+++ b/var/csv/setupTestConfig_advanced.csv
@@ -25,3 +25,5 @@ combat,Claim_Atk_1,origine Accessible,Beta-Combat,Echo,passive,{},Eagle Scout|Ve
 combat,Claim_Def_1,origine Accessible,Beta-Combat,Beta,passive,{},Dark Impulse|Common Folk
 combat,Claim_Atk_2,origine Accessible,Beta-Combat,Charlie,passive,{},Eagle Scout|Patrol Warden
 combat,Claim_Def_2,origine Accessible,Beta-Combat,Delta,passive,{},Blank Slate|Common Folk
+cross,Hunter_Cross,origine Accessible,Beta-Combat,Alpha,investigate,{},Eagle Scout|Patrol Warden
+cross,Runner_Cross,origine Accessible,Beta-Combat,Beta,passive,{},Blank Slate|Common Folk

--- a/var/csv/setupTestConfig_artefacts.csv
+++ b/var/csv/setupTestConfig_artefacts.csv
@@ -1,0 +1,2 @@
+name,description,full_description,locations__name->location_id
+Artefact Alpha,Ancient relic concealed in Location A,Full lore about Artefact Alpha revealed only to the controller of the location,Location A


### PR DESCRIPTION
Contributes to #2.                                                                                                                                                                                               
                      
  - **Gap 1 (UI)** — captured worker now verified in both controllers' own faction views (`workers/viewAll.php`), not just the admin page. New `ui_faction_sections` helper + 2 tests in `TestChainAttack`.        
  - **Gap 2 (UI)** — new `TestCrossZoneAttack` class + `_ui_move` helper verifying the default `LIMIT_ATTACK_BY_ZONE=0` behavior: agent moved to another zone still dies from the attacker's queued hit. Adds 2 new
   `cross` agents to `setupTestConfig_advanced.csv`.                                                                                                                                                               
  - **Gap 3 (UI)** — new `setupTestConfig_artefacts.csv` (TestConfig had no artefact, so the `LOCATIONARTEFACTSDIFF=2` threshold couldn't be tested). 3 new tests in `TestLocationDetection` cover visible/hidden
  artefact per `enquete_difference`.                                                                                                  
  - **Housekeeping (S1/S2)** — remove dead `_worker_status` / `_worker_report_db` helpers and a redundant `session_start()` in `controllers/management.php` (no behavior change; `basePHP.php` already handles it).
