### PR TITLE
test : assert no PHP warning/fatal on every UI page

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,15 +38,29 @@ PHP_BASE_URL = os.environ.get("PHP_BASE_URL", "http://localhost:8080/RPGConquest
 
 def ensure_gm_login(page, base_url=None):
     """Login as gm if not already logged in. Skip login if session is active."""
-    from playwright.sync_api import Page
+    from helpers import safe_goto
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/base/accueil.php")
-    page.wait_for_load_state("networkidle")
+    safe_goto(page, f"{url}/base/accueil.php", wait_state="networkidle")
     if "loginForm.php" in page.url:
         page.locator("input[name='username']").fill("gm")
         page.locator("input[name='passwd']").fill("orga")
         page.locator("input[type='submit']").first.click()
         page.wait_for_load_state("networkidle")
+
+
+@pytest.fixture(autouse=True)
+def _php_error_guard(request):
+    """Belt-and-buckle PHP error detection: register a response listener
+    on the page fixture (if the test uses one) and assert no errors at
+    teardown. Catches click-driven navigations that bypass safe_goto."""
+    if 'page' not in request.fixturenames:
+        yield
+        return
+    from helpers import register_php_error_listener, assert_no_collected_php_errors
+    page = request.getfixturevalue('page')
+    register_php_error_listener(page)
+    yield
+    assert_no_collected_php_errors(page)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -88,7 +88,7 @@ def load_minimal_data(prefix=None):
 
 def login_as(page: Page, base_url: str, username: str, password: str):
     """Navigate to the login form and submit the given credentials."""
-    page.goto(f"{base_url}/connection/loginForm.php")
+    safe_goto(page, f"{base_url}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill(username)
     page.locator("input[name='passwd']").fill(password)
@@ -98,7 +98,7 @@ def login_as(page: Page, base_url: str, username: str, password: str):
 
 def logout(page: Page, base_url: str):
     """Navigate to the logout endpoint."""
-    page.goto(f"{base_url}/connection/logout.php")
+    safe_goto(page, f"{base_url}/connection/logout.php")
     page.wait_for_load_state("networkidle")
 
 
@@ -108,7 +108,7 @@ def end_turn(page: Page, base_url: str = None):
     Asserts no PHP warning or fatal error in the rendered response.
     """
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/mechanics/endTurn.php")
+    safe_goto(page, f"{url}/mechanics/endTurn.php")
     page.wait_for_load_state("load", timeout=120000)
     html = page.content()
     assert "<b>Warning</b>" not in html, "PHP warning during end turn"
@@ -123,7 +123,7 @@ def load_scenario_via_admin(browser, base_url: str, scenario_name: str):
     context = browser.new_context()
     page = context.new_page()
     login_as(page, base_url, "gm", "orga")
-    page.goto(f"{base_url}/base/admin.php")
+    safe_goto(page, f"{base_url}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option(scenario_name)
     page.locator("input[name='submit'][value='Submit']").click()
@@ -146,7 +146,7 @@ def ui_controller_id(page: Page, lastname: str, base_url: str = None):
 
     Raises AssertionError if not found."""
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/base/accueil.php")
+    safe_goto(page, f"{url}/base/accueil.php")
     page.wait_for_load_state("networkidle")
     options = page.locator("select#controllerSelect option").all()
     for opt in options:
@@ -168,7 +168,7 @@ def ui_all_workers(page: Page, base_url: str = None):
     controller_id and action_choice, which is what we need to disambiguate
     captured/original vs trace rows."""
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/workers/management_workers.php")
+    safe_goto(page, f"{url}/workers/management_workers.php")
     page.wait_for_load_state("load")
     rows = page.locator("div.management table tr").all()
     workers = []
@@ -243,7 +243,7 @@ def ui_all_zones(page: Page, base_url: str = None):
     also extract the current controller names.
     """
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/zones/management_zones.php")
+    safe_goto(page, f"{url}/zones/management_zones.php")
     page.wait_for_load_state("load")
     rows = page.locator("div.management table tr").all()
     zones = []
@@ -297,7 +297,7 @@ def _scrape_location_discovery_flags(page: Page, base_url: str = None):
     per controller. Stable attributes — no emoji/text matching needed.
     """
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/zones/management_locations.php")
+    safe_goto(page, f"{url}/zones/management_locations.php")
     page.wait_for_load_state("load")
     result = {}
     blocks = page.locator("div.management div[style*='border']").all()
@@ -367,10 +367,10 @@ def ui_worker_stats(page: Page, lastname: str, base_url: str = None):
     url = base_url or PHP_BASE_URL
     # Switch session to the worker's controller so the page shows the report
     ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
-    page.goto(f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
     page.wait_for_load_state("networkidle")
     wid = ui_worker_id(page, lastname, base_url=url)
-    page.goto(f"{url}/workers/action.php?worker_id={wid}")
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
     page.wait_for_load_state("load")
     html = page.content()
     m = _STATS_RE.search(html)
@@ -402,7 +402,7 @@ def ui_turn_counter(page: Page, base_url: str = None):
     subsequent digits belong to the optional controller info suffix).
     """
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/base/accueil.php")
+    safe_goto(page, f"{url}/base/accueil.php")
     page.wait_for_load_state("networkidle")
     text = (page.locator("div.header").first.inner_text() or "").strip()
     m = _TURN_RE.search(text)
@@ -444,10 +444,10 @@ def ui_detected_enemies_of(page: Page, searcher_lastname: str, base_url: str = N
     """
     url = base_url or PHP_BASE_URL
     ctrl_id = ui_worker_controller_id(page, searcher_lastname, base_url=url)
-    page.goto(f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
     page.wait_for_load_state("networkidle")
     wid = ui_worker_id(page, searcher_lastname, base_url=url)
-    page.goto(f"{url}/workers/action.php?worker_id={wid}")
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
     page.wait_for_load_state("load")
     detected = set()
     options = page.locator("select#enemyWorkersSelect option").all()
@@ -473,7 +473,7 @@ def ui_power_options_by_type(page: Page, base_url: str = None):
     admin page are the authoritative UI enumeration of all powers
     linked to each type (via the link_power_type junction)."""
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/base/admin.php")
+    safe_goto(page, f"{url}/base/admin.php")
     page.wait_for_load_state("networkidle")
     type_map = {
         "Hobby": "select#power_hobby_id",
@@ -505,7 +505,7 @@ def ui_all_controllers(page: Page, base_url: str = None):
     table; each row carries data-controller-name=LastName.
     """
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/controllers/management.php")
+    safe_goto(page, f"{url}/controllers/management.php")
     page.wait_for_load_state("load")
     rows = page.locator("tr.controller-row").all()
     return {
@@ -526,7 +526,7 @@ def ui_controller_counters(page: Page, lastname: str, base_url: str = None):
     td[data-field=Y] — stable against text/emoji changes.
     Raises AssertionError if lastname not found."""
     url = base_url or PHP_BASE_URL
-    page.goto(f"{url}/controllers/management.php")
+    safe_goto(page, f"{url}/controllers/management.php")
     page.wait_for_load_state("load")
     row = page.locator(f'tr.controller-row[data-controller-name="{lastname}"]')
     if row.count() == 0:
@@ -572,9 +572,9 @@ def ui_faction_sections(page: Page, controller_lastname: str, base_url: str = No
     """
     url = base_url or PHP_BASE_URL
     ctrl_id = ui_controller_id(page, controller_lastname, base_url=url)
-    page.goto(f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
     page.wait_for_load_state("networkidle")
-    page.goto(f"{url}/workers/viewAll.php")
+    safe_goto(page, f"{url}/workers/viewAll.php")
     page.wait_for_load_state("load")
 
     heading_to_key = {
@@ -659,7 +659,7 @@ def ui_attack(page: Page, attacker_lastname: str, target_lastname: str,
     url = base_url or PHP_BASE_URL
     atk_id = _cached_wid(page, attacker_lastname, base_url)
     tgt_id = _cached_wid(page, target_lastname, base_url)
-    page.goto(
+    safe_goto(page, 
         f"{url}/workers/action.php"
         f"?worker_id={atk_id}"
         f"&enemy_worker_id[]=worker_{tgt_id}"
@@ -672,7 +672,7 @@ def ui_investigate(page: Page, lastname: str, base_url: str = None):
     """Queue an investigate action via workers/action.php URL endpoint."""
     url = base_url or PHP_BASE_URL
     wid = _cached_wid(page, lastname, base_url)
-    page.goto(
+    safe_goto(page, 
         f"{url}/workers/action.php"
         f"?worker_id={wid}&investigate=1"
     )
@@ -685,7 +685,7 @@ def ui_claim(page: Page, lastname: str, claim_controller_lastname: str,
     url = base_url or PHP_BASE_URL
     wid = _cached_wid(page, lastname, base_url)
     cid = _cached_cid(page, claim_controller_lastname, base_url)
-    page.goto(
+    safe_goto(page, 
         f"{url}/workers/action.php"
         f"?worker_id={wid}&claim_controller_id={cid}&claim=1"
     )
@@ -702,7 +702,7 @@ def ui_move(page: Page, lastname: str, zone_name: str, base_url: str = None):
     url = base_url or PHP_BASE_URL
     wid = _cached_wid(page, lastname, base_url)
     zid = ui_zone_id(page, zone_name, base_url)
-    page.goto(
+    safe_goto(page, 
         f"{url}/workers/action.php"
         f"?worker_id={wid}&zone_id={zid}&move=1"
     )
@@ -721,14 +721,14 @@ def worker_report_html(page: Page, lastname: str, base_url: str = None):
     url = base_url or PHP_BASE_URL
     ensure_gm_login(page, url)
     ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
-    page.goto(
+    safe_goto(page, 
         f"{url}/base/accueil.php"
         f"?controller_id={ctrl_id}&chosir=Choisir"
     )
     page.wait_for_load_state("networkidle")
     wid = _cached_wid(page, lastname, base_url)
     assert wid, f"Worker {lastname} not found"
-    page.goto(f"{url}/workers/action.php?worker_id={wid}")
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
     page.wait_for_load_state("load")
     return page.content()
 
@@ -768,3 +768,70 @@ def ui_worker_action_state(page: Page, lastname: str, base_url: str = None):
         'action_params': locator.get_attribute('data-action-params') or '{}',
         'worker_status': locator.get_attribute('data-worker-status') or '',
     }
+
+
+# ---------------------------------------------------------------------------
+# PHP error guard — belt-and-buckle: explicit safe_goto + response listener
+# ---------------------------------------------------------------------------
+
+PHP_ERROR_MARKERS = ('<b>Warning</b>', '<b>Fatal error</b>', '<b>Parse error</b>')
+
+
+def assert_no_php_errors(page, context=None):
+    """Assert that page.content() contains no PHP error markers
+    (Warning / Fatal error / Parse error, as PHP renders them with
+    default html_errors=On)."""
+    html = page.content()
+    found = [m for m in PHP_ERROR_MARKERS if m in html]
+    if found:
+        suffix = f" ({context})" if context else ""
+        raise AssertionError(
+            f"PHP error(s) {found} on {page.url}{suffix}"
+        )
+
+
+def safe_goto(page: Page, url: str, wait_state: str = "load", timeout: int = 30000):
+    """page.goto + wait_for_load_state + assert_no_php_errors.
+    Drop-in replacement for page.goto in tests against the game's UI."""
+    page.goto(url, timeout=timeout)
+    page.wait_for_load_state(wait_state, timeout=timeout)
+    assert_no_php_errors(page)
+
+
+def register_php_error_listener(page: Page):
+    """Attach an HTML-only response listener that flags PHP error
+    markers on every response. Findings accumulate on
+    page._php_errors_seen for later assertion via
+    assert_no_collected_php_errors(). Belt-and-buckle for safe_goto
+    — catches click-driven navigations that bypassed the wrapper.
+    Filtered to text/html responses to keep overhead negligible."""
+    page._php_errors_seen = []
+
+    def _on_response(response):
+        try:
+            ctype = (response.headers.get('content-type') or '').lower()
+            if 'text/html' not in ctype:
+                return
+            body = response.text()
+            for marker in PHP_ERROR_MARKERS:
+                if marker in body:
+                    page._php_errors_seen.append((response.url, marker))
+                    break
+        except Exception:
+            # Listener must never throw — would wedge Playwright internals.
+            pass
+
+    page.on("response", _on_response)
+
+
+def assert_no_collected_php_errors(page: Page):
+    """Check the list populated by register_php_error_listener and
+    fail if any PHP error marker was seen during the page's lifetime."""
+    errors = getattr(page, '_php_errors_seen', None) or []
+    if errors:
+        first_url, first_marker = errors[0]
+        raise AssertionError(
+            f"PHP error '{first_marker}' detected by response listener "
+            f"on {first_url}"
+            + (f" (and {len(errors)-1} other(s))" if len(errors) > 1 else "")
+        )

--- a/tests/test_admin_csv_load_e2e.py
+++ b/tests/test_admin_csv_load_e2e.py
@@ -21,7 +21,7 @@ from conftest import (
     PHP_BASE_URL,
 )
 
-from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data
+from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto
 
 
 def table_row_count(table_name):
@@ -56,7 +56,7 @@ def ensure_base_data():
 @pytest.fixture
 def logged_in_page(page: Page, base_url):
     """Login as game master (gm/orga) and return the page."""
-    page.goto(f"{base_url}/connection/loginForm.php")
+    safe_goto(page, f"{base_url}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
 
     page.locator("input[name='username']").fill("gm")
@@ -76,7 +76,7 @@ class TestLoginFlow:
 
     def test_login_page_loads(self, page: Page, base_url):
         """Login page should be accessible."""
-        page.goto(f"{base_url}/connection/loginForm.php")
+        safe_goto(page, f"{base_url}/connection/loginForm.php")
         expect(page).to_have_title(re.compile(".*", re.IGNORECASE))
         expect(page.locator("input[type='password']")).to_be_visible()
 
@@ -88,7 +88,7 @@ class TestLoginFlow:
             f"Login redirect failed — still on loginForm.php: {logged_in_page.url}"
         assert "accueil.php" in logged_in_page.url, \
             f"Expected redirect to accueil.php, got: {logged_in_page.url}"
-        logged_in_page.goto(f"{base_url}/base/admin.php")
+        safe_goto(logged_in_page, f"{base_url}/base/admin.php")
         logged_in_page.wait_for_load_state("networkidle")
         expect(logged_in_page.locator("select[name='config_name']")).to_be_visible()
 
@@ -98,13 +98,13 @@ class TestAdminPanel:
 
     def test_admin_page_loads(self, logged_in_page: Page, base_url):
         """Admin page should be accessible after login."""
-        logged_in_page.goto(f"{base_url}/base/admin.php")
+        safe_goto(logged_in_page, f"{base_url}/base/admin.php")
         logged_in_page.wait_for_load_state("networkidle")
         expect(logged_in_page.locator("select[name='config_name']")).to_be_visible()
 
     def test_config_options_available(self, logged_in_page: Page, base_url):
         """Config dropdown should have the expected scenarios."""
-        logged_in_page.goto(f"{base_url}/base/admin.php")
+        safe_goto(logged_in_page, f"{base_url}/base/admin.php")
         logged_in_page.wait_for_load_state("networkidle")
         select = logged_in_page.locator("select[name='config_name']")
         options = select.locator("option").all()
@@ -131,7 +131,7 @@ class TestCSVLoadViaAdmin:
 
     def test_full_reset_test_config(self, logged_in_page: Page, base_url):
         """Trigger a full reset with TestConfig and verify DB is populated."""
-        logged_in_page.goto(f"{base_url}/base/admin.php")
+        safe_goto(logged_in_page, f"{base_url}/base/admin.php")
         logged_in_page.wait_for_load_state("networkidle")
 
         logged_in_page.locator("select[name='config_name']").select_option("TestConfig")
@@ -166,7 +166,7 @@ class TestCSVLoadViaAdmin:
             "TestConfig should load hobbys into powers"
 
         # Verify page title and header reflect the loaded scenario
-        logged_in_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(logged_in_page, f"{base_url}/base/accueil.php")
         logged_in_page.wait_for_load_state("networkidle")
         header_text = logged_in_page.locator("div.header").inner_text()
         assert "Tour" in header_text, \
@@ -174,7 +174,7 @@ class TestCSVLoadViaAdmin:
 
     def test_full_reset_japon1555_sql(self, logged_in_page: Page, base_url):
         """Trigger a full reset with Japon1555SQL and verify larger dataset."""
-        logged_in_page.goto(f"{base_url}/base/admin.php")
+        safe_goto(logged_in_page, f"{base_url}/base/admin.php")
         logged_in_page.wait_for_load_state("networkidle")
 
         logged_in_page.locator("select[name='config_name']").select_option("Japon1555SQL")
@@ -207,7 +207,7 @@ class TestCSVLoadViaAdmin:
             "Japon1555 should load 50+ worker names"
 
         # Verify page title and header reflect Japon1555 scenario
-        logged_in_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(logged_in_page, f"{base_url}/base/accueil.php")
         logged_in_page.wait_for_load_state("networkidle")
         page_html = logged_in_page.content()
         assert "<b>Warning</b>" not in page_html, \
@@ -218,7 +218,7 @@ class TestCSVLoadViaAdmin:
 
     def test_full_reset_japon1555_csv(self, logged_in_page: Page, base_url):
         """Trigger a full reset with Japon1555CSV and verify CSV-loaded dataset."""
-        logged_in_page.goto(f"{base_url}/base/admin.php")
+        safe_goto(logged_in_page, f"{base_url}/base/admin.php")
         logged_in_page.wait_for_load_state("networkidle")
 
         logged_in_page.locator("select[name='config_name']").select_option("Japon1555CSV")
@@ -266,7 +266,7 @@ class TestCSVLoadViaAdmin:
             "Japon1555CSV advanced should create exactly 9 workers"
 
         # Verify page header reflects Japon1555 scenario
-        logged_in_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(logged_in_page, f"{base_url}/base/accueil.php")
         logged_in_page.wait_for_load_state("networkidle")
         page_html = logged_in_page.content()
         assert "<b>Warning</b>" not in page_html, \
@@ -277,7 +277,7 @@ class TestCSVLoadViaAdmin:
 
     def test_full_reset_vampire1966_csv(self, logged_in_page: Page, base_url):
         """Trigger a full reset with Vampire1966CSV and verify CSV-loaded dataset."""
-        logged_in_page.goto(f"{base_url}/base/admin.php")
+        safe_goto(logged_in_page, f"{base_url}/base/admin.php")
         logged_in_page.wait_for_load_state("networkidle")
 
         logged_in_page.locator("select[name='config_name']").select_option("Vampire1966CSV")
@@ -325,7 +325,7 @@ class TestCSVLoadViaAdmin:
             "Vampire1966CSV advanced should create exactly 3 workers"
 
         # Verify page header reflects Vampire1966 scenario
-        logged_in_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(logged_in_page, f"{base_url}/base/accueil.php")
         logged_in_page.wait_for_load_state("networkidle")
         page_html = logged_in_page.content()
         assert "<b>Warning</b>" not in page_html, \

--- a/tests/test_admin_forms_e2e.py
+++ b/tests/test_admin_forms_e2e.py
@@ -19,7 +19,10 @@ from conftest import (
 )
 
 
-from helpers import DB_AVAILABLE, load_minimal_data, safe_goto
+from helpers import (
+    DB_AVAILABLE, load_minimal_data, safe_goto,
+    register_php_error_listener, assert_no_collected_php_errors,
+)
 
 
 @pytest.fixture(scope="session")
@@ -48,6 +51,7 @@ def load_test_config(browser):
 
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
     safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
@@ -60,6 +64,7 @@ def load_test_config(browser):
     page.locator("input[name='submit'][value='Submit']").click()
     page.wait_for_timeout(5000)
     page.wait_for_load_state("load", timeout=90000)
+    assert_no_collected_php_errors(page)
     context.close()
     yield
 

--- a/tests/test_admin_forms_e2e.py
+++ b/tests/test_admin_forms_e2e.py
@@ -19,7 +19,7 @@ from conftest import (
 )
 
 
-from helpers import DB_AVAILABLE, load_minimal_data
+from helpers import DB_AVAILABLE, load_minimal_data, safe_goto
 
 
 @pytest.fixture(scope="session")
@@ -48,13 +48,13 @@ def load_test_config(browser):
 
     context = browser.new_context()
     page = context.new_page()
-    page.goto(f"{PHP_BASE_URL}/connection/loginForm.php")
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
     page.locator("input[name='passwd']").fill("orga")
     page.locator("input[type='submit']").first.click()
     page.wait_for_load_state("networkidle")
-    page.goto(f"{PHP_BASE_URL}/base/admin.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option("TestConfig")
     page.locator("input[name='submit'][value='Submit']").click()
@@ -74,7 +74,7 @@ class TestCreatePerfectAgentForm:
     def test_form_present_on_admin_page(self, page: Page, base_url):
         """The Recruter et Affecter button should be visible on admin page."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         submit_btn = page.locator("input[name='chosir'][value='Recruter et Affecter']")
         expect(submit_btn).to_be_visible()
@@ -82,7 +82,7 @@ class TestCreatePerfectAgentForm:
     def test_form_dropdowns_populated(self, page: Page, base_url):
         """All required dropdowns should have options."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
 
         # Use the second controllerSelect (the one inside the worker form)
@@ -102,7 +102,7 @@ class TestCreatePerfectAgentForm:
     def test_origin_dropdown_has_test_data(self, page: Page, base_url):
         """Origin dropdown should contain TestConfig origins."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         form = page.locator("form[action*='workers/action.php']")
         options_text = form.locator("select#origin_id option").all_inner_texts()
@@ -114,7 +114,7 @@ class TestCreatePerfectAgentForm:
     def test_zone_dropdown_has_test_data(self, page: Page, base_url):
         """Zone dropdown should contain TestConfig zones."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         form = page.locator("form[action*='workers/action.php']")
         options_text = form.locator("select#zoneSelect option").all_inner_texts()
@@ -124,7 +124,7 @@ class TestCreatePerfectAgentForm:
     def test_hobby_dropdown_includes_test_powers(self, page: Page, base_url):
         """Hobby dropdown should have Eagle Scout loaded from TestConfig CSV."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         form = page.locator("form[action*='workers/action.php']")
         options_text = form.locator("select#power_hobby_id option").all_inner_texts()
@@ -134,7 +134,7 @@ class TestCreatePerfectAgentForm:
     def test_metier_dropdown_includes_test_powers(self, page: Page, base_url):
         """Metier dropdown should have Veteran Tactician from TestConfig CSV."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         form = page.locator("form[action*='workers/action.php']")
         options_text = form.locator("select#power_metier_id option").all_inner_texts()
@@ -157,7 +157,7 @@ class TestCreatePerfectAgentForm:
         target_controller_id = "1"  # Lord Alpha
 
         # --- Fill the worker-creation form on admin.php ---
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         form = page.locator("form[action*='workers/action.php']")
         form.locator("select#controllerSelect").select_option(target_controller_id)
@@ -170,14 +170,14 @@ class TestCreatePerfectAgentForm:
         page.wait_for_load_state("networkidle")
 
         # --- Switch gm's view to Lord Alpha's faction (Ma Faction page) ---
-        page.goto(f"{base_url}/controllers/action.php")
+        safe_goto(page, f"{base_url}/controllers/action.php")
         page.wait_for_load_state("networkidle")
         page.locator("form select#controllerSelect").select_option(target_controller_id)
         page.locator("input[name='chosir'][value='Choisir']").click()
         page.wait_for_load_state("networkidle")
 
         # --- Assert the new worker is visible in Alpha's agents view ---
-        page.goto(f"{base_url}/workers/viewAll.php")
+        safe_goto(page, f"{base_url}/workers/viewAll.php")
         page.wait_for_load_state("networkidle")
         html = page.content()
         assert firstname_val in html and lastname_val in html, (
@@ -201,7 +201,7 @@ class TestCreatePerfectAgentForm:
         target_controller_id = "2"  # Lord Beta
 
         # --- Fill the worker-creation form on admin.php ---
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         form = page.locator("form[action*='workers/action.php']")
         form.locator("select#controllerSelect").select_option(target_controller_id)
@@ -214,14 +214,14 @@ class TestCreatePerfectAgentForm:
         page.wait_for_load_state("networkidle")
 
         # --- Switch gm's view to Lord Beta's faction (Ma Faction page) ---
-        page.goto(f"{base_url}/controllers/action.php")
+        safe_goto(page, f"{base_url}/controllers/action.php")
         page.wait_for_load_state("networkidle")
         page.locator("form select#controllerSelect").select_option(target_controller_id)
         page.locator("input[name='chosir'][value='Choisir']").click()
         page.wait_for_load_state("networkidle")
 
         # --- Assert the new worker is visible in Beta's agents view ---
-        page.goto(f"{base_url}/workers/viewAll.php")
+        safe_goto(page, f"{base_url}/workers/viewAll.php")
         page.wait_for_load_state("networkidle")
         html = page.content()
         assert firstname_val in html and lastname_val in html, (
@@ -251,7 +251,7 @@ class TestPerfectWorkerValidation:
         loop, not by 5 separate tests (avoids test-suite bloat for a
         non-critical admin form)."""
         ensure_gm_login(page, base_url)
-        page.goto(
+        safe_goto(page,
             f"{base_url}/workers/action.php"
             f"?creation=true"
             f"&firstname=Sentinel"
@@ -284,7 +284,7 @@ class TestPerfectWorkerValidation:
         """
         ensure_gm_login(page, base_url)
 
-        page.goto(
+        safe_goto(page,
             f"{base_url}/workers/action.php"
             f"?creation=true"
             f"&firstname=Zero"
@@ -301,9 +301,9 @@ class TestPerfectWorkerValidation:
         assert "<b>Fatal error</b>" not in body_creation, \
             "PHP Fatal error on action.php after 0-powers creation"
 
-        page.goto(f"{base_url}/base/accueil.php?controller_id=1&chosir=Choisir")
+        safe_goto(page, f"{base_url}/base/accueil.php?controller_id=1&chosir=Choisir")
         page.wait_for_load_state("networkidle")
-        page.goto(f"{base_url}/workers/viewAll.php")
+        safe_goto(page, f"{base_url}/workers/viewAll.php")
         page.wait_for_load_state("load")
         body_viewall = page.content()
         assert "<b>Warning</b>" not in body_viewall, \
@@ -322,7 +322,7 @@ class TestBDDExport:
     def test_export_button_visible(self, page: Page, base_url):
         """Export BDD button should be visible on admin page."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         export_btn = page.locator("input[value='Export BDD to file.sql']")
         expect(export_btn).to_be_visible()
@@ -330,7 +330,7 @@ class TestBDDExport:
     def test_export_triggers_download(self, page: Page, base_url):
         """Clicking export should trigger a file download."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
 
         # Set up download listener
@@ -361,7 +361,7 @@ class TestBDDImport:
     def test_import_form_visible(self, page: Page, base_url):
         """Import form with file input and submit button should be visible."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         file_input = page.locator("input[type='file'][name='bddFile']")
         expect(file_input).to_be_visible()
@@ -371,7 +371,7 @@ class TestBDDImport:
     def test_import_form_uses_multipart(self, page: Page, base_url):
         """Import form must be enctype='multipart/form-data' for file upload."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         form = page.locator("form:has(input[name='importBDD'])")
         expect(form).to_be_visible()
@@ -382,7 +382,7 @@ class TestBDDImport:
     def test_import_form_has_importBDD_hidden_field(self, page: Page, base_url):
         """Import form should have the importBDD hidden input."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/admin.php")
+        safe_goto(page, f"{base_url}/base/admin.php")
         page.wait_for_load_state("networkidle")
         hidden = page.locator("input[type='hidden'][name='importBDD']")
         assert hidden.count() >= 1, "importBDD hidden input should exist"

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -59,7 +59,7 @@ from helpers import (
     ui_workers_by_lastname, ui_faction_sections, ui_zone_id,
     clear_ui_caches, ui_attack, ui_investigate, ui_claim, ui_move,
     worker_report_html, cached_faction_sections, ui_worker_action_state,
-    safe_goto,
+    safe_goto, register_php_error_listener, assert_no_collected_php_errors,
 )
 
 
@@ -108,6 +108,7 @@ def combat_scenario(browser):
 
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
 
     # Login and load TestConfig
     ensure_gm_login(page, PHP_BASE_URL)
@@ -176,6 +177,7 @@ def combat_scenario(browser):
     # End turn 1 → 2 (combat resolves)
     end_turn(page)
 
+    assert_no_collected_php_errors(page)
     context.close()
     yield
 

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -59,6 +59,7 @@ from helpers import (
     ui_workers_by_lastname, ui_faction_sections, ui_zone_id,
     clear_ui_caches, ui_attack, ui_investigate, ui_claim, ui_move,
     worker_report_html, cached_faction_sections, ui_worker_action_state,
+    safe_goto,
 )
 
 
@@ -70,7 +71,7 @@ def base_url():
 def _ensure_controller_session(page):
     """Ensure the gm is logged in and has a controller selected."""
     ensure_gm_login(page, PHP_BASE_URL)
-    page.goto(f"{PHP_BASE_URL}/base/accueil.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/accueil.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='controller_id']").first.select_option(index=0)
     page.locator("input[name='chosir']").first.click()
@@ -110,7 +111,7 @@ def combat_scenario(browser):
 
     # Login and load TestConfig
     ensure_gm_login(page, PHP_BASE_URL)
-    page.goto(f"{PHP_BASE_URL}/base/admin.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option("TestConfig")
     page.locator("input[name='submit'][value='Submit']").click()
@@ -612,7 +613,7 @@ class TestActionBlockedByCombat:
         """
         ensure_gm_login(page, PHP_BASE_URL)
         _ensure_controller_session(page)
-        page.goto(f"{PHP_BASE_URL}/zones/management_zones.php")
+        safe_goto(page, f"{PHP_BASE_URL}/zones/management_zones.php")
         page.wait_for_load_state("networkidle")
         # Beta-Combat row's holder <select>: the currently-selected option
         # must be the empty "-- Aucun --" one (value="").

--- a/tests/test_agent_detection_e2e.py
+++ b/tests/test_agent_detection_e2e.py
@@ -34,7 +34,7 @@ from helpers import (
     ui_known_locations_for_controller,
     ui_known_secret_locations_for_controller,
     ui_worker_stats, ui_turn_counter, ui_detected_enemies_of,
-    safe_goto,
+    safe_goto, register_php_error_listener, assert_no_collected_php_errors,
 )
 
 
@@ -175,6 +175,7 @@ def load_and_end_turn(browser):
 
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
 
     safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
@@ -194,6 +195,7 @@ def load_and_end_turn(browser):
     safe_goto(page, f"{PHP_BASE_URL}/mechanics/endTurn.php")
     page.wait_for_load_state("load", timeout=90000)
 
+    assert_no_collected_php_errors(page)
     context.close()
     yield
 
@@ -231,16 +233,6 @@ class TestEndTurn:
         assert count >= 26, \
             f"Expected at least 26 action rows for turn 1, got {count}"
 
-    def test_end_turn_page_no_warnings(self, page: Page, base_url):
-        """Re-visit end turn page and verify no PHP warnings.
-        Since turn already advanced, this tests the 'already done' path.
-        UI-only smoke check — runs under UI_ONLY=1."""
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/mechanics/endTurn.php")
-        page.wait_for_load_state("load", timeout=30000)
-        html = page.content()
-        assert "<b>Warning</b>" not in html, "PHP warnings on end turn page"
-        assert "<b>Fatal error</b>" not in html, "PHP fatal error on end turn page"
 
 
 # ---------------------------------------------------------------------------
@@ -621,13 +613,6 @@ class TestWorkerViewPage:
         safe_goto(page, f"{base_url}/workers/action.php?worker_id={worker_id}")
         page.wait_for_load_state("networkidle")
 
-    def test_agent1_page_no_warnings(self, page: Page, base_url):
-        """Finder_1 worker page loads without PHP warnings."""
-        self._go_to_worker(page, base_url, 'Charlie', 'Finder_1')
-        html = page.content()
-        assert "<b>Warning</b>" not in html
-        assert "<b>Fatal error</b>" not in html
-
     def test_agent1_page_has_report(self, page: Page, base_url):
         """Finder_1 page has Rapport section with Tour 0."""
         self._go_to_worker(page, base_url, 'Charlie', 'Finder_1')
@@ -667,9 +652,3 @@ class TestWorkerViewPage:
         report_section = html.split("Mes recherches")[1] if "Mes recherches" in html else html
         assert "Location A" not in report_section
 
-    def test_agent4_page_no_warnings(self, page: Page, base_url):
-        """Finder_4 worker page loads without PHP warnings."""
-        self._go_to_worker(page, base_url, 'Foxtrot', 'Finder_4')
-        html = page.content()
-        assert "<b>Warning</b>" not in html
-        assert "<b>Fatal error</b>" not in html

--- a/tests/test_agent_detection_e2e.py
+++ b/tests/test_agent_detection_e2e.py
@@ -34,6 +34,7 @@ from helpers import (
     ui_known_locations_for_controller,
     ui_known_secret_locations_for_controller,
     ui_worker_stats, ui_turn_counter, ui_detected_enemies_of,
+    safe_goto,
 )
 
 
@@ -95,11 +96,11 @@ def _worker_report_html(page, worker_lastname, base_url=None):
     ensure_gm_login(page, url)
     ctrl_id = ui_worker_controller_id(page, worker_lastname, base_url=url)
     assert ctrl_id, f"Worker {worker_lastname} has no controller"
-    page.goto(f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
     page.wait_for_load_state("networkidle")
     wid = _cached_wid(page, worker_lastname)
     assert wid, f"Worker {worker_lastname} not found"
-    page.goto(f"{url}/workers/action.php?worker_id={wid}")
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
     page.wait_for_load_state("load")
     return page.content()
 
@@ -175,14 +176,14 @@ def load_and_end_turn(browser):
     context = browser.new_context()
     page = context.new_page()
 
-    page.goto(f"{PHP_BASE_URL}/connection/loginForm.php")
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
     page.locator("input[name='passwd']").fill("orga")
     page.locator("input[type='submit']").first.click()
     page.wait_for_load_state("networkidle")
 
-    page.goto(f"{PHP_BASE_URL}/base/admin.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option("TestConfig")
     page.locator("input[name='submit'][value='Submit']").click()
@@ -190,7 +191,7 @@ def load_and_end_turn(browser):
     page.wait_for_load_state("load", timeout=90000)
 
     # Trigger end turn and capture page for warning check
-    page.goto(f"{PHP_BASE_URL}/mechanics/endTurn.php")
+    safe_goto(page, f"{PHP_BASE_URL}/mechanics/endTurn.php")
     page.wait_for_load_state("load", timeout=90000)
 
     context.close()
@@ -235,7 +236,7 @@ class TestEndTurn:
         Since turn already advanced, this tests the 'already done' path.
         UI-only smoke check — runs under UI_ONLY=1."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/mechanics/endTurn.php")
+        safe_goto(page, f"{base_url}/mechanics/endTurn.php")
         page.wait_for_load_state("load", timeout=30000)
         html = page.content()
         assert "<b>Warning</b>" not in html, "PHP warnings on end turn page"
@@ -483,9 +484,9 @@ class TestLocationDetection:
     def test_name_only_not_on_zones_page(self, page: Page, base_url):
         """Golf (name-only) should NOT see Location A on zones page."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Golf')}")
+        safe_goto(page, f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Golf')}")
         page.wait_for_load_state("networkidle")
-        page.goto(f"{base_url}/zones/action.php")
+        safe_goto(page, f"{base_url}/zones/action.php")
         page.wait_for_load_state("networkidle")
         assert "Location A" not in page.content()
 
@@ -517,16 +518,16 @@ class TestLocationDetection:
     def test_desc_on_zones_page(self, page: Page, base_url):
         """Foxtrot should see Location A on zones page."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Foxtrot')}")
+        safe_goto(page, f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Foxtrot')}")
         page.wait_for_load_state("networkidle")
-        page.goto(f"{base_url}/zones/action.php")
+        safe_goto(page, f"{base_url}/zones/action.php")
         page.wait_for_load_state("networkidle")
         assert "Location A" in page.content()
 
     def test_desc_on_controller_page(self, page: Page, base_url):
         """Foxtrot should see Location A on controller/accueil page."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Foxtrot')}")
+        safe_goto(page, f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Foxtrot')}")
         page.wait_for_load_state("networkidle")
         assert "Location A" in page.inner_text("body") or "Location A" in page.content()
 
@@ -556,18 +557,18 @@ class TestLocationDetection:
     def test_secret_on_zones_page(self, page: Page, base_url):
         """Charlie should see Location A on zones page (in hidden description div)."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Charlie')}")
+        safe_goto(page, f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Charlie')}")
         page.wait_for_load_state("networkidle")
-        page.goto(f"{base_url}/zones/action.php")
+        safe_goto(page, f"{base_url}/zones/action.php")
         page.wait_for_load_state("networkidle")
         assert "Location A" in page.content()
 
     def test_undiscovered_not_on_zones_page(self, page: Page, base_url):
         """Alpha (unfound) should NOT see Location A on zones page."""
         ensure_gm_login(page, base_url)
-        page.goto(f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Alpha')}")
+        safe_goto(page, f"{base_url}/base/accueil.php?controller_id={_cached_cid(page, 'Alpha')}")
         page.wait_for_load_state("networkidle")
-        page.goto(f"{base_url}/zones/action.php")
+        safe_goto(page, f"{base_url}/zones/action.php")
         page.wait_for_load_state("networkidle")
         assert "Location A" not in page.content()
 
@@ -615,9 +616,9 @@ class TestWorkerViewPage:
         ensure_gm_login(page, base_url)
         ctrl_id = _cached_cid(page, controller_lastname)
         worker_id = _cached_wid(page, worker_lastname)
-        page.goto(f"{base_url}/base/accueil.php?controller_id={ctrl_id}")
+        safe_goto(page, f"{base_url}/base/accueil.php?controller_id={ctrl_id}")
         page.wait_for_load_state("networkidle")
-        page.goto(f"{base_url}/workers/action.php?worker_id={worker_id}")
+        safe_goto(page, f"{base_url}/workers/action.php?worker_id={worker_id}")
         page.wait_for_load_state("networkidle")
 
     def test_agent1_page_no_warnings(self, page: Page, base_url):

--- a/tests/test_controller_recruitment_e2e.py
+++ b/tests/test_controller_recruitment_e2e.py
@@ -53,6 +53,7 @@ from conftest import (
 from helpers import (
     DB_AVAILABLE, get_db_connection as get_db, end_turn, load_minimal_data,
     ui_controller_id, ui_zone_id, ui_controller_counters,
+    safe_goto,
 )
 
 
@@ -97,7 +98,7 @@ def _switch_controller(page, controller_lastname):
     Uses UI-only controller-id resolution so it works under UI_ONLY=1."""
     ensure_gm_login(page, PHP_BASE_URL)
     cid = ui_controller_id(page, controller_lastname)
-    page.goto(
+    safe_goto(page,
         f"{PHP_BASE_URL}/base/accueil.php?controller_id={cid}&chosir=Choisir"
     )
     page.wait_for_load_state("networkidle")
@@ -106,7 +107,7 @@ def _switch_controller(page, controller_lastname):
 def _workers_page_html(page, controller_lastname):
     """Return the viewAll workers page HTML for a controller."""
     _switch_controller(page, controller_lastname)
-    page.goto(f"{PHP_BASE_URL}/workers/viewAll.php")
+    safe_goto(page, f"{PHP_BASE_URL}/workers/viewAll.php")
     page.wait_for_load_state("load")
     return page.content()
 
@@ -121,7 +122,7 @@ def _accueil_html(page, controller_lastname):
     """
     ensure_gm_login(page, PHP_BASE_URL)
     cid = ui_controller_id(page, controller_lastname)
-    page.goto(f"{PHP_BASE_URL}/base/accueil.php?controller_id={cid}&chosir=Choisir")
+    safe_goto(page, f"{PHP_BASE_URL}/base/accueil.php?controller_id={cid}&chosir=Choisir")
     page.wait_for_load_state("load")
     return page.content()
 
@@ -142,7 +143,7 @@ def _create_base(page, controller_lastname, zone_name):
     cid = ui_controller_id(page, controller_lastname)
     zid = ui_zone_id(page, zone_name)
     _switch_controller(page, controller_lastname)
-    page.goto(
+    safe_goto(page,
         f"{PHP_BASE_URL}/controllers/action.php"
         f"?createBase=1&controller_id={cid}&zone_id={zid}"
     )
@@ -154,7 +155,7 @@ def _do_first_come(page, controller_lastname):
     ensure_gm_login(page, PHP_BASE_URL)
     cid = ui_controller_id(page, controller_lastname)
     _switch_controller(page, controller_lastname)
-    page.goto(
+    safe_goto(page,
         f"{PHP_BASE_URL}/workers/new.php?first_come=true&controller_id={cid}"
     )
     page.wait_for_load_state("load")
@@ -168,7 +169,7 @@ def _do_regular_recruit(page, controller_lastname):
     ensure_gm_login(page, PHP_BASE_URL)
     cid = ui_controller_id(page, controller_lastname)
     _switch_controller(page, controller_lastname)
-    page.goto(
+    safe_goto(page,
         f"{PHP_BASE_URL}/workers/new.php?recrutement=true&controller_id={cid}"
     )
     page.wait_for_load_state("load")
@@ -209,7 +210,7 @@ def recruitment_scenario(browser):
 
     # Login + load TestConfig
     ensure_gm_login(page, PHP_BASE_URL)
-    page.goto(f"{PHP_BASE_URL}/base/admin.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option("TestConfig")
     page.locator("input[name='submit'][value='Submit']").click()
@@ -250,7 +251,7 @@ def recruitment_scenario(browser):
     # Phase 4: Alpha uses regular recruitment
     # Capture the recruitment form BEFORE submitting (for form validation tests)
     _switch_controller(page, 'Alpha')
-    page.goto(
+    safe_goto(page,
         f"{PHP_BASE_URL}/workers/new.php?recrutement=true&controller_id={_snapshot['alpha_cid']}"
     )
     page.wait_for_load_state("load")
@@ -269,7 +270,7 @@ def recruitment_scenario(browser):
     # Phase 5: Beta creates base + captures recruitment form (for faction filtering)
     _create_base(page, 'Beta', 'Zeta-Unclaimed')
     _switch_controller(page, 'Beta')
-    page.goto(
+    safe_goto(page,
         f"{PHP_BASE_URL}/workers/new.php?recrutement=true&controller_id={_snapshot['beta_cid']}"
     )
     page.wait_for_load_state("load")

--- a/tests/test_controller_recruitment_e2e.py
+++ b/tests/test_controller_recruitment_e2e.py
@@ -53,7 +53,7 @@ from conftest import (
 from helpers import (
     DB_AVAILABLE, get_db_connection as get_db, end_turn, load_minimal_data,
     ui_controller_id, ui_zone_id, ui_controller_counters,
-    safe_goto,
+    safe_goto, register_php_error_listener, assert_no_collected_php_errors,
 )
 
 
@@ -207,6 +207,7 @@ def recruitment_scenario(browser):
 
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
 
     # Login + load TestConfig
     ensure_gm_login(page, PHP_BASE_URL)
@@ -296,6 +297,7 @@ def recruitment_scenario(browser):
         _workers_page_html(page, 'Alpha')
     )
 
+    assert_no_collected_php_errors(page)
     context.close()
     yield
 

--- a/tests/test_controllers_e2e.py
+++ b/tests/test_controllers_e2e.py
@@ -19,7 +19,10 @@ from conftest import (
 from helpers import DB_AVAILABLE
 
 
-from helpers import get_db_connection, load_minimal_data, login_as, logout, safe_goto
+from helpers import (
+    get_db_connection, load_minimal_data, login_as, logout, safe_goto,
+    register_php_error_listener, assert_no_collected_php_errors,
+)
 
 
 @pytest.fixture(scope="session")
@@ -40,6 +43,7 @@ def load_test_config_with_players(browser):
 
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
     safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
@@ -52,6 +56,7 @@ def load_test_config_with_players(browser):
     page.locator("input[name='submit'][value='Submit']").click()
     page.wait_for_timeout(5000)
     page.wait_for_load_state("load", timeout=90000)
+    assert_no_collected_php_errors(page)
     context.close()
 
     yield
@@ -70,13 +75,6 @@ def gm_page(page: Page, base_url):
 
 class TestControllerAdmin:
     """Admin user (gm) with multiple controllers."""
-
-    def test_accueil_no_warnings(self, gm_page: Page, base_url):
-        safe_goto(gm_page, f"{base_url}/base/accueil.php")
-        gm_page.wait_for_load_state("networkidle")
-        page_html = gm_page.content()
-        assert "<b>Warning</b>" not in page_html
-        assert "<b>Fatal error</b>" not in page_html
 
     def test_admin_sees_controller_dropdown(self, gm_page: Page, base_url):
         """Admin with multiple controllers should see a selection dropdown."""
@@ -115,13 +113,6 @@ class TestControllerSinglePlayer:
         yield page
         logout(page, base_url)
 
-    def test_no_warnings(self, single_page: Page, base_url):
-        safe_goto(single_page, f"{base_url}/base/accueil.php")
-        single_page.wait_for_load_state("networkidle")
-        page_html = single_page.content()
-        assert "<b>Warning</b>" not in page_html
-        assert "<b>Fatal error</b>" not in page_html
-
     def test_no_controller_chooser(self, single_page: Page, base_url):
         """Single-controller player should NOT see the controller_id dropdown."""
         safe_goto(single_page, f"{base_url}/base/accueil.php")
@@ -151,13 +142,6 @@ class TestControllerMultiPlayer:
         login_as(page, base_url, "multi_player", "test")
         yield page
         logout(page, base_url)
-
-    def test_no_warnings(self, multi_page: Page, base_url):
-        safe_goto(multi_page, f"{base_url}/base/accueil.php")
-        multi_page.wait_for_load_state("networkidle")
-        page_html = multi_page.content()
-        assert "<b>Warning</b>" not in page_html
-        assert "<b>Fatal error</b>" not in page_html
 
     def test_sees_controller_dropdown(self, multi_page: Page, base_url):
         safe_goto(multi_page, f"{base_url}/base/accueil.php")

--- a/tests/test_controllers_e2e.py
+++ b/tests/test_controllers_e2e.py
@@ -19,7 +19,7 @@ from conftest import (
 from helpers import DB_AVAILABLE
 
 
-from helpers import get_db_connection, load_minimal_data, login_as, logout
+from helpers import get_db_connection, load_minimal_data, login_as, logout, safe_goto
 
 
 @pytest.fixture(scope="session")
@@ -40,13 +40,13 @@ def load_test_config_with_players(browser):
 
     context = browser.new_context()
     page = context.new_page()
-    page.goto(f"{PHP_BASE_URL}/connection/loginForm.php")
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
     page.locator("input[name='passwd']").fill("orga")
     page.locator("input[type='submit']").first.click()
     page.wait_for_load_state("networkidle")
-    page.goto(f"{PHP_BASE_URL}/base/admin.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option("TestConfig")
     page.locator("input[name='submit'][value='Submit']").click()
@@ -72,7 +72,7 @@ class TestControllerAdmin:
     """Admin user (gm) with multiple controllers."""
 
     def test_accueil_no_warnings(self, gm_page: Page, base_url):
-        gm_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(gm_page, f"{base_url}/base/accueil.php")
         gm_page.wait_for_load_state("networkidle")
         page_html = gm_page.content()
         assert "<b>Warning</b>" not in page_html
@@ -80,13 +80,13 @@ class TestControllerAdmin:
 
     def test_admin_sees_controller_dropdown(self, gm_page: Page, base_url):
         """Admin with multiple controllers should see a selection dropdown."""
-        gm_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(gm_page, f"{base_url}/base/accueil.php")
         gm_page.wait_for_load_state("networkidle")
         select = gm_page.locator("select#controllerSelect[name='controller_id']")
         expect(select).to_be_visible()
 
     def test_admin_dropdown_lists_both_controllers(self, gm_page: Page, base_url):
-        gm_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(gm_page, f"{base_url}/base/accueil.php")
         gm_page.wait_for_load_state("networkidle")
         select = gm_page.locator("select#controllerSelect[name='controller_id']")
         options = select.locator("option").all()
@@ -97,7 +97,7 @@ class TestControllerAdmin:
             f"Beta not in dropdown: {option_texts}"
 
     def test_admin_choose_button_visible(self, gm_page: Page, base_url):
-        gm_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(gm_page, f"{base_url}/base/accueil.php")
         gm_page.wait_for_load_state("networkidle")
         expect(gm_page.locator("input[value='Choisir']")).to_be_visible()
 
@@ -116,7 +116,7 @@ class TestControllerSinglePlayer:
         logout(page, base_url)
 
     def test_no_warnings(self, single_page: Page, base_url):
-        single_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(single_page, f"{base_url}/base/accueil.php")
         single_page.wait_for_load_state("networkidle")
         page_html = single_page.content()
         assert "<b>Warning</b>" not in page_html
@@ -124,7 +124,7 @@ class TestControllerSinglePlayer:
 
     def test_no_controller_chooser(self, single_page: Page, base_url):
         """Single-controller player should NOT see the controller_id dropdown."""
-        single_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(single_page, f"{base_url}/base/accueil.php")
         single_page.wait_for_load_state("networkidle")
         chooser = single_page.locator("select#controllerSelect[name='controller_id']")
         assert chooser.count() == 0, \
@@ -132,7 +132,7 @@ class TestControllerSinglePlayer:
 
     def test_sees_faction_directly(self, single_page: Page, base_url):
         """Single-controller player should see their faction info immediately."""
-        single_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(single_page, f"{base_url}/base/accueil.php")
         single_page.wait_for_load_state("networkidle")
         page_text = single_page.inner_text("body")
         assert "Alpha" in page_text, \
@@ -153,21 +153,21 @@ class TestControllerMultiPlayer:
         logout(page, base_url)
 
     def test_no_warnings(self, multi_page: Page, base_url):
-        multi_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(multi_page, f"{base_url}/base/accueil.php")
         multi_page.wait_for_load_state("networkidle")
         page_html = multi_page.content()
         assert "<b>Warning</b>" not in page_html
         assert "<b>Fatal error</b>" not in page_html
 
     def test_sees_controller_dropdown(self, multi_page: Page, base_url):
-        multi_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(multi_page, f"{base_url}/base/accueil.php")
         multi_page.wait_for_load_state("networkidle")
         select = multi_page.locator("select#controllerSelect[name='controller_id']")
         expect(select).to_be_visible()
 
     def test_sees_only_own_controllers(self, multi_page: Page, base_url):
         """Should see Alpha and Beta (their own), not any hidden controllers."""
-        multi_page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(multi_page, f"{base_url}/base/accueil.php")
         multi_page.wait_for_load_state("networkidle")
         select = multi_page.locator("select#controllerSelect[name='controller_id']")
         options = select.locator("option").all()

--- a/tests/test_csv_features_e2e.py
+++ b/tests/test_csv_features_e2e.py
@@ -25,7 +25,7 @@ from conftest import (
 
 
 from helpers import (
-    DB_AVAILABLE, get_db_connection, load_minimal_data,
+    DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto,
     ui_worker_count, ui_power_options_by_type, ui_all_workers,
 )
 
@@ -42,13 +42,13 @@ def _load_test_config(browser):
 
     context = browser.new_context()
     page = context.new_page()
-    page.goto(f"{PHP_BASE_URL}/connection/loginForm.php")
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
     page.locator("input[name='passwd']").fill("orga")
     page.locator("input[type='submit']").first.click()
     page.wait_for_load_state("networkidle")
-    page.goto(f"{PHP_BASE_URL}/base/admin.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option("TestConfig")
     page.locator("input[name='submit'][value='Submit']").click()
@@ -335,7 +335,7 @@ class TestLoadWorkersCSV:
         """
         ensure_gm_login(page, base_url)
         # Build controller_id → lastname map from accueil's controllerSelect
-        page.goto(f"{base_url}/base/accueil.php")
+        safe_goto(page, f"{base_url}/base/accueil.php")
         page.wait_for_load_state("networkidle")
         id_to_lastname = {}
         for opt in page.locator("select#controllerSelect option").all():

--- a/tests/test_csv_features_e2e.py
+++ b/tests/test_csv_features_e2e.py
@@ -27,6 +27,7 @@ from conftest import (
 from helpers import (
     DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto,
     ui_worker_count, ui_power_options_by_type, ui_all_workers,
+    register_php_error_listener, assert_no_collected_php_errors,
 )
 
 
@@ -42,6 +43,7 @@ def _load_test_config(browser):
 
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
     safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
@@ -54,6 +56,7 @@ def _load_test_config(browser):
     page.locator("input[name='submit'][value='Submit']").click()
     page.wait_for_timeout(5000)
     page.wait_for_load_state("load", timeout=90000)
+    assert_no_collected_php_errors(page)
     context.close()
 
 

--- a/tests/test_empty_scenario_e2e.py
+++ b/tests/test_empty_scenario_e2e.py
@@ -16,7 +16,7 @@ from conftest import (
     PHP_BASE_URL, ensure_gm_login,
 )
 
-from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, ui_turn_counter
+from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto, ui_turn_counter
 
 
 @pytest.fixture(scope="session")
@@ -47,13 +47,13 @@ def load_empty_scenario(browser):
     # Load TestConfig via admin UI
     context = browser.new_context()
     page = context.new_page()
-    page.goto(f"{PHP_BASE_URL}/connection/loginForm.php")
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
     page.locator("input[name='passwd']").fill("orga")
     page.locator("input[type='submit']").first.click()
     page.wait_for_load_state("networkidle")
-    page.goto(f"{PHP_BASE_URL}/base/admin.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option("TestConfig")
     page.locator("input[name='submit'][value='Submit']").click()
@@ -81,7 +81,7 @@ def load_empty_scenario(browser):
     conn.close()
 
     # Trigger end turn
-    page.goto(f"{PHP_BASE_URL}/mechanics/endTurn.php")
+    safe_goto(page, f"{PHP_BASE_URL}/mechanics/endTurn.php")
     page.wait_for_load_state("load", timeout=90000)
 
     context.close()

--- a/tests/test_empty_scenario_e2e.py
+++ b/tests/test_empty_scenario_e2e.py
@@ -16,7 +16,10 @@ from conftest import (
     PHP_BASE_URL, ensure_gm_login,
 )
 
-from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto, ui_turn_counter
+from helpers import (
+    DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto, ui_turn_counter,
+    register_php_error_listener, assert_no_collected_php_errors,
+)
 
 
 @pytest.fixture(scope="session")
@@ -47,6 +50,7 @@ def load_empty_scenario(browser):
     # Load TestConfig via admin UI
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
     safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
@@ -84,6 +88,7 @@ def load_empty_scenario(browser):
     safe_goto(page, f"{PHP_BASE_URL}/mechanics/endTurn.php")
     page.wait_for_load_state("load", timeout=90000)
 
+    assert_no_collected_php_errors(page)
     context.close()
     yield
 

--- a/tests/test_parallel_games_e2e.py
+++ b/tests/test_parallel_games_e2e.py
@@ -33,6 +33,7 @@ from helpers import (
     DB_AVAILABLE, get_db_connection as get_db,
     login_as, end_turn, load_scenario_via_admin, load_minimal_data,
     ui_worker_count, ui_zone_names, ui_all_controllers,
+    register_php_error_listener, assert_no_collected_php_errors,
 )
 
 
@@ -121,8 +122,10 @@ def _end_turn_fresh_context(browser, url_base):
     """End turn via a fresh browser context (used for parallel-games isolation)."""
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
     login_as(page, url_base, "gm", "orga")
     end_turn(page, url_base)
+    assert_no_collected_php_errors(page)
     context.close()
 
 

--- a/tests/test_zones_e2e.py
+++ b/tests/test_zones_e2e.py
@@ -15,7 +15,10 @@ from conftest import (
     PHP_BASE_URL,
 )
 
-from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, login_as, logout, safe_goto
+from helpers import (
+    DB_AVAILABLE, get_db_connection, load_minimal_data, login_as, logout, safe_goto,
+    register_php_error_listener, assert_no_collected_php_errors,
+)
 
 
 @pytest.fixture(scope="session")
@@ -39,6 +42,7 @@ def load_test_config_with_controllers(browser):
     # Load TestConfig via admin UI (works everywhere)
     context = browser.new_context()
     page = context.new_page()
+    register_php_error_listener(page)
     safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
@@ -51,6 +55,7 @@ def load_test_config_with_controllers(browser):
     page.locator("input[name='submit'][value='Submit']").click()
     page.wait_for_timeout(5000)
     page.wait_for_load_state("load", timeout=90000)
+    assert_no_collected_php_errors(page)
     context.close()
 
     yield
@@ -66,19 +71,6 @@ def gm_page(page: Page, base_url):
 # ---------------------------------------------------------------------------
 # Zones page tests
 # ---------------------------------------------------------------------------
-
-class TestZonesPageNoWarnings:
-    """Zones page should load without PHP warnings or errors."""
-
-    def test_zones_page_no_php_warnings(self, gm_page: Page, base_url):
-        safe_goto(gm_page, f"{base_url}/zones/action.php")
-        gm_page.wait_for_load_state("networkidle")
-        page_html = gm_page.content()
-        assert "<b>Warning</b>" not in page_html, \
-            "PHP warnings on zones page"
-        assert "<b>Fatal error</b>" not in page_html, \
-            "PHP fatal error on zones page"
-
 
 class TestZonesPageStructure:
     """Zones page displays zone section with correct content."""

--- a/tests/test_zones_e2e.py
+++ b/tests/test_zones_e2e.py
@@ -15,7 +15,7 @@ from conftest import (
     PHP_BASE_URL,
 )
 
-from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, login_as, logout
+from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, login_as, logout, safe_goto
 
 
 @pytest.fixture(scope="session")
@@ -39,13 +39,13 @@ def load_test_config_with_controllers(browser):
     # Load TestConfig via admin UI (works everywhere)
     context = browser.new_context()
     page = context.new_page()
-    page.goto(f"{PHP_BASE_URL}/connection/loginForm.php")
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
     page.wait_for_load_state("networkidle")
     page.locator("input[name='username']").fill("gm")
     page.locator("input[name='passwd']").fill("orga")
     page.locator("input[type='submit']").first.click()
     page.wait_for_load_state("networkidle")
-    page.goto(f"{PHP_BASE_URL}/base/admin.php")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
     page.wait_for_load_state("networkidle")
     page.locator("select[name='config_name']").select_option("TestConfig")
     page.locator("input[name='submit'][value='Submit']").click()
@@ -71,7 +71,7 @@ class TestZonesPageNoWarnings:
     """Zones page should load without PHP warnings or errors."""
 
     def test_zones_page_no_php_warnings(self, gm_page: Page, base_url):
-        gm_page.goto(f"{base_url}/zones/action.php")
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
         gm_page.wait_for_load_state("networkidle")
         page_html = gm_page.content()
         assert "<b>Warning</b>" not in page_html, \
@@ -84,7 +84,7 @@ class TestZonesPageStructure:
     """Zones page displays zone section with correct content."""
 
     def test_zones_section_visible(self, gm_page: Page, base_url):
-        gm_page.goto(f"{base_url}/zones/action.php")
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
         gm_page.wait_for_load_state("networkidle")
         zones_section = gm_page.locator("div.section.zones")
         expect(zones_section).to_be_visible()
@@ -92,7 +92,7 @@ class TestZonesPageStructure:
 
     def test_all_test_config_zones_listed(self, gm_page: Page, base_url):
         """All 7 TestConfig zones should appear on the page."""
-        gm_page.goto(f"{base_url}/zones/action.php")
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
         gm_page.wait_for_load_state("networkidle")
         page_text = gm_page.locator("div.section.zones").inner_text()
 
@@ -102,7 +102,7 @@ class TestZonesPageStructure:
 
     def test_zones_have_description_divs(self, gm_page: Page, base_url):
         """Each zone should have a hidden description div."""
-        gm_page.goto(f"{base_url}/zones/action.php")
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
         gm_page.wait_for_load_state("networkidle")
         description_divs = gm_page.locator("div[id^='description-']")
         count = description_divs.count()
@@ -116,7 +116,7 @@ class TestZonesPageControllers:
 
     def test_claimed_zones_show_banner(self, gm_page: Page, base_url):
         """Gamma-Claims and Delta-Disputed were claimed — they should have banner tags."""
-        gm_page.goto(f"{base_url}/zones/action.php")
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
         gm_page.wait_for_load_state("networkidle")
         banner_tags = gm_page.locator("span.tag.is-warning")
         assert banner_tags.count() >= 2, \
@@ -124,7 +124,7 @@ class TestZonesPageControllers:
 
     def test_banner_shows_controller_name(self, gm_page: Page, base_url):
         """Banner tags should contain the controller lastname."""
-        gm_page.goto(f"{base_url}/zones/action.php")
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
         gm_page.wait_for_load_state("networkidle")
         page_text = gm_page.locator("div.section.zones").inner_text()
         assert "Alpha" in page_text, \
@@ -135,9 +135,9 @@ class TestZonesPageControllers:
     def test_own_zone_shows_control_tag(self, gm_page: Page, base_url):
         """Zones held by the player's controller should show 'our control' tag."""
         # gm is linked to controller Alpha who claims Gamma-Claims
-        gm_page.goto(f"{base_url}/base/accueil.php?controller_id=1")
+        safe_goto(gm_page, f"{base_url}/base/accueil.php?controller_id=1")
         gm_page.wait_for_load_state("networkidle")
-        gm_page.goto(f"{base_url}/zones/action.php")
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
         gm_page.wait_for_load_state("networkidle")
         danger_tags = gm_page.locator("span.tag.is-danger")
         assert danger_tags.count() >= 1, \

--- a/workers/functions.php
+++ b/workers/functions.php
@@ -539,9 +539,14 @@ function randomWorkerName($pdo, $newWorker) {
 
     // Fetch the results
     $worker_names = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    // Store worker_origins in the array
-    $newWorker['firstname'] = $worker_names[0]['firstname'];
-    $newWorker['lastname'] = $worker_names[1]['lastname'];
+    // Store worker_origins in the array. SQL is LIMIT 2 but small
+    // worker_names pools may return only 1 row — fall back to the
+    // first row so we don't access an undefined index. The 0-rows
+    // case is tracked as audit N2 (proper rollback + UX error).
+    $first_row  = $worker_names[0] ?? null;
+    $second_row = $worker_names[1] ?? $first_row;
+    $newWorker['firstname'] = $first_row['firstname']  ?? '';
+    $newWorker['lastname']  = $second_row['lastname']  ?? '';
     return $newWorker;
 }
 


### PR DESCRIPTION
  Body:                                                                                                                                                                                                            
  ## Summary                                                                                                                                                                                                     
  - ** fix** (`workers/functions.php`) — `randomWorkerName` now falls back gracefully when an origin's name pool has fewer than 2 rows (no more `Undefined array key 1` warning).
  - **step 1** — added `safe_goto`, `assert_no_php_errors`, `register_php_error_listener`, and `assert_no_collected_php_errors` to `tests/helpers.py`. All 119 `page.goto` sites migrated to `safe_goto`.
  Conftest autouse fixture attaches the response listener to every function-scoped `page`.                                                                                                                         
  - **step 2** — every module-scoped browser context now registers the listener and asserts before closing. 7 redundant per-page smoke tests deleted (safe_goto + listener catches them automatically).         
                                                                                                                                                                                                                   
  Strict markers: `<b>Warning</b>`, `<b>Fatal error</b>`, `<b>Parse error</b>`. Belt-and-buckle: explicit wrapper for navigation + response listener for click-driven nav.                                         
                                                                                                                                                                                                                 
  The fix was surfaced **by** the new instrumentation — proof that the approach works end-to-end. 