### PR TITLE
test : Replace hardcoded TestConfig CSV-row counts with dynamic reads

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,8 +10,11 @@ Extracts exact-copy duplicated functions from individual test modules:
 The DB_AVAILABLE flag is computed once at import time so test modules
 can use it for `pytest.skip` guards without repeating the probe.
 """
+import csv
 import os
 import re
+from pathlib import Path
+
 import pymysql
 from playwright.sync_api import Page
 
@@ -19,6 +22,20 @@ from conftest import (
     GAME_PREFIX, MYSQL_HOST, MYSQL_PORT, MYSQL_USER, MYSQL_PASSWORD, MYSQL_DB,
     PHP_BASE_URL, SQL_DIR, ensure_gm_login,
 )
+
+
+# ---------------------------------------------------------------------------
+# CSV helpers
+# ---------------------------------------------------------------------------
+
+CSV_DIR = Path(__file__).parent.parent / "var" / "csv"
+
+
+def csv_row_count(csv_filename):
+    """Number of data rows in a CSV (header excluded). Used to keep test
+    count assertions in lockstep with CSV content."""
+    with open(CSV_DIR / csv_filename) as f:
+        return sum(1 for _ in csv.reader(f)) - 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_admin_csv_load_e2e.py
+++ b/tests/test_admin_csv_load_e2e.py
@@ -21,7 +21,7 @@ from conftest import (
     PHP_BASE_URL,
 )
 
-from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto
+from helpers import DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto, csv_row_count
 
 
 def table_row_count(table_name):
@@ -146,14 +146,19 @@ class TestCSVLoadViaAdmin:
             "PHP warnings found on page after TestConfig reset"
 
         # Verify CSV load success messages with correct row counts
-        assert "setupTestConfig_worker_origins.csv loaded successfully (3 rows)" in page_html, \
-            "Expected worker_origins CSV to load 3 rows"
-        assert "setupTestConfig_worker_names.csv loaded successfully (8 rows)" in page_html, \
-            "Expected worker_names CSV to load 8 rows"
-        assert "setupTestConfig_zones.csv loaded successfully (8 rows)" in page_html, \
-            "Expected zones CSV to load 8 rows"
-        assert "setupTestConfig_hobbys.csv loaded successfully (13 rows)" in page_html, \
-            "Expected hobbys CSV to load 13 rows"
+        # (counts read live from the CSVs so adding rows doesn't break the test)
+        wo_n = csv_row_count("setupTestConfig_worker_origins.csv")
+        wn_n = csv_row_count("setupTestConfig_worker_names.csv")
+        zones_n = csv_row_count("setupTestConfig_zones.csv")
+        hobbys_n = csv_row_count("setupTestConfig_hobbys.csv")
+        assert f"setupTestConfig_worker_origins.csv loaded successfully ({wo_n} rows)" in page_html, \
+            f"Expected worker_origins CSV to load {wo_n} rows"
+        assert f"setupTestConfig_worker_names.csv loaded successfully ({wn_n} rows)" in page_html, \
+            f"Expected worker_names CSV to load {wn_n} rows"
+        assert f"setupTestConfig_zones.csv loaded successfully ({zones_n} rows)" in page_html, \
+            f"Expected zones CSV to load {zones_n} rows"
+        assert f"setupTestConfig_hobbys.csv loaded successfully ({hobbys_n} rows)" in page_html, \
+            f"Expected hobbys CSV to load {hobbys_n} rows"
 
         # Verify DB row counts
         assert table_row_count("worker_origins") >= 3, \

--- a/tests/test_csv_features_e2e.py
+++ b/tests/test_csv_features_e2e.py
@@ -28,6 +28,7 @@ from helpers import (
     DB_AVAILABLE, get_db_connection, load_minimal_data, safe_goto,
     ui_worker_count, ui_power_options_by_type, ui_all_workers,
     register_php_error_listener, assert_no_collected_php_errors,
+    csv_row_count,
 )
 
 
@@ -274,13 +275,17 @@ class TestLoadWorkersCSV:
     """
 
     def test_workers_table_populated(self, page: Page, base_url):
-        """Exactly 33 workers should exist (7 detection + 19 combat + 5 cross + 2 artefact).
+        """Worker count must match setupTestConfig_advanced.csv data rows.
 
         Counts rows on /workers/management_workers.php — UI-runnable.
+        Compares against csv_row_count() so adding a worker to the CSV
+        doesn't require updating the assertion here.
         """
         ensure_gm_login(page, base_url)
         count = ui_worker_count(page, base_url=base_url)
-        assert count == 33, f"Expected 33 workers, got {count}"
+        expected = csv_row_count("setupTestConfig_advanced.csv")
+        assert count == expected, \
+            f"Expected {expected} workers (per setupTestConfig_advanced.csv), got {count}"
 
     @pytest.mark.db
     def test_all_workers_have_origin_and_zone(self):

--- a/tests/test_csv_load.py
+++ b/tests/test_csv_load.py
@@ -13,6 +13,7 @@ import pymysql
 import pytest
 
 from conftest import GAME_PREFIX, CSV_DIR, SQL_DIR, MYSQL_DB
+from helpers import csv_row_count
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +262,7 @@ class TestLoadCSVFile:
              "controllers__lastname->holder_controller_id"]
         )
         # All zones should be loaded (empty lookups resolve to NULL)
-        assert count == 8
+        assert count == csv_row_count("setupTestConfig_zones.csv")
 
         cursor = conn.cursor()
         cursor.execute(f"SELECT claimer_controller_id, holder_controller_id FROM `{GAME_PREFIX}zones`")
@@ -404,18 +405,21 @@ class TestFullScenarioLoad:
 
         cursor = conn.cursor()
 
-        # Verify counts
+        # Verify counts (dynamic — read from the source CSVs)
         cursor.execute(f"SELECT COUNT(*) as c FROM `{GAME_PREFIX}worker_origins`")
-        assert cursor.fetchone()["c"] == 3
+        assert cursor.fetchone()["c"] == csv_row_count("setupTestConfig_worker_origins.csv")
 
         cursor.execute(f"SELECT COUNT(*) as c FROM `{GAME_PREFIX}zones`")
-        assert cursor.fetchone()["c"] == 8
+        assert cursor.fetchone()["c"] == csv_row_count("setupTestConfig_zones.csv")
 
         cursor.execute(f"SELECT COUNT(*) as c FROM `{GAME_PREFIX}worker_names`")
-        assert cursor.fetchone()["c"] == 8
+        assert cursor.fetchone()["c"] == csv_row_count("setupTestConfig_worker_names.csv")
 
         cursor.execute(f"SELECT COUNT(*) as c FROM `{GAME_PREFIX}powers`")
-        assert cursor.fetchone()["c"] == 25  # 13 hobbys + 12 jobs
+        assert cursor.fetchone()["c"] == (
+            csv_row_count("setupTestConfig_hobbys.csv")
+            + csv_row_count("setupTestConfig_jobs.csv")
+        )
 
         # Verify FK integrity: all worker_names have valid origin_ids
         cursor.execute(f"""

--- a/tests/test_parallel_games_e2e.py
+++ b/tests/test_parallel_games_e2e.py
@@ -34,6 +34,7 @@ from helpers import (
     login_as, end_turn, load_scenario_via_admin, load_minimal_data,
     ui_worker_count, ui_zone_names, ui_all_controllers,
     register_php_error_listener, assert_no_collected_php_errors,
+    csv_row_count,
 )
 
 
@@ -189,13 +190,17 @@ class TestBothGamesLoaded:
         assert count == 9, f"Expected 9 Shikoku workers, got {count}"
 
     def test_primary_has_workers(self, page: Page, base_url):
-        """TestConfig in primary loaded 33 workers (7 detection + 19 combat + 5 cross + 2 artefact).
+        """TestConfig in primary loaded the workers from setupTestConfig_advanced.csv.
 
         Counts rows on /workers/management_workers.php on the primary URL.
+        Compared dynamically against the CSV row count so CSV growth
+        doesn't require a test-side bump.
         """
         login_as(page, base_url, "gm", "orga")
         count = ui_worker_count(page, base_url=base_url)
-        assert count == 33, f"Expected 33 TestConfig workers, got {count}"
+        expected = csv_row_count("setupTestConfig_advanced.csv")
+        assert count == expected, \
+            f"Expected {expected} TestConfig workers (per setupTestConfig_advanced.csv), got {count}"
 
     def test_secondary_has_shikoku_zones(self, page: Page, base_url):
         """Secondary has Shikoku zones (11 total). Counted via management_zones."""
@@ -205,11 +210,12 @@ class TestBothGamesLoaded:
             f"Expected 11 Shikoku zones, got {len(zones)}: {zones}"
 
     def test_primary_has_testconfig_zones(self, page: Page, base_url):
-        """Primary has the 8 TestConfig zones. Counted via management_zones."""
+        """Primary has the TestConfig zones from setupTestConfig_zones.csv. Counted via management_zones."""
         login_as(page, base_url, "gm", "orga")
         zones = ui_zone_names(page, base_url=base_url)
-        assert len(zones) == 8, \
-            f"Expected 8 TestConfig zones, got {len(zones)}: {zones}"
+        expected = csv_row_count("setupTestConfig_zones.csv")
+        assert len(zones) == expected, \
+            f"Expected {expected} TestConfig zones (per setupTestConfig_zones.csv), got {len(zones)}: {zones}"
 
 
 class TestShodoshimaInSecondary:


### PR DESCRIPTION
Add csv_row_count() helper in tests/helpers.py that opens var/csv/<filename> and counts data rows excluding the header. Use it at TestConfig assertion sites in test_csv_features_e2e, test_parallel_games_e2e, test_csv_load, and test_admin_csv_load_e2e so future CSV additions to TestConfig no longer require test-side count bumps. Japon1555/Vampire1966 counts intentionally remain hardcoded — different scenarios, out of scope for this refactor.