### PR TITLE
chore : bump GitHub Actions to Node.js 24 majors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Boot Docker stack
         run: docker compose up -d --build
@@ -20,7 +20,7 @@ jobs:
         run: ./docker/smoke_test.sh
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip


### PR DESCRIPTION
actions/checkout@v4 → v5 and actions/setup-python@v5 → v6 — both v5/v6 run on Node.js 24. Clears the runner deprecation warning ahead of the Node.js 20 removal deadline (2026-09-16). No behaviour change; same inputs, same outputs.