### PR TITLE
fix : block direct HTTP access to /workers/view.php  

### DIFF
--- a/controllers/view.php
+++ b/controllers/view.php
@@ -1,4 +1,10 @@
 <?php
+// Include-only partial — block direct HTTP access. The supported URL is
+// /controllers/action.php which require_once's this file.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
 
     $zonesArray = getZonesArray($gameReady);
 

--- a/workers/newPerfectWorker.php
+++ b/workers/newPerfectWorker.php
@@ -1,4 +1,11 @@
 <?php
+// Include-only partial — block direct HTTP access. Reached via the
+// admin link that require_once's this file from a bootstrapped page.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
+
     $title = 'Admin - Create Perfect Agent';
 
     // Build form and call workers/action.php

--- a/workers/view.php
+++ b/workers/view.php
@@ -1,4 +1,11 @@
 <?php
+// Include-only partial — block direct HTTP access. The supported URL is
+// /workers/action.php?worker_id=N which require_once's this file.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
+
 if ($_SESSION['DEBUG'] == true) echo "_SESSION: ".var_export($_SESSION, true)."<br /><br />";
 
 if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {

--- a/zones/view.php
+++ b/zones/view.php
@@ -1,4 +1,11 @@
 <?php
+// Include-only partial — block direct HTTP access. The supported URL is
+// /zones/action.php which require_once's this file.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
+
     $zones = getZonesArray($gameReady);
     $map_file = getConfig($gameReady, 'map_file');
 


### PR DESCRIPTION
- workers/view.php is an include-only partial pulled in by workers/action.php; direct GET emitted PHP warnings before
  the bouncer rendered.                                                                                                 
  - 4-line realpath-comparison guard returns 403 on direct access; include path unaffected (require_once gives a        
  different realpath than the request).