### PR TITLE
feat : data-* worker-status attributes + UI helper upgrade 

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -731,3 +731,40 @@ def worker_report_html(page: Page, lastname: str, base_url: str = None):
     page.goto(f"{url}/workers/action.php?worker_id={wid}")
     page.wait_for_load_state("load")
     return page.content()
+
+
+def ui_worker_action_state(page: Page, lastname: str, base_url: str = None):
+    """Return the worker's current-turn action state by scraping the
+    'worker-action-state' marker emitted by workers/view.php.
+
+    Replaces direct DB access for action_choice / action_params checks
+    so tests can run under UI_ONLY=1 against prod. Reuses
+    worker_report_html's controller-switch + navigation, then reads
+    data-* attributes off the marker div.
+
+    Returns dict:
+      {
+        'worker_id': int,
+        'lastname': str,
+        'action_choice': str,
+        'action_params': str,   # raw JSON string as stored in the DB
+        'worker_status': str,   # 'alive' / 'dead' / 'captured' / 'double_agent' / 'prisoner' / 'unfound'
+      }
+
+    Raises AssertionError if the marker for `lastname` isn't found.
+    """
+    worker_report_html(page, lastname, base_url=base_url)
+    locator = page.locator(
+        f'[data-worker-lastname="{lastname}"][data-action-choice]'
+    ).first
+    if locator.count() == 0:
+        raise AssertionError(
+            f"No worker-action-state marker found for lastname='{lastname}'"
+        )
+    return {
+        'worker_id': int(locator.get_attribute('data-worker-id') or 0),
+        'lastname': locator.get_attribute('data-worker-lastname') or '',
+        'action_choice': locator.get_attribute('data-action-choice') or '',
+        'action_params': locator.get_attribute('data-action-params') or '{}',
+        'worker_status': locator.get_attribute('data-worker-status') or '',
+    }

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -58,7 +58,7 @@ from helpers import (
     ui_all_workers, ui_controller_id, ui_worker_id, ui_worker_controller_id,
     ui_workers_by_lastname, ui_faction_sections, ui_zone_id,
     clear_ui_caches, ui_attack, ui_investigate, ui_claim, ui_move,
-    worker_report_html, cached_faction_sections,
+    worker_report_html, cached_faction_sections, ui_worker_action_state,
 )
 
 
@@ -193,34 +193,21 @@ def combat_scenario(browser):
 # what the old DB `action_choice` queries checked.
 
 def _ui_worker_is_downed(page, lastname):
-    """True if the worker's action.php view shows them as dead, captured,
-    or a prisoner under a new controller.
+    """True if the worker is dead, captured, or a prisoner.
 
-    After captureWorker(), a captured worker is MOVED to the captor's
-    controller and its action becomes 'prisoner' (text: "est un.e agent
-    ... prisonnier.e"). The original controller sees a trace worker
-    whose action is 'captured' / 'dead' (text: "A disparu"). Both paths
-    count as "downed" from the attacker-test perspective.
-
-    The action form is absent for both inactive actions and prisoner
-    views, so `name="attack"` input is not rendered.
+    Reads data-worker-status from workers/view.php's card-header.
     """
-    html = worker_report_html(page, lastname)
-    is_disparu_or_prisoner = 'A disparu' in html or 'prisonnier' in html
-    return is_disparu_or_prisoner and 'name="attack"' not in html
+    state = ui_worker_action_state(page, lastname)
+    return state['worker_status'] in ('dead', 'captured', 'prisoner')
 
 
 def _ui_worker_is_passive(page, lastname):
-    """True if the worker's action.php view shows them as still passive.
-
-    txt_ps_passive => "surveille", ucfirst => "Surveille". Checks for the
-    `name="passive"` submit button (rendered for every active worker
-    regardless of zone) rather than `name="attack"` (rendered only when
-    the controller has known alive enemies in the worker's current zone,
-    which breaks down for workers who moved to a zone with no targets).
-    """
-    html = worker_report_html(page, lastname)
-    return 'Surveille' in html and 'name="passive"' in html
+    """True if the worker's current-turn action_choice is 'passive' AND
+    they're still alive (not downed). Reads data-* attributes from
+    workers/view.php's card-header."""
+    state = ui_worker_action_state(page, lastname)
+    return (state['action_choice'] == 'passive'
+            and state['worker_status'] == 'alive')
 
 
 def _ui_worker_is_attacking(page, lastname, target_lastname):
@@ -297,6 +284,16 @@ class TestBaseCombat:
             "Counter_Atk should be dead (A disparu) after being countered"
         assert _ui_worker_is_passive(page, 'Counter_Def'), \
             "Counter_Def should remain passive (Surveille) after countering"
+
+    def test_passive_worker_view_renders_french_text(self, page: Page, base_url):
+        """Smoke test for the txt_ps_passive config + ucfirst rendering chain.
+        Even_Def survived as passive on turn 1, so their action.php page
+        must render 'Surveille' in the worker action text. Guards against
+        config / template / ucfirst regressions that the data-* attribute
+        helpers (which read action_choice directly) would not catch."""
+        html = worker_report_html(page, 'Even_Def')
+        assert 'Surveille' in html, \
+            "passive worker view must render the French txt_ps_passive 'Surveille'"
 
     # --- B2 belt-and-buckle: faction-section views post-combat ---
 
@@ -752,27 +749,21 @@ class TestMoveClearsActionParams:
         assert _ui_worker_is_passive(page, 'Mover_Test'), \
             "Mover_Test should be passive (survived via cleared attack)"
 
-    @pytest.mark.db
-    def test_mover_action_params_is_empty_json(self):
-        """Direct DB check: worker_actions.action_params must be the
-        literal string '{}'. moveWorker passes json_encode([]) = '{}'
-        as the last argument to updateWorkerAction, so this value is
-        contractually guaranteed — this test locks that contract."""
-        conn = get_db()
-        cursor = conn.cursor()
-        cursor.execute(f"""
-            SELECT wa.action_choice, wa.action_params
-            FROM `{GAME_PREFIX}worker_actions` wa
-            JOIN `{GAME_PREFIX}workers` w ON w.id = wa.worker_id
-            WHERE w.lastname = 'Mover_Test' AND wa.turn_number = 1
-        """)
-        row = cursor.fetchone()
-        conn.close()
-        assert row is not None, "Mover_Test must have a turn-1 worker_actions row"
-        assert row['action_choice'] == 'passive', \
-            f"After move-after-attack, action_choice should be 'passive', got {row['action_choice']!r}"
-        assert row['action_params'] == '{}', \
-            f"action_params should be empty JSON '{{}}' after move, got {row['action_params']!r}"
+    def test_mover_action_params_is_empty_json(self, page: Page, base_url):
+        """worker_actions.action_params must be the literal string '{}'.
+        updateWorkerAction emits '{}' for empty arrays per the project
+        convention; this test locks that contract.
+
+        Reads the worker-action-state marker emitted by workers/view.php
+        (data-action-params attribute) — UI-only, runs under UI_ONLY=1.
+        Note: turn-2's row inherits action_params from turn-1 via
+        createNewTurnLines, so scraping the current-turn rendering
+        verifies the turn-1 value was preserved correctly."""
+        state = ui_worker_action_state(page, 'Mover_Test', base_url=base_url)
+        assert state['action_choice'] == 'passive', \
+            f"After move-after-attack, action_choice should be 'passive', got {state['action_choice']!r}"
+        assert state['action_params'] == '{}', \
+            f"action_params should be empty JSON '{{}}' after move, got {state['action_params']!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -808,22 +799,17 @@ class TestAttackKeepsDefenderParams:
     '{}' during the defender loop.
     """
 
-    @pytest.mark.db
-    def test_keep_def_preserves_claim_params_after_survived_miss(self):
+    def test_keep_def_preserves_claim_params_after_survived_miss(self, page: Page, base_url):
         """Keep_Def survives Keep_Atk's miss; its turn-1 action_params
-        must still contain the queued claim_controller_id."""
-        conn = get_db()
-        cursor = conn.cursor()
-        cursor.execute(f"""
-            SELECT wa.action_choice, wa.action_params
-            FROM `{GAME_PREFIX}worker_actions` wa
-            JOIN `{GAME_PREFIX}workers` w ON w.id = wa.worker_id
-            WHERE w.lastname = 'Keep_Def' AND wa.turn_number = 1
-        """)
-        row = cursor.fetchone()
-        conn.close()
-        assert row is not None, "Keep_Def must have a turn-1 worker_actions row"
-        assert row['action_choice'] == 'claim', \
-            f"Keep_Def should still have action_choice='claim' after surviving miss, got {row['action_choice']!r}"
-        assert 'claim_controller_id' in (row['action_params'] or ''), \
-            f"Keep_Def's action_params must preserve claim_controller_id after surviving miss — regression guard for attackMechanic.php:306 init. Got: {row['action_params']!r}"
+        must still contain the queued claim_controller_id.
+
+        Reads the worker-action-state marker emitted by workers/view.php
+        (data-* attributes) — UI-only, runs under UI_ONLY=1.
+        Turn-2's row inherits action_params from turn-1 via
+        createNewTurnLines, so scraping the current-turn rendering
+        verifies the turn-1 value was preserved correctly."""
+        state = ui_worker_action_state(page, 'Keep_Def', base_url=base_url)
+        assert state['action_choice'] == 'claim', \
+            f"Keep_Def should still have action_choice='claim' after surviving miss, got {state['action_choice']!r}"
+        assert 'claim_controller_id' in state['action_params'], \
+            f"Keep_Def's action_params must preserve claim_controller_id after surviving miss — regression guard for attackMechanic.php:306 init. Got: {state['action_params']!r}"

--- a/workers/functions.php
+++ b/workers/functions.php
@@ -374,7 +374,13 @@ function showWorkerShort($pdo, $worker, $mechanics, $showCheckBox = false) {
     }
 
     $return = sprintf(
-        '<div class="worker-short">
+        '<div class="worker-short" 
+            data-worker-id="%1$s"
+            data-worker-lastname="%3$s"
+            data-action-choice="%9$s"
+            data-action-params="%10$s"
+            data-worker-status="%11$s"
+        >
             %8$s
             <a href="/%7$s/workers/action.php?worker_id=%1$s" class="has-text-weight-semibold is-size-5" role="button" style="text-decoration:none;">
                 %2$s %3$s
@@ -395,6 +401,9 @@ function showWorkerShort($pdo, $worker, $mechanics, $showCheckBox = false) {
         ) // %6$s
         , $_SESSION['FOLDER'] // %7$s
         , ($showCheckBox ? sprintf('<input type="checkbox" name="worker_ids[]" value="%s" class="mr-2">', $worker['id']) : '') // %8$s
+        , htmlspecialchars($currentAction['action_choice'] ?? '', ENT_QUOTES) // %9$s
+        , htmlspecialchars($currentAction['action_params'] ?? '{}', ENT_QUOTES) // %10$s
+        , htmlspecialchars($workerStatus, ENT_QUOTES) // %11$s
     );
 
     return $return;

--- a/workers/view.php
+++ b/workers/view.php
@@ -424,7 +424,14 @@ if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {
 
             $viewHTML = sprintf(
                 '<div class="card">
-                    <header class="card-header">
+                    <header 
+                        class="card-header"
+                        data-worker-id="%1$s"
+                        data-worker-lastname="%3$s"
+                        data-action-choice="%12$s"
+                        data-action-params="%13$s"
+                        data-worker-status="%14$s"
+                    >
                         <p class="card-header-title">
                             Agent %2$s %3$s
                         </p>
@@ -442,7 +449,7 @@ if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {
                         %11$s
                     </div>
                 </div>',
-                $worker['id'], // %1$s
+                (int)$worker['id'], // %1$s
                 $worker['firstname'], // %2$s
                 $worker['lastname'], // %3$s
                 $workerActionText, // %4$s
@@ -452,7 +459,10 @@ if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {
                 $worker['total_defence'], // %8$s
                 $viewHistoryHTML, // %9$s
                 $actionHTML, // %10$s
-                $upgradeHTML // %11$s
+                $upgradeHTML, // %11$s
+                htmlspecialchars($currentAction['action_choice'] ?? '', ENT_QUOTES), // %12$s
+                htmlspecialchars($currentAction['action_params'] ?? '{}', ENT_QUOTES), // %13$s
+                htmlspecialchars($workerStatus, ENT_QUOTES) // %14$s
             );
             echo $viewHTML;
 


### PR DESCRIPTION
Stacked on PR #24 — review second, after #24 merges.

  Adds 5 `data-*` attributes (`data-worker-id`, `data-worker-lastname`,
  `data-action-choice`, `data-action-params`, `data-worker-status`) to
  `showWorkerShort`'s `<div class="worker-short">` and `workers/view.php`'s `<header
   class="card-header">`. New `ui_worker_action_state()` helper in `helpers.py`
  reads them via an attribute-only selector. The 2 brittle French-text helpers
  (`_ui_worker_is_downed`, `_ui_worker_is_passive`) now read `data-worker-status` /
  `data-action-choice` directly — 15 existing call sites benefit with zero per-test
  changes.

  Two previously DB-locked tests are now UI-only (run under `UI_ONLY=1` against
  prod): `test_mover_action_params_is_empty_json` and
  `test_keep_def_preserves_claim_params_after_survived_miss`. New
  `test_passive_worker_view_renders_french_text` keeps a smoke test on the
  `txt_ps_passive` rendering chain. 