### PR TITLE
fix + test : move-after-attack clears action_params    

### DIFF
--- a/mechanics/attackMechanic.php
+++ b/mechanics/attackMechanic.php
@@ -303,7 +303,7 @@ function attackMechanic($pdo, $mechanics){
             $attackerReport= array();
             $defenderReport= array();
             $defender_status = NULL;
-            $defender_json = array();
+            $defender_json = null;
             $attacker_status = NULL;
             $survived = true;
 

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -263,6 +263,15 @@ def combat_scenario(browser):
     _ui_attack(page, 'Mover_Test', 'Chain_A')
     _ui_move(page, 'Mover_Test', 'Delta-Disputed')
 
+    # Keep-action-params-on-miss: Keep_Def queues claim for Alpha;
+    # Keep_Atk attacks Keep_Def. Equal 3/3/3 stats → attack_difference=0
+    # < ATTACKDIFF0=1 → miss. Both survive. Keep_Def's action_params
+    # (claim target) must survive the defender-branch of attackMechanic
+    # without being wiped to '{}' — regression guard for the
+    # updateWorkerAction gate change (see TestAttackKeepsDefenderParams).
+    _ui_claim(page, 'Keep_Def', 'Alpha')
+    _ui_attack(page, 'Keep_Atk', 'Keep_Def')
+
     # End turn 1 → 2 (combat resolves)
     end_turn(page)
 
@@ -764,3 +773,57 @@ class TestMoveClearsActionParams:
             f"After move-after-attack, action_choice should be 'passive', got {row['action_choice']!r}"
         assert row['action_params'] == '{}', \
             f"action_params should be empty JSON '{{}}' after move, got {row['action_params']!r}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: attackMechanic preserves surviving defender's action_params
+# ---------------------------------------------------------------------------
+
+class TestAttackKeepsDefenderParams:
+    """Regression guard for the `$defender_json = null` initialization in
+    attackMechanic.php (vs the earlier `array()`).
+
+    Context: the updateWorkerAction gate was tightened from
+    `!empty($jsonArray)` to `$jsonArray !== null` so moveWorker could reset
+    action_params to '{}'. That silently introduced a behaviour change
+    at attackMechanic.php:449 where non-capture defender paths
+    (kill / miss / escape / riposte) pass $defender_json to
+    updateWorkerAction. The loop initializes $defender_json per iteration
+    and only populates it inside the capture branch, so miss-path
+    defenders would previously have passed `array()` and had their
+    action_params wiped to '{}'. Fix: initialize to null instead.
+
+    Setup (combat_scenario fixture):
+      - Keep_Def (Beta, Beta-Combat, Blank Slate|Common Folk → 3/3/3)
+        queues `claim` for Alpha on turn 1 — populates action_params
+        with {"claim_controller_id": Alpha_id}.
+      - Keep_Atk (Foxtrot, same powers → 3/3/3) queues attack on
+        Keep_Def. attack_difference = 3-3 = 0 < ATTACKDIFF0=1 → miss.
+        riposte_difference = 0 < RIPOSTDIFF=2 → no counter. Both
+        survive.
+      - End turn 1 → 2.
+
+    If the fix works, Keep_Def's turn-1 action_params still contain the
+    claim target. If not (pre-fix `array()` init), params are wiped to
+    '{}' during the defender loop.
+    """
+
+    @pytest.mark.db
+    def test_keep_def_preserves_claim_params_after_survived_miss(self):
+        """Keep_Def survives Keep_Atk's miss; its turn-1 action_params
+        must still contain the queued claim_controller_id."""
+        conn = get_db()
+        cursor = conn.cursor()
+        cursor.execute(f"""
+            SELECT wa.action_choice, wa.action_params
+            FROM `{GAME_PREFIX}worker_actions` wa
+            JOIN `{GAME_PREFIX}workers` w ON w.id = wa.worker_id
+            WHERE w.lastname = 'Keep_Def' AND wa.turn_number = 1
+        """)
+        row = cursor.fetchone()
+        conn.close()
+        assert row is not None, "Keep_Def must have a turn-1 worker_actions row"
+        assert row['action_choice'] == 'claim', \
+            f"Keep_Def should still have action_choice='claim' after surviving miss, got {row['action_choice']!r}"
+        assert 'claim_controller_id' in (row['action_params'] or ''), \
+            f"Keep_Def's action_params must preserve claim_controller_id after surviving miss — regression guard for attackMechanic.php:306 init. Got: {row['action_params']!r}"

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -257,6 +257,12 @@ def combat_scenario(browser):
     _ui_move(page, 'Runner_Cross', 'Delta-Disputed')
     _ui_attack(page, 'Hunter_Cross', 'Runner_Cross')
 
+    # Move-clears-action-params: Mover_Test queues an attack THEN moves.
+    # moveWorker must clobber the action to 'passive' AND reset
+    # action_params to '{}' — no residual attack target data.
+    _ui_attack(page, 'Mover_Test', 'Chain_A')
+    _ui_move(page, 'Mover_Test', 'Delta-Disputed')
+
     # End turn 1 → 2 (combat resolves)
     end_turn(page)
 
@@ -298,11 +304,14 @@ def _ui_worker_is_downed(page, lastname):
 def _ui_worker_is_passive(page, lastname):
     """True if the worker's action.php view shows them as still passive.
 
-    txt_ps_passive => "surveille", ucfirst => "Surveille". The action form
-    must still be rendered (worker is active).
+    txt_ps_passive => "surveille", ucfirst => "Surveille". Checks for the
+    `name="passive"` submit button (rendered for every active worker
+    regardless of zone) rather than `name="attack"` (rendered only when
+    the controller has known alive enemies in the worker's current zone,
+    which breaks down for workers who moved to a zone with no targets).
     """
     html = _worker_report_html(page, lastname)
-    return 'Surveille' in html and 'name="attack"' in html
+    return 'Surveille' in html and 'name="passive"' in html
 
 
 def _ui_worker_is_attacking(page, lastname, target_lastname):
@@ -701,3 +710,57 @@ class TestCrossZoneAttack:
         html = _worker_report_html(page, 'Hunter_Cross')
         assert 'Runner_Cross' in html, \
             "Hunter_Cross's page should reference Runner_Cross in the attack report"
+
+
+# ---------------------------------------------------------------------------
+# Tests: moveWorker clears action_params on a previously-attacking worker
+# ---------------------------------------------------------------------------
+
+class TestMoveClearsActionParams:
+    """Regression guard: when a worker queues an attack and then moves
+    in the same turn, moveWorker() must reset the worker's
+    action_choice to 'passive' AND action_params to '{}'. The test
+    verifies both the UI rendering and the DB row directly.
+
+    Setup (combat_scenario fixture):
+      - Mover_Test (Alpha, Beta-Combat, passive on turn 0).
+      - Between turns: _ui_attack(Mover_Test, Chain_A), then
+        _ui_move(Mover_Test, 'Delta-Disputed').
+      - End turn 1 → 2.
+
+    If the clear works: Mover_Test survives (passive, moved).
+    If the clear fails: Mover_Test's attack fires (atk=3 vs Chain_A
+      def=7, diff=-4 → miss) and Chain_A's riposte lands (atk=8 vs
+      def=3, diff=5 ≥ RIPOSTDIFF=2 → Mover_Test dies).
+    """
+
+    def test_mover_action_is_passive_no_target_in_view(self, page: Page, base_url):
+        """Mover_Test's own view page should show passive + move text,
+        with no reference to the cancelled attack target (Chain_A)."""
+        html = _worker_report_html(page, 'Mover_Test')
+        assert 'Chain_A' not in html, \
+            "Mover_Test's view must not reference the cancelled attack target Chain_A"
+        assert _ui_worker_is_passive(page, 'Mover_Test'), \
+            "Mover_Test should be passive (survived via cleared attack)"
+
+    @pytest.mark.db
+    def test_mover_action_params_is_empty_json(self):
+        """Direct DB check: worker_actions.action_params must be the
+        literal string '{}'. moveWorker passes json_encode([]) = '{}'
+        as the last argument to updateWorkerAction, so this value is
+        contractually guaranteed — this test locks that contract."""
+        conn = get_db()
+        cursor = conn.cursor()
+        cursor.execute(f"""
+            SELECT wa.action_choice, wa.action_params
+            FROM `{GAME_PREFIX}worker_actions` wa
+            JOIN `{GAME_PREFIX}workers` w ON w.id = wa.worker_id
+            WHERE w.lastname = 'Mover_Test' AND wa.turn_number = 1
+        """)
+        row = cursor.fetchone()
+        conn.close()
+        assert row is not None, "Mover_Test must have a turn-1 worker_actions row"
+        assert row['action_choice'] == 'passive', \
+            f"After move-after-attack, action_choice should be 'passive', got {row['action_choice']!r}"
+        assert row['action_params'] == '{}', \
+            f"action_params should be empty JSON '{{}}' after move, got {row['action_params']!r}"

--- a/tests/test_csv_features_e2e.py
+++ b/tests/test_csv_features_e2e.py
@@ -271,13 +271,13 @@ class TestLoadWorkersCSV:
     """
 
     def test_workers_table_populated(self, page: Page, base_url):
-        """Exactly 28 workers should exist (7 detection + 19 combat + 2 cross).
+        """Exactly 29 workers should exist (7 detection + 19 combat + 3 cross).
 
         Counts rows on /workers/management_workers.php — UI-runnable.
         """
         ensure_gm_login(page, base_url)
         count = ui_worker_count(page, base_url=base_url)
-        assert count == 28, f"Expected 28 workers, got {count}"
+        assert count == 29, f"Expected 29 workers, got {count}"
 
     @pytest.mark.db
     def test_all_workers_have_origin_and_zone(self):
@@ -367,6 +367,7 @@ class TestLoadWorkersCSV:
             'Claim_Atk_2': 'Charlie', 'Claim_Def_2': 'Delta',
             # Cross-zone attack (Beta-Combat → Delta-Disputed)
             'Hunter_Cross': 'Alpha', 'Runner_Cross': 'Beta',
+            'Mover_Test': 'Echo',
         }
         assert mapping == expected, f"Worker-controller mapping wrong: got {mapping}"
 

--- a/tests/test_csv_features_e2e.py
+++ b/tests/test_csv_features_e2e.py
@@ -271,13 +271,13 @@ class TestLoadWorkersCSV:
     """
 
     def test_workers_table_populated(self, page: Page, base_url):
-        """Exactly 29 workers should exist (7 detection + 19 combat + 3 cross).
+        """Exactly 31 workers should exist (7 detection + 19 combat + 5 cross).
 
         Counts rows on /workers/management_workers.php — UI-runnable.
         """
         ensure_gm_login(page, base_url)
         count = ui_worker_count(page, base_url=base_url)
-        assert count == 29, f"Expected 29 workers, got {count}"
+        assert count == 31, f"Expected 31 workers, got {count}"
 
     @pytest.mark.db
     def test_all_workers_have_origin_and_zone(self):
@@ -368,6 +368,8 @@ class TestLoadWorkersCSV:
             # Cross-zone attack (Beta-Combat → Delta-Disputed)
             'Hunter_Cross': 'Alpha', 'Runner_Cross': 'Beta',
             'Mover_Test': 'Echo',
+            # Defender-params-preserved regression (Beta-Combat miss)
+            'Keep_Def': 'Beta', 'Keep_Atk': 'Foxtrot',
         }
         assert mapping == expected, f"Worker-controller mapping wrong: got {mapping}"
 

--- a/tests/test_parallel_games_e2e.py
+++ b/tests/test_parallel_games_e2e.py
@@ -186,13 +186,13 @@ class TestBothGamesLoaded:
         assert count == 9, f"Expected 9 Shikoku workers, got {count}"
 
     def test_primary_has_workers(self, page: Page, base_url):
-        """TestConfig in primary loaded 29 workers (7 detection + 19 combat + 3 cross).
+        """TestConfig in primary loaded 31 workers (7 detection + 19 combat + 5 cross).
 
         Counts rows on /workers/management_workers.php on the primary URL.
         """
         login_as(page, base_url, "gm", "orga")
         count = ui_worker_count(page, base_url=base_url)
-        assert count == 29, f"Expected 29 TestConfig workers, got {count}"
+        assert count == 31, f"Expected 31 TestConfig workers, got {count}"
 
     def test_secondary_has_shikoku_zones(self, page: Page, base_url):
         """Secondary has Shikoku zones (11 total). Counted via management_zones."""

--- a/tests/test_parallel_games_e2e.py
+++ b/tests/test_parallel_games_e2e.py
@@ -186,13 +186,13 @@ class TestBothGamesLoaded:
         assert count == 9, f"Expected 9 Shikoku workers, got {count}"
 
     def test_primary_has_workers(self, page: Page, base_url):
-        """TestConfig in primary loaded 28 workers (7 detection + 19 combat + 2 cross).
+        """TestConfig in primary loaded 29 workers (7 detection + 19 combat + 3 cross).
 
         Counts rows on /workers/management_workers.php on the primary URL.
         """
         login_as(page, base_url, "gm", "orga")
         count = ui_worker_count(page, base_url=base_url)
-        assert count == 28, f"Expected 28 TestConfig workers, got {count}"
+        assert count == 29, f"Expected 29 TestConfig workers, got {count}"
 
     def test_secondary_has_shikoku_zones(self, page: Page, base_url):
         """Secondary has Shikoku zones (11 total). Counted via management_zones."""

--- a/var/csv/setupTestConfig_advanced.csv
+++ b/var/csv/setupTestConfig_advanced.csv
@@ -27,3 +27,4 @@ combat,Claim_Atk_2,origine Accessible,Beta-Combat,Charlie,passive,{},Eagle Scout
 combat,Claim_Def_2,origine Accessible,Beta-Combat,Delta,passive,{},Blank Slate|Common Folk
 cross,Hunter_Cross,origine Accessible,Beta-Combat,Alpha,investigate,{},Eagle Scout|Patrol Warden
 cross,Runner_Cross,origine Accessible,Beta-Combat,Beta,passive,{},Blank Slate|Common Folk
+cross,Mover_Test,origine Accessible,Beta-Combat,Echo,passive,{},Blank Slate|Common Folk

--- a/var/csv/setupTestConfig_advanced.csv
+++ b/var/csv/setupTestConfig_advanced.csv
@@ -28,3 +28,5 @@ combat,Claim_Def_2,origine Accessible,Beta-Combat,Delta,passive,{},Blank Slate|C
 cross,Hunter_Cross,origine Accessible,Beta-Combat,Alpha,investigate,{},Eagle Scout|Patrol Warden
 cross,Runner_Cross,origine Accessible,Beta-Combat,Beta,passive,{},Blank Slate|Common Folk
 cross,Mover_Test,origine Accessible,Beta-Combat,Echo,passive,{},Blank Slate|Common Folk
+cross,Keep_Def,origine Accessible,Beta-Combat,Beta,passive,{},Blank Slate|Common Folk
+cross,Keep_Atk,origine Accessible,Beta-Combat,Foxtrot,passive,{},Blank Slate|Common Folk

--- a/workers/functions.php
+++ b/workers/functions.php
@@ -60,9 +60,13 @@ function updateWorkerAction($pdo, $workerId, $turnNumber, $actionChoice = null, 
     if (!empty($actionChoice)) {
         $updates[] = "action_choice = '$actionChoice'";
     }
-    if (!empty($jsonArray)) {
+    // $jsonArray: null → don't touch action_params; array (incl. empty) →
+    // set action_params. Force object-form encoding so an empty array
+    // serializes as '{}' (project convention, cf. investigateMechanic.php
+    // which compares action_params against '{}') rather than '[]'.
+    if ($jsonArray !== null) {
         $updates[] = "action_params = :json";
-        $params['json'] = json_encode($jsonArray);
+        $params['json'] = empty($jsonArray) ? '{}' : json_encode($jsonArray);
         if (json_last_error() !== JSON_ERROR_NONE) {
             echo  __FUNCTION__."(): Failed to encode JSON: " . json_last_error_msg()."<br />";
             return false;
@@ -876,7 +880,9 @@ function moveWorker($pdo, $workerId, $zoneId) {
 
     $mechanics = getMechanics($pdo);
     $zone_name = getZoneName($pdo, $zoneId);
-    updateWorkerAction($pdo, $workerId, $mechanics['turncounter'], 'passive', ['life_report' => "J'ai déménagé vers <strong>$zone_name</strong>. <br/>"], json_encode([]));
+    // Reset action_params — moveWorker clears any queued action's data.
+    // updateWorkerAction now accepts empty arrays (emitted as '{}').
+    updateWorkerAction($pdo, $workerId, $mechanics['turncounter'], 'passive', ['life_report' => "J'ai déménagé vers <strong>$zone_name</strong>. <br/>"], array());
 
     try{
         // UPDATE worker_actions values

--- a/workers/functions.php
+++ b/workers/functions.php
@@ -60,10 +60,6 @@ function updateWorkerAction($pdo, $workerId, $turnNumber, $actionChoice = null, 
     if (!empty($actionChoice)) {
         $updates[] = "action_choice = '$actionChoice'";
     }
-    // $jsonArray: null → don't touch action_params; array (incl. empty) →
-    // set action_params. Force object-form encoding so an empty array
-    // serializes as '{}' (project convention, cf. investigateMechanic.php
-    // which compares action_params against '{}') rather than '[]'.
     if ($jsonArray !== null) {
         $updates[] = "action_params = :json";
         $params['json'] = empty($jsonArray) ? '{}' : json_encode($jsonArray);
@@ -880,8 +876,6 @@ function moveWorker($pdo, $workerId, $zoneId) {
 
     $mechanics = getMechanics($pdo);
     $zone_name = getZoneName($pdo, $zoneId);
-    // Reset action_params — moveWorker clears any queued action's data.
-    // updateWorkerAction now accepts empty arrays (emitted as '{}').
     updateWorkerAction($pdo, $workerId, $mechanics['turncounter'], 'passive', ['life_report' => "J'ai déménagé vers <strong>$zone_name</strong>. <br/>"], array());
 
     try{


### PR DESCRIPTION
Contributes to #2                                     
                                                                                                                                       
  - **PHP fix**: `updateWorkerAction`'s gate `!empty($jsonArray)` conflated "don't touch" with "set empty"; `moveWorker` worked around 
  it with `json_encode([])` causing double-encoding `'"[]"'` in DB. Gate now `!== null`, empty array emits `'{}'`, `moveWorker` passes 
  `array()`.                                                                                                                           
  - **Tests**: new `TestMoveClearsActionParams` (1 UI + 1 DB-mark) verifying `action_choice='passive'` and `action_params='{}'` after  
  move-after-attack. New `Mover_Test` agent on Echo. Tweaks `_ui_worker_is_passive` to check passive button (always rendered) instead
  of attack form (zone-dependent). 189/189 local. 