### PR TITLE
feat : security pass: auth + ownership + direct-access hardening 

### DIFF
--- a/base/baseHTML.php
+++ b/base/baseHTML.php
@@ -1,5 +1,12 @@
 <?php
 
+// Include-only page — block direct HTTP access.
+// Requires a run of base/basePHP.php and set $gameTitle / $mechanics / $_SESSION.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
+
 // Check if the user is logged in
 if (
     (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true)

--- a/connection/logout.php
+++ b/connection/logout.php
@@ -1,6 +1,14 @@
 <?php
 session_start(); // Start the session
 
+// Anonymous direct GET: nothing to log out from. loginForm.php sits in
+// the same /connection/ directory so a relative Location header works
+// without needing $_SESSION['FOLDER'] (which is unset for anon).
+if (empty($_SESSION['logged_in']) || empty($_SESSION['FOLDER'])) {
+    header('Location: loginForm.php');
+    exit();
+}
+
 $folder = $_SESSION['FOLDER'];
 
 // Unset session variables

--- a/controllers/action.php
+++ b/controllers/action.php
@@ -4,6 +4,44 @@ require_once '../base/basePHP.php';
 $pageName = 'controllers_action';
 $debug = strtolower($_SESSION['DEBUG']) === 'true';
 
+// Check if the user is logged in
+if (
+    (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true)
+) {
+    // Redirect the user to the login page if not logged in
+    header(sprintf('Location: /%s/connection/loginForm.php', $_SESSION['FOLDER']));
+    exit();
+}
+
+// Resolve controller_id from URL (may be empty for bare-GET view flows
+// where the active controller is held in $_SESSION['controller'])
+$controller_id = NULL;
+if ( !empty($_GET['controller_id']) ) $controller_id = $_GET['controller_id'];
+if ($debug) echo "controller_id (guard): ".var_export($controller_id, true)."<br /><br />";
+
+// Ownership guard fires only on mutating actions; bare GET passes through
+// to view.php so foreign-controller intel views keep working.
+$MUTATING_ACTIONS = [
+    'createBase', 'moveBase', 'attackLocation', 'repairLocation',
+    'giftInformationAgent', 'giftInformationLocation',
+];
+$is_mutating = false;
+foreach ($MUTATING_ACTIONS as $k) {
+    if (isset($_GET[$k])) { $is_mutating = true; break; }
+}
+
+if ($is_mutating && empty($_SESSION['is_privileged'])) {
+    $session_controller_id = $_SESSION['controller']['id'] ?? null;
+    if (empty($session_controller_id) || empty($controller_id)) {
+        http_response_code(403);
+        exit();
+    }
+    if ((int)$session_controller_id !== (int)$controller_id) {
+        http_response_code(403);
+        exit();
+    }
+}
+
 if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
     if ($debug) echo "_GET:".var_export($_GET, true)." <br /> <br />";
     $prefix = $_SESSION['GAME_PREFIX'];

--- a/controllers/view.php
+++ b/controllers/view.php
@@ -1,17 +1,18 @@
 <?php
-// Include-only partial — block direct HTTP access. The supported URL is
-// /controllers/action.php which require_once's this file.
+// Include-only page — block direct HTTP access.
 if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
     http_response_code(403);
     exit();
 }
 
+    // Get zones information
     $zonesArray = getZonesArray($gameReady);
 
     $controllersArray = array();
     $playerURL = null;
     $prefix = $_SESSION['GAME_PREFIX'];
 
+    // get player information
     if (isset( $_SESSION['user_id'])) {
         try{
             $sqlPlayers = sprintf("SELECT p.*
@@ -28,6 +29,7 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
         $playerURL = $players[0]['url'];
     }
 
+    // Get Controllers information
     $controllers = getControllers($gameReady, $_SESSION['user_id'], null, false);
     $debug = false;
     if (strtolower(getConfig($gameReady, 'DEBUG')) == 'true') $debug = true;

--- a/mechanics/attackMechanic.php
+++ b/mechanics/attackMechanic.php
@@ -1,4 +1,9 @@
 <?php
+// Include-only page — block direct HTTP access.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
 
 /**
  * Search database for all workers in attack mode and return their targets and combat power differences.

--- a/mechanics/investigateMechanic.php
+++ b/mechanics/investigateMechanic.php
@@ -1,4 +1,9 @@
 <?php
+// Include-only page — block direct HTTP access.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
 
 /**
  *  Remove curly braces and quotes and Split the string by commas into an array

--- a/mechanics/locationSearchMechanic.php
+++ b/mechanics/locationSearchMechanic.php
@@ -1,5 +1,9 @@
 <?php
-
+// Include-only page — block direct HTTP access.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
 
 /**
  * gets the comparaison table between the workers on search/investigate and there possible targets locations

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -125,7 +125,7 @@ def as_controller(page: Page, lastname: str, base_url: str = None):
     Assumes the page already has a logged-in session (gm or any non-privileged
     player linked to this controller). Sets $_SESSION['controller'] so
     subsequent /workers/action.php and /controllers/action.php calls pass the
-    M2 ownership guard for non-privileged users. Privileged users (gm) bypass
+    ownership guard for non-privileged users. Privileged users (gm) bypass
     the guard regardless, but selecting still affects view.php's
     controller-scoped rendering.
     """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -119,6 +119,22 @@ def logout(page: Page, base_url: str):
     page.wait_for_load_state("networkidle")
 
 
+def as_controller(page: Page, lastname: str, base_url: str = None):
+    """Select the named controller via the accueil flow.
+
+    Assumes the page already has a logged-in session (gm or any non-privileged
+    player linked to this controller). Sets $_SESSION['controller'] so
+    subsequent /workers/action.php and /controllers/action.php calls pass the
+    M2 ownership guard for non-privileged users. Privileged users (gm) bypass
+    the guard regardless, but selecting still affects view.php's
+    controller-scoped rendering.
+    """
+    url = base_url or PHP_BASE_URL
+    cid = ui_controller_id(page, lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={cid}&chosir=Choisir")
+    page.wait_for_load_state("networkidle")
+
+
 def end_turn(page: Page, base_url: str = None):
     """Trigger end-of-turn. Page must already be logged in.
 

--- a/tests/test_controllers_action_auth_e2e.py
+++ b/tests/test_controllers_action_auth_e2e.py
@@ -1,0 +1,148 @@
+"""Playwright E2E tests for /controllers/action.php auth + ownership guard.
+
+Guard at the top of controllers/action.php:
+  - Must be logged in (session.logged_in) — anonymous → loginForm.php redirect
+  - Bare GET (no mutating action key) passes through to view.php so the
+    "select foreign controller via accueil + render intel" flow keeps working
+  - On any of the 6 mutating action keys
+    (createBase, moveBase, attackLocation, repairLocation,
+     giftInformationAgent, giftInformationLocation):
+      - Privileged users (gm) bypass ownership entirely
+      - Non-privileged: session.controller.id must equal URL controller_id
+      - Otherwise: HTTP 403 + exit() before any state-mutating handler runs
+
+Test users (TestConfig, shared with test_workers_action_auth_e2e.py):
+  - gm / orga              — privileged, linked to all 7 controllers
+  - single_player / test   — not privileged, linked to Alpha only
+                             (auto-selected on login, loginForm.php:95-97)
+
+UI-only / prod-DEMO-runnable.
+
+Run:
+    python3 -m pytest tests/test_controllers_action_auth_e2e.py -v
+"""
+import pytest
+from playwright.sync_api import Page
+
+from conftest import PHP_BASE_URL, ensure_gm_login
+from helpers import (
+    DB_AVAILABLE, load_minimal_data, login_as, safe_goto,
+    ui_controller_id,
+)
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_testconfig(browser):
+    """Load TestConfig once per module so the test controllers exist."""
+    if DB_AVAILABLE:
+        load_minimal_data()
+    context = browser.new_context()
+    page = context.new_page()
+    ensure_gm_login(page, PHP_BASE_URL)
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
+    page.wait_for_load_state("networkidle")
+    page.locator("select[name='config_name']").select_option("TestConfig")
+    page.locator("input[name='submit'][value='Submit']").click()
+    page.wait_for_timeout(5000)
+    page.wait_for_load_state("load", timeout=90000)
+    context.close()
+    yield
+
+
+def _resolve_controller_id(browser, base_url, lastname):
+    """Helper: spin up a gm context, look up a controller_id, tear down."""
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    ensure_gm_login(page, base_url)
+    cid = ui_controller_id(page, lastname, base_url=base_url)
+    ctx.close()
+    return cid
+
+
+# ---------------------------------------------------------------------------
+# 1. Anonymous direct GET — must redirect to loginForm.php
+# ---------------------------------------------------------------------------
+
+def test_anonymous_get_redirects_to_login(browser, base_url):
+    """No session → action.php redirects (302) to /connection/loginForm.php
+    rather than 403, matching the existing pattern used by admin pages and
+    workers/action.php."""
+    alpha_cid = _resolve_controller_id(browser, base_url, "Alpha")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    page.goto(f"{base_url}/controllers/action.php?controller_id={alpha_cid}")
+    assert "loginForm.php" in page.url, (
+        f"Anonymous GET on /controllers/action.php must redirect to the login form; "
+        f"landed on {page.url}"
+    )
+    ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-privileged user, NOT owner — must 403
+# ---------------------------------------------------------------------------
+
+def test_non_owner_mutation_returns_403(browser, base_url):
+    """single_player auto-selects Alpha on login; attempting a mutating
+    action (createBase) on Beta's controller_id must 403. Bare GET on a
+    foreign controller_id is allowed (view.php controls intel filtering);
+    only mutations are gated."""
+    beta_cid = _resolve_controller_id(browser, base_url, "Beta")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    login_as(page, base_url, "single_player", "test")
+    # createBase is the cheapest mutating key — zone_id=1 is bogus but the
+    # 403 fires before the handler runs.
+    response = page.goto(
+        f"{base_url}/controllers/action.php"
+        f"?controller_id={beta_cid}&createBase=1&zone_id=1"
+    )
+    assert response is not None
+    assert response.status == 403, \
+        f"Non-owner mutation on a foreign controller must 403; got {response.status}"
+    ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-privileged user, IS owner — must succeed
+# ---------------------------------------------------------------------------
+
+def test_owner_acts_on_own_controller(browser, base_url):
+    """single_player auto-selects Alpha; hitting Alpha's own controller_id
+    must render the page (200)."""
+    alpha_cid = _resolve_controller_id(browser, base_url, "Alpha")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    login_as(page, base_url, "single_player", "test")
+    response = page.goto(f"{base_url}/controllers/action.php?controller_id={alpha_cid}")
+    assert response is not None
+    assert response.status == 200, \
+        f"Owner action on own controller must succeed; got {response.status}"
+    ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# 4. Privileged gm — bypasses ownership
+# ---------------------------------------------------------------------------
+
+def test_gm_privileged_bypasses_ownership(browser, base_url):
+    """gm has is_privileged=1 and is linked to all controllers; guard must
+    let them through regardless of which controller_id is targeted."""
+    beta_cid = _resolve_controller_id(browser, base_url, "Beta")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    login_as(page, base_url, "gm", "orga")
+    response = page.goto(f"{base_url}/controllers/action.php?controller_id={beta_cid}")
+    assert response is not None
+    assert response.status == 200, \
+        f"Privileged gm must bypass ownership; got {response.status}"
+    ctx.close()

--- a/tests/test_direct_access_e2e.py
+++ b/tests/test_direct_access_e2e.py
@@ -1,0 +1,53 @@
+"""Playwright E2E tests for direct-access hardening.
+
+Several PHP files are include-only partials or entry points that are not
+meant to be hit directly from a browser. Each is hardened either with a
+realpath include-guard (partials, returns 403) or a redirect to the
+login form (navigational entry points like logout).
+
+Files covered here:
+  - /connection/logout.php        — entry point, anon → 302 to loginForm
+  - /base/baseHTML.php            — include-only partial, direct GET → 403
+
+UI-only / prod-DEMO-runnable.
+
+Run:
+    python3 -m pytest tests/test_direct_access_e2e.py -v
+"""
+import pytest
+
+from conftest import PHP_BASE_URL
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+def test_anonymous_logout_redirects_to_login(browser, base_url):
+    """No session → /connection/logout.php must redirect to loginForm.php
+    (relative Location header), not emit a PHP warning on undefined
+    $_SESSION['FOLDER']."""
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    page.goto(f"{base_url}/connection/logout.php")
+    assert "loginForm.php" in page.url, (
+        f"Anonymous GET on /connection/logout.php must redirect to "
+        f"loginForm.php; landed on {page.url}"
+    )
+    ctx.close()
+
+
+def test_anonymous_basehtml_returns_403(browser, base_url):
+    """Direct GET on /base/baseHTML.php must 403; the file is an
+    include-only partial and would emit PHP warnings on $_SESSION
+    and undefined $gameTitle / $mechanics if it ran standalone."""
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    response = page.goto(f"{base_url}/base/baseHTML.php")
+    assert response is not None
+    assert response.status == 403, (
+        f"Direct GET on /base/baseHTML.php must 403; "
+        f"got {response.status}"
+    )
+    ctx.close()

--- a/tests/test_workers_action_auth_e2e.py
+++ b/tests/test_workers_action_auth_e2e.py
@@ -1,0 +1,192 @@
+"""Playwright E2E tests for /workers/action.php auth + ownership guard (audit M2).
+
+Guard at the top of workers/action.php (added 2026-04-27):
+  - Must be logged in (session.logged_in + session.user_id)
+  - Privileged users (gm) bypass ownership entirely
+  - Non-privileged: session.controller.id must own the target worker_id (any
+    controller_worker row, covering primary + double-agent links)
+  - Otherwise: HTTP 403 + exit() before any state-mutating code runs
+
+Test users (TestConfig):
+  - gm / orga              — privileged, linked to all 7 controllers
+  - single_player / test   — not privileged, linked to Alpha only
+                             (auto-selected on login, loginForm.php:95-97)
+
+Test workers (TestConfig):
+  - Searcher_1   — Alpha, Alpha-Investigation, passive
+  - Bystander_1  — Beta,  Alpha-Investigation, passive
+
+UI-only / prod-DEMO-runnable.
+
+Run:
+    python3 -m pytest tests/test_workers_action_auth_e2e.py -v
+"""
+import pytest
+from playwright.sync_api import Page
+
+from conftest import PHP_BASE_URL, ensure_gm_login
+from helpers import (
+    DB_AVAILABLE, load_minimal_data, login_as, safe_goto,
+    ui_worker_id, ui_workers_by_lastname,
+)
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_testconfig(browser):
+    """Load TestConfig once per module so the test workers exist."""
+    if DB_AVAILABLE:
+        load_minimal_data()
+    context = browser.new_context()
+    page = context.new_page()
+    ensure_gm_login(page, PHP_BASE_URL)
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
+    page.wait_for_load_state("networkidle")
+    page.locator("select[name='config_name']").select_option("TestConfig")
+    page.locator("input[name='submit'][value='Submit']").click()
+    page.wait_for_timeout(5000)
+    page.wait_for_load_state("load", timeout=90000)
+    context.close()
+    yield
+
+
+def _resolve_worker_id(browser, base_url, lastname):
+    """Helper: spin up a gm context, look up a worker_id, tear down."""
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    ensure_gm_login(page, base_url)
+    wid = ui_worker_id(page, lastname, base_url=base_url)
+    ctx.close()
+    return wid
+
+
+# ---------------------------------------------------------------------------
+# 1. Anonymous direct GET — must redirect to loginForm.php
+# ---------------------------------------------------------------------------
+
+def test_anonymous_get_redirects_to_login(browser, base_url):
+    """No session → action.php redirects (302) to /connection/loginForm.php
+    rather than 403, matching the existing pattern used by admin pages.
+    Playwright follows the redirect by default; assert the final URL lands
+    on the login form."""
+    wid = _resolve_worker_id(browser, base_url, "Searcher_1")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    page.goto(f"{base_url}/workers/action.php?worker_id={wid}")
+    assert "loginForm.php" in page.url, (
+        f"Anonymous GET on /workers/action.php must redirect to the login form; "
+        f"landed on {page.url}"
+    )
+    ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-privileged user, NOT owner — must 403
+# ---------------------------------------------------------------------------
+
+def test_non_owner_returns_403(browser, base_url):
+    """single_player auto-selects Alpha on login; Bystander_1 is Beta's worker."""
+    bystander_wid = _resolve_worker_id(browser, base_url, "Bystander_1")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    login_as(page, base_url, "single_player", "test")
+    response = page.goto(f"{base_url}/workers/action.php?worker_id={bystander_wid}")
+    assert response is not None
+    assert response.status == 403, \
+        f"Non-owner action on a foreign worker must 403; got {response.status}"
+    ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-privileged user, IS owner — must succeed
+# ---------------------------------------------------------------------------
+
+def test_owner_acts_on_own_worker(browser, base_url):
+    """single_player auto-selects Alpha; Searcher_1 is Alpha's worker."""
+    searcher_wid = _resolve_worker_id(browser, base_url, "Searcher_1")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    login_as(page, base_url, "single_player", "test")
+    response = page.goto(f"{base_url}/workers/action.php?worker_id={searcher_wid}")
+    assert response is not None
+    assert response.status == 200, \
+        f"Owner action on own worker must succeed; got {response.status}"
+    ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# 4. Privileged gm — bypasses ownership
+# ---------------------------------------------------------------------------
+
+def test_gm_privileged_bypasses_ownership(browser, base_url):
+    """gm has is_privileged=1 and is linked to all controllers; guard must
+    let them through regardless of whose worker is targeted."""
+    bystander_wid = _resolve_worker_id(browser, base_url, "Bystander_1")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    login_as(page, base_url, "gm", "orga")
+    response = page.goto(f"{base_url}/workers/action.php?worker_id={bystander_wid}")
+    assert response is not None
+    assert response.status == 200, \
+        f"Privileged gm must bypass ownership; got {response.status}"
+    ctx.close()
+
+
+# ---------------------------------------------------------------------------
+# 5. State-mutation guard — 403'd attack must NOT change action_choice
+# ---------------------------------------------------------------------------
+
+def test_anonymous_attack_does_not_mutate_state(browser, base_url):
+    """Belt-and-buckle: even though the guard exit()s before activateWorker,
+    verify the attack URL anonymously really doesn't move worker_actions
+    out of 'passive'. Reads pre/post action_choice via UI."""
+    searcher_wid = _resolve_worker_id(browser, base_url, "Searcher_1")
+    bystander_wid = _resolve_worker_id(browser, base_url, "Bystander_1")
+
+    # Pre-state via gm
+    gm_ctx = browser.new_context()
+    gm_page = gm_ctx.new_page()
+    ensure_gm_login(gm_page, base_url)
+    pre_rows = ui_workers_by_lastname(gm_page, "Searcher_1", base_url=base_url)
+    pre_live = [r for r in pre_rows if r['action_choice'] != 'trace']
+    assert pre_live, "Searcher_1 should have a live row pre-attempt"
+    pre_action = pre_live[0]['action_choice']
+    gm_ctx.close()
+
+    # Anonymous attack attempt — must be intercepted before any mutation runs.
+    # Anonymous flow now redirects to loginForm.php (302) rather than 403'ing.
+    anon_ctx = browser.new_context()
+    anon_page = anon_ctx.new_page()
+    attack_url = (
+        f"{base_url}/workers/action.php"
+        f"?worker_id={searcher_wid}&attack=Attaquer"
+        f"&enemy_worker_id=worker_{bystander_wid}"
+    )
+    anon_page.goto(attack_url)
+    assert "loginForm.php" in anon_page.url, (
+        f"Anonymous attack must redirect to login; landed on {anon_page.url}"
+    )
+    anon_ctx.close()
+
+    # Post-state via gm
+    gm_ctx2 = browser.new_context()
+    gm_page2 = gm_ctx2.new_page()
+    ensure_gm_login(gm_page2, base_url)
+    post_rows = ui_workers_by_lastname(gm_page2, "Searcher_1", base_url=base_url)
+    post_live = [r for r in post_rows if r['action_choice'] != 'trace']
+    assert post_live, "Searcher_1 should still have a live row post-attempt"
+    post_action = post_live[0]['action_choice']
+    gm_ctx2.close()
+
+    assert post_action == pre_action, (
+        f"403'd attack must NOT mutate state; action_choice "
+        f"changed from '{pre_action}' to '{post_action}'"
+    )

--- a/tests/test_workers_action_auth_e2e.py
+++ b/tests/test_workers_action_auth_e2e.py
@@ -1,6 +1,6 @@
-"""Playwright E2E tests for /workers/action.php auth + ownership guard (audit M2).
+"""Playwright E2E tests for /workers/action.php auth + ownership guard.
 
-Guard at the top of workers/action.php (added 2026-04-27):
+Guard at the top of workers/action.php:
   - Must be logged in (session.logged_in + session.user_id)
   - Privileged users (gm) bypass ownership entirely
   - Non-privileged: session.controller.id must own the target worker_id (any
@@ -227,8 +227,8 @@ class TestInactiveStateBlock:
 
     def test_dead_worker_blocks_attack_allows_transform(self, browser, base_url):
         """Same dead Inv_Def_2 — attack 403s, transform passes through (200).
-        Logged in as delta_player (non-privileged, owns Delta) so the M2.1
-        block actually runs (privileged users bypass)."""
+        Logged in as delta_player (non-privileged, owns Delta) so the
+        inactive-state block actually runs (privileged users bypass)."""
         wid = _resolve_worker_id(browser, base_url, "Inv_Def_2")
 
         # 1. Mutating-action that is NOT transform → must 403.

--- a/tests/test_workers_action_auth_e2e.py
+++ b/tests/test_workers_action_auth_e2e.py
@@ -11,10 +11,14 @@ Test users (TestConfig):
   - gm / orga              — privileged, linked to all 7 controllers
   - single_player / test   — not privileged, linked to Alpha only
                              (auto-selected on login, loginForm.php:95-97)
+  - delta_player / test    — not privileged, linked to Delta only;
+                             added to seed a dead-worker scenario for the
+                             trace/dead state-mutation block.
 
 Test workers (TestConfig):
   - Searcher_1   — Alpha, Alpha-Investigation, passive
   - Bystander_1  — Beta,  Alpha-Investigation, passive
+  - Inv_Def_2    — Delta, Beta-Combat — killed by Inv_Atk_2 after end-turn
 
 UI-only / prod-DEMO-runnable.
 
@@ -28,6 +32,7 @@ from conftest import PHP_BASE_URL, ensure_gm_login
 from helpers import (
     DB_AVAILABLE, load_minimal_data, login_as, safe_goto,
     ui_worker_id, ui_workers_by_lastname,
+    ui_attack, end_turn,
 )
 
 
@@ -190,3 +195,70 @@ def test_anonymous_attack_does_not_mutate_state(browser, base_url):
         f"403'd attack must NOT mutate state; action_choice "
         f"changed from '{pre_action}' to '{post_action}'"
     )
+
+
+# ---------------------------------------------------------------------------
+# Inactive-state block
+#
+# After ownership passes, workers/action.php blocks mutating actions on
+# 'trace' and 'dead' workers. Carve-out: 'transform' is allowed on dead
+# (vampire resurrect / ghost path). The dead+transform branch is the most
+# likely to silently regress (a typo in `!isset($_GET['transform'])` or a
+# refactor that drops the carve-out), so it gets the regression test.
+# Trace-block has no carve-out — single condition, code-review covers it.
+# ---------------------------------------------------------------------------
+
+class TestInactiveStateBlock:
+    """Belt-and-buckle for the dead-worker carve-out: attack on a dead worker
+    must 403, but transform on the same dead worker must pass through (vampire
+    resurrect path)."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def kill_inv_def_2(self, browser, base_url):
+        """Seed: Inv_Atk_2 (Charlie) attacks Inv_Def_2 (Delta), end-turn → kill.
+        Mirrors the existing combat-fixture pattern from test_agent_combat_e2e."""
+        ctx = browser.new_context()
+        page = ctx.new_page()
+        ensure_gm_login(page, base_url)
+        ui_attack(page, "Inv_Atk_2", "Inv_Def_2", base_url=base_url)
+        end_turn(page, base_url=base_url)
+        ctx.close()
+        yield
+
+    def test_dead_worker_blocks_attack_allows_transform(self, browser, base_url):
+        """Same dead Inv_Def_2 — attack 403s, transform passes through (200).
+        Logged in as delta_player (non-privileged, owns Delta) so the M2.1
+        block actually runs (privileged users bypass)."""
+        wid = _resolve_worker_id(browser, base_url, "Inv_Def_2")
+
+        # 1. Mutating-action that is NOT transform → must 403.
+        ctx_attack = browser.new_context()
+        page_attack = ctx_attack.new_page()
+        login_as(page_attack, base_url, "delta_player", "test")
+        attack_url = (
+            f"{base_url}/workers/action.php?worker_id={wid}&attack=Attaquer"
+            f"&enemy_worker_id=worker_1"
+        )
+        response = page_attack.goto(attack_url)
+        assert response is not None
+        assert response.status == 403, (
+            f"Mutating non-transform action on a dead worker must 403; "
+            f"got {response.status}"
+        )
+        ctx_attack.close()
+
+        # 2. Same dead worker, transform action — must pass the block.
+        # The downstream upgradeWorker call may itself fail (no real
+        # transformation power supplied), but that happens AFTER the block;
+        # for the block-regression assertion, status != 403 is enough.
+        ctx_xform = browser.new_context()
+        page_xform = ctx_xform.new_page()
+        login_as(page_xform, base_url, "delta_player", "test")
+        transform_url = f"{base_url}/workers/action.php?worker_id={wid}&transform=1"
+        response = page_xform.goto(transform_url)
+        assert response is not None
+        assert response.status != 403, (
+            f"Transform on a dead worker must pass the block (vampire "
+            f"resurrect carve-out); got 403"
+        )
+        ctx_xform.close()

--- a/var/csv/setupTestConfig_player_controller.csv
+++ b/var/csv/setupTestConfig_player_controller.csv
@@ -9,3 +9,4 @@ gm,Golf
 single_player,Alpha
 multi_player,Alpha
 multi_player,Beta
+delta_player,Delta

--- a/var/csv/setupTestConfig_players.csv
+++ b/var/csv/setupTestConfig_players.csv
@@ -1,3 +1,4 @@
 username,passwd,is_privileged
 single_player,test,0
 multi_player,test,0
+delta_player,test,0

--- a/workers/action.php
+++ b/workers/action.php
@@ -53,6 +53,38 @@ if (empty($_SESSION['is_privileged'])) {
     }
 }
 
+// Blocking trace and dead workers from changing action illogicaly
+$MUTATING_ACTIONS = [ 'move', 'attack', 'hide', 'passive', 'investigate',
+    'claim', 'gift', 'recallDoubleAgent', 'returnPrisoner',
+    'teach_discipline', 'transform'
+];
+$is_mutating = false;
+foreach ($MUTATING_ACTIONS as $k) {
+    if (isset($_GET[$k])) { $is_mutating = true; break; }
+}
+if ($is_mutating && empty($_SESSION['is_privileged']) && $worker_id) {
+        $prefix = $_SESSION['GAME_PREFIX'];
+        $stmt = $gameReady->prepare(
+            "SELECT action_choice FROM {$prefix}worker_actions
+             WHERE worker_id = :wid AND turn_number = :turn LIMIT 1"
+        );
+        $stmt->execute([
+            ':wid' => $worker_id,
+            ':turn' => $mechanics['turncounter'],
+        ]);
+        $current_choice = $stmt->fetchColumn();
+
+        if (
+            // trace worker should never change action
+            $current_choice === 'trace'
+            // dead worker sould only be able to transform
+            || ($current_choice === 'dead' && !isset($_GET['transform']))
+        ) {
+            http_response_code(403);
+            exit();
+        }
+}
+
 if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
     if ($_SESSION['DEBUG'] == true) echo "_GET:".var_export($_GET, true)." <br /> <br />";
 

--- a/workers/action.php
+++ b/workers/action.php
@@ -3,15 +3,63 @@
 require_once '../base/basePHP.php';
 $pageName = 'workers_action';
 
+// Check if the user is logged in
+if (
+    (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true)
+) {
+    // Redirect the user to the login page if not logged in
+    header(sprintf('Location: /%s/connection/loginForm.php', $_SESSION['FOLDER']));
+    exit();
+}
+
+// A worker_id is necessary
+$worker_id = NULL;
+if ( !empty($_GET['worker_id']) ) $worker_id = $_GET['worker_id'];
+if ( $_SESSION['DEBUG'] == true ) echo "worker_id: ".var_export($worker_id, true)."<br /><br />";
+// it can be determined by worker creation 
+if (isset($_GET['creation'])){
+    $worker_id = createWorker($gameReady, $_GET);
+    if ($_SESSION['DEBUG'] == true) echo 'createWorker : DONE <br />';
+}
+// if the is not worker ID this is an error
+if (empty($worker_id)) {
+    http_response_code(403);
+    exit();
+}
+
+// If the user is not privileged and not the owner of the worker, he should not have access
+if (empty($_SESSION['is_privileged'])) {
+    $session_controller_id = $_SESSION['controller']['id'] ?? null;
+    if (empty($session_controller_id)) {
+        http_response_code(403);
+        exit();
+    }
+
+    try {
+        $prefix = $_SESSION['GAME_PREFIX'];
+        $stmt = $gameReady->prepare(
+            "SELECT 1 FROM {$prefix}controller_worker
+                WHERE worker_id = :wid AND controller_id = :cid LIMIT 1"
+        );
+        $stmt->execute([':wid' => $worker_id, ':cid' => $session_controller_id]);
+        if ($stmt->fetchColumn() === false) {
+            http_response_code(403);
+            exit();
+        }
+    } catch (PDOException $e) {
+        echo __FUNCTION__."(): SELECT controller_worker Failed: " . $e->getMessage()."<br />";
+        http_response_code(403);
+        exit();
+    }
+}
+
 if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
     if ($_SESSION['DEBUG'] == true) echo "_GET:".var_export($_GET, true)." <br /> <br />";
 
-    $worker_id = NULL;
-    if ( !empty($_GET['worker_id']) ) $worker_id = $_GET['worker_id'];
-    if ( $_SESSION['DEBUG'] == true ) echo "worker_id: ".var_export($worker_id, true)."<br /><br />";
     $zone_id = NULL;
     if ( !empty($_GET['zone_id']) ) $zone_id = $_GET['zone_id'];
     if ( $_SESSION['DEBUG'] == true ) echo "zone_id: ".var_export($zone_id, true)."<br /><br />";
+
     $enemy_worker_id = NULL;
     if ( !empty($_GET['enemy_worker_id']) ) $enemy_worker_id = $_GET['enemy_worker_id'];
     if ( $_SESSION['DEBUG'] == true ) echo "enemy_worker_id: ".var_export($enemy_worker_id, true)."<br /><br />";
@@ -39,11 +87,6 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
     $double_controller_id = NULL;
     if ( !empty($_GET['double_controller_id']) ) $double_controller_id = $_GET['double_controller_id'];
     if ( $_SESSION['DEBUG'] == true ) echo "double_controller_id: ".var_export($double_controller_id, true)."<br /><br />";
-
-    if (isset($_GET['creation'])){
-        $worker_id = createWorker($gameReady, $_GET);
-        if ($_SESSION['DEBUG'] == true) echo 'createWorker : DONE <br />';
-    }
 
     if (isset($_GET['move'])){
         if (!empty($zone_id)) moveWorker($gameReady, $worker_id, $zone_id);

--- a/workers/newPerfectWorker.php
+++ b/workers/newPerfectWorker.php
@@ -1,6 +1,5 @@
 <?php
-// Include-only partial — block direct HTTP access. Reached via the
-// admin link that require_once's this file from a bootstrapped page.
+// Include-only page — block direct HTTP access.
 if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
     http_response_code(403);
     exit();
@@ -8,7 +7,6 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
 
     $title = 'Admin - Create Perfect Agent';
 
-    // Build form and call workers/action.php
     // Select a controller from controllers
     $controllerValues = getControllers($gameReady, NULL, NULL, FALSE);
 

--- a/workers/view.php
+++ b/workers/view.php
@@ -1,6 +1,5 @@
 <?php
-// Include-only partial — block direct HTTP access. The supported URL is
-// /workers/action.php?worker_id=N which require_once's this file.
+// Include-only page — block direct HTTP access.
 if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
     http_response_code(403);
     exit();
@@ -13,6 +12,7 @@ if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {
     if ( empty($controller_id) ) $controller_id = $_SESSION['controller']['id'];
     if ( $_SESSION['DEBUG'] == true ) echo "controller_id: ".var_export($controller_id, true)."<br /><br />";
 
+    // Get workers information
     $workersArray = getWorkers($gameReady, [$worker_id]);
 
     echo "<div class='workers section'>";

--- a/zones/view.php
+++ b/zones/view.php
@@ -1,12 +1,13 @@
 <?php
-// Include-only partial — block direct HTTP access. The supported URL is
-// /zones/action.php which require_once's this file.
+// Include-only page — block direct HTTP access.
 if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
     http_response_code(403);
     exit();
 }
 
+    // Get Zones information
     $zones = getZonesArray($gameReady);
+    // Extract map file
     $map_file = getConfig($gameReady, 'map_file');
 
     $imgString = '';


### PR DESCRIPTION
  Add login + ownership guards on /workers/action.php and /controllers/action.php (mutating actions  
  only on the controllers endpoint; privileged users bypass).
  Block state mutation on inactive workers (trace, dead) at /workers/action.php with a transform     
  carve-out for the vampire resurrect / become-ghost path.                                           
  Add direct-access guards on workers/view.php, zones/view.php, controllers/view.php,
  workers/newPerfectWorker.php, mechanics/*.php partials, connection/logout.php, and                 
  base/baseHTML.php.                                           
  New tests cover anonymous, non-owner, owner, privileged-bypass, the dead-worker transform          
  carve-out, and direct-access 403s.                           
  Out of scope (tracked separately): POST + CSRF, sequential-ID enumeration hardening,
  workers/new.php recruitment auth. 