### PR TITLE
test : flake-fix + UI-click sweep on workers/view + controllers/view buttons

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -740,10 +740,28 @@ def ui_investigate(page: Page, lastname: str, base_url: str = None):
     """Queue an investigate action via workers/action.php URL endpoint."""
     url = base_url or PHP_BASE_URL
     wid = _cached_wid(page, lastname, base_url)
-    safe_goto(page, 
+    safe_goto(page,
         f"{url}/workers/action.php"
         f"?worker_id={wid}&investigate=1"
     )
+    page.wait_for_load_state("load")
+
+
+def ui_investigate_click(page: Page, lastname: str, base_url: str = None):
+    """UI-button-click variant of ui_investigate. Switches to the worker's
+    owner, opens /workers/action.php, and clicks the rendered 'Investigate'
+    button (input[name='investigate']). Use on the FIRST investigate call
+    in each test file (per audit's once-per-file rule); subsequent calls
+    can use the URL-driver ui_investigate."""
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    wid = _cached_wid(page, lastname, base_url)
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
+    _wait_loaded(page, "input[name='investigate']")
+    page.locator("input[name='investigate']").click()
     page.wait_for_load_state("load")
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -830,10 +830,31 @@ def ui_move(page: Page, lastname: str, zone_name: str, base_url: str = None):
     url = base_url or PHP_BASE_URL
     wid = _cached_wid(page, lastname, base_url)
     zid = ui_zone_id(page, zone_name, base_url)
-    safe_goto(page, 
+    safe_goto(page,
         f"{url}/workers/action.php"
         f"?worker_id={wid}&zone_id={zid}&move=1"
     )
+    page.wait_for_load_state("load")
+
+
+def ui_move_click(page: Page, lastname: str, zone_name: str,
+                  base_url: str = None):
+    """UI-button-click variant of ui_move. Switches to the worker's owner,
+    opens /workers/action.php, selects the target zone in the zone_id
+    dropdown, and clicks the rendered 'Déménager' button. Use on the
+    FIRST move call in each test file (per audit's once-per-file rule);
+    subsequent calls can use the URL-driver ui_move."""
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    wid = _cached_wid(page, lastname, base_url)
+    zid = ui_zone_id(page, zone_name, base_url)
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
+    _wait_loaded(page, "input[name='move']")
+    page.locator("select[name='zone_id']").first.select_option(value=str(zid))
+    page.locator("input[name='move']").click()
     page.wait_for_load_state("load")
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -778,6 +778,27 @@ def ui_claim(page: Page, lastname: str, claim_controller_lastname: str,
     page.wait_for_load_state("load")
 
 
+def ui_claim_click(page: Page, lastname: str, claim_controller_lastname: str,
+                   base_url: str = None):
+    """UI-button-click variant of ui_claim. Switches to the worker's owner,
+    opens /workers/action.php, selects the target controller in the
+    claim_controller_id dropdown, and clicks the rendered claim submit
+    button. Use on the FIRST claim call in each test file (per audit's
+    once-per-file rule); subsequent calls can use the URL-driver ui_claim."""
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    wid = _cached_wid(page, lastname, base_url)
+    target_cid = _cached_cid(page, claim_controller_lastname, base_url)
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
+    _wait_loaded(page, "input[name='claim']")
+    page.locator("select[name='claim_controller_id']").select_option(value=str(target_cid))
+    page.locator("input[name='claim']").click()
+    page.wait_for_load_state("load")
+
+
 def ui_gift_click(page: Page, lastname: str, target_controller_lastname: str,
                   base_url: str = None):
     """UI-button-click variant of ui_gift. Switches to the worker's owner,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -704,12 +704,35 @@ def ui_attack(page: Page, attacker_lastname: str, target_lastname: str,
     url = base_url or PHP_BASE_URL
     atk_id = _cached_wid(page, attacker_lastname, base_url)
     tgt_id = _cached_wid(page, target_lastname, base_url)
-    safe_goto(page, 
+    safe_goto(page,
         f"{url}/workers/action.php"
         f"?worker_id={atk_id}"
         f"&enemy_worker_id[]=worker_{tgt_id}"
         f"&attack=Attaquer"
     )
+    page.wait_for_load_state("load")
+
+
+def ui_attack_click(page: Page, attacker_lastname: str, target_lastname: str,
+                    base_url: str = None):
+    """UI-button-click variant of ui_attack. Switches to the attacker's
+    owner, opens /workers/action.php, selects the target in the
+    enemyWorkersSelect dropdown, and clicks the rendered 'Attaquer' button.
+    Requires that the attacker has already detected the target — otherwise
+    the attack form does not render. Use on the FIRST attack call in each
+    test file (per audit's once-per-file rule); subsequent calls can use
+    the URL-driver ui_attack."""
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    ctrl_id = ui_worker_controller_id(page, attacker_lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    atk_id = _cached_wid(page, attacker_lastname, base_url)
+    tgt_id = _cached_wid(page, target_lastname, base_url)
+    safe_goto(page, f"{url}/workers/action.php?worker_id={atk_id}")
+    _wait_loaded(page, "input[name='attack']")
+    page.locator("select#enemyWorkersSelect").select_option(value=f"worker_{tgt_id}")
+    page.locator("input[name='attack']").click()
     page.wait_for_load_state("load")
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -103,20 +103,32 @@ def load_minimal_data(prefix=None):
 # Page navigation helpers
 # ---------------------------------------------------------------------------
 
+def _wait_loaded(page: Page, ready_selector: str = None, timeout: int = 30000):
+    """Wait for `load` + (optionally) a specific element. Replaces
+    `wait_for_load_state('networkidle')`, which waits for 500ms of zero
+    network activity and is unreliable under suite load (long-tail asset
+    fetches keep the page from reaching idle within the default 30s).
+    `load` fires once the document and subresources finish; `ready_selector`
+    is the actual readiness signal the caller cares about."""
+    page.wait_for_load_state("load", timeout=timeout)
+    if ready_selector:
+        page.locator(ready_selector).first.wait_for(state="visible", timeout=timeout)
+
+
 def login_as(page: Page, base_url: str, username: str, password: str):
     """Navigate to the login form and submit the given credentials."""
     safe_goto(page, f"{base_url}/connection/loginForm.php")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "input[name='username']")
     page.locator("input[name='username']").fill(username)
     page.locator("input[name='passwd']").fill(password)
     page.locator("input[type='submit']").first.click()
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "a.logout-btn")
 
 
 def logout(page: Page, base_url: str):
     """Navigate to the logout endpoint."""
     safe_goto(page, f"{base_url}/connection/logout.php")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "input[name='username']")
 
 
 def as_controller(page: Page, lastname: str, base_url: str = None):
@@ -132,7 +144,7 @@ def as_controller(page: Page, lastname: str, base_url: str = None):
     url = base_url or PHP_BASE_URL
     cid = ui_controller_id(page, lastname, base_url=url)
     safe_goto(page, f"{url}/base/accueil.php?controller_id={cid}&chosir=Choisir")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "div.header")
 
 
 def end_turn(page: Page, base_url: str = None):
@@ -157,7 +169,7 @@ def load_scenario_via_admin(browser, base_url: str, scenario_name: str):
     page = context.new_page()
     login_as(page, base_url, "gm", "orga")
     safe_goto(page, f"{base_url}/base/admin.php")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "select[name='config_name']")
     page.locator("select[name='config_name']").select_option(scenario_name)
     page.locator("input[name='submit'][value='Submit']").click()
     page.wait_for_timeout(5000)
@@ -180,7 +192,7 @@ def ui_controller_id(page: Page, lastname: str, base_url: str = None):
     Raises AssertionError if not found."""
     url = base_url or PHP_BASE_URL
     safe_goto(page, f"{url}/base/accueil.php")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "select#controllerSelect")
     options = page.locator("select#controllerSelect option").all()
     for opt in options:
         if lastname in (opt.inner_text() or ""):
@@ -401,7 +413,7 @@ def ui_worker_stats(page: Page, lastname: str, base_url: str = None):
     # Switch session to the worker's controller so the page shows the report
     ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
     safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "div.header")
     wid = ui_worker_id(page, lastname, base_url=url)
     safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
     page.wait_for_load_state("load")
@@ -436,7 +448,7 @@ def ui_turn_counter(page: Page, base_url: str = None):
     """
     url = base_url or PHP_BASE_URL
     safe_goto(page, f"{url}/base/accueil.php")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "div.header")
     text = (page.locator("div.header").first.inner_text() or "").strip()
     m = _TURN_RE.search(text)
     if not m:
@@ -478,7 +490,7 @@ def ui_detected_enemies_of(page: Page, searcher_lastname: str, base_url: str = N
     url = base_url or PHP_BASE_URL
     ctrl_id = ui_worker_controller_id(page, searcher_lastname, base_url=url)
     safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "div.header")
     wid = ui_worker_id(page, searcher_lastname, base_url=url)
     safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
     page.wait_for_load_state("load")
@@ -507,7 +519,7 @@ def ui_power_options_by_type(page: Page, base_url: str = None):
     linked to each type (via the link_power_type junction)."""
     url = base_url or PHP_BASE_URL
     safe_goto(page, f"{url}/base/admin.php")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "select#power_hobby_id")
     type_map = {
         "Hobby": "select#power_hobby_id",
         "Metier": "select#power_metier_id",
@@ -606,7 +618,7 @@ def ui_faction_sections(page: Page, controller_lastname: str, base_url: str = No
     url = base_url or PHP_BASE_URL
     ctrl_id = ui_controller_id(page, controller_lastname, base_url=url)
     safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "div.header")
     safe_goto(page, f"{url}/workers/viewAll.php")
     page.wait_for_load_state("load")
 
@@ -771,11 +783,11 @@ def worker_report_html(page: Page, lastname: str, base_url: str = None):
     url = base_url or PHP_BASE_URL
     ensure_gm_login(page, url)
     ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
-    safe_goto(page, 
+    safe_goto(page,
         f"{url}/base/accueil.php"
         f"?controller_id={ctrl_id}&chosir=Choisir"
     )
-    page.wait_for_load_state("networkidle")
+    _wait_loaded(page, "div.header")
     wid = _cached_wid(page, lastname, base_url)
     assert wid, f"Worker {lastname} not found"
     safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -737,20 +737,24 @@ def ui_claim(page: Page, lastname: str, claim_controller_lastname: str,
     page.wait_for_load_state("load")
 
 
-def ui_gift(page: Page, lastname: str, target_controller_lastname: str,
-            base_url: str = None):
-    """Gift `lastname` to `target_controller_lastname` via the
-    workers/action.php URL endpoint (mirrors workers/view.php's
-    'Donner' form). Drives the gift case at workers/functions.php:1020;
-    state effects (live-row swap, trace at old owner, life_report) are
-    asserted by callers."""
+def ui_gift_click(page: Page, lastname: str, target_controller_lastname: str,
+                  base_url: str = None):
+    """UI-button-click variant of ui_gift. Switches to the worker's owner,
+    opens /workers/action.php, selects the target in the gift_controller_id
+    dropdown, and clicks the rendered 'Donner' button. Use on the FIRST
+    gift call in each test file (per audit's once-per-file rule); subsequent
+    calls can use the URL-driver ui_gift."""
     url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
     wid = _cached_wid(page, lastname, base_url)
     target_cid = _cached_cid(page, target_controller_lastname, base_url)
-    safe_goto(page,
-        f"{url}/workers/action.php"
-        f"?worker_id={wid}&gift_controller_id={target_cid}&gift=Donner"
-    )
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
+    _wait_loaded(page, "input[name='gift']")
+    page.locator("select[name='gift_controller_id']").select_option(value=str(target_cid))
+    page.locator("input[name='gift']").click()
     page.wait_for_load_state("load")
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -765,6 +765,40 @@ def ui_investigate_click(page: Page, lastname: str, base_url: str = None):
     page.wait_for_load_state("load")
 
 
+def ui_passive_click(page: Page, lastname: str, base_url: str = None):
+    """UI-button-click for the 'Surveiller' (passive) action button on
+    workers/view.php. Switches to the worker's owner, opens the action
+    page, clicks input[name='passive']. No URL-driver counterpart exists
+    for passive (it's the default state); this helper is the way to
+    exercise the button."""
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    wid = _cached_wid(page, lastname, base_url)
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
+    _wait_loaded(page, "input[name='passive']")
+    page.locator("input[name='passive']").click()
+    page.wait_for_load_state("load")
+
+
+def ui_hide_click(page: Page, lastname: str, base_url: str = None):
+    """UI-button-click for the 'Se cacher' (hide) action button on
+    workers/view.php. Same flow as ui_passive_click; clicks
+    input[name='hide']. No URL-driver counterpart."""
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    wid = _cached_wid(page, lastname, base_url)
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
+    _wait_loaded(page, "input[name='hide']")
+    page.locator("input[name='hide']").click()
+    page.wait_for_load_state("load")
+
+
 def ui_claim(page: Page, lastname: str, claim_controller_lastname: str,
              base_url: str = None):
     """Queue a claim action targeting `claim_controller_lastname`."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -799,6 +799,98 @@ def ui_hide_click(page: Page, lastname: str, base_url: str = None):
     page.wait_for_load_state("load")
 
 
+def _open_worker_action_page(page: Page, lastname: str, base_url: str = None):
+    """Switch session to the worker's controller, navigate to
+    workers/action.php, return the worker_id."""
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    ctrl_id = ui_worker_controller_id(page, lastname, base_url=url)
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={ctrl_id}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    wid = _cached_wid(page, lastname, base_url)
+    safe_goto(page, f"{url}/workers/action.php?worker_id={wid}")
+    page.wait_for_load_state("load")
+    return wid
+
+
+def ui_teach_button_visible(page: Page, lastname: str, base_url: str = None) -> bool:
+    """True if the teach_discipline submit button is rendered on
+    workers/view.php (within /workers/action.php) for this worker."""
+    _open_worker_action_page(page, lastname, base_url)
+    return page.locator("input[name='teach_discipline']").count() > 0
+
+
+def _power_name_from_option_text(text: str) -> str:
+    """Power option labels are rendered as 'Name (e, a/d)' by
+    `getSQLPowerText` (powers/functions.php:33). Strip the stat suffix."""
+    return (text or "").strip().split(" (")[0].strip()
+
+
+def _select_option_value_by_power_name(page: Page, select_selector: str,
+                                       power_name: str):
+    """Select an option whose label starts with `power_name + ' ('` and
+    select it by its value attribute (label-based select_option fails
+    because Playwright doesn't substring-match labels)."""
+    options = page.locator(f"{select_selector} option").all()
+    for opt in options:
+        text = (opt.inner_text() or "").strip()
+        if _power_name_from_option_text(text) == power_name:
+            value = opt.get_attribute("value") or ""
+            if value:
+                page.locator(select_selector).select_option(value=value)
+                return value
+    raise AssertionError(
+        f"Power '{power_name}' not in {select_selector} options"
+    )
+
+
+def ui_teach_discipline_options(page: Page, lastname: str, base_url: str = None) -> list:
+    """Return the discipline names (suffix stripped) from the rendered
+    teach select on workers/view.php. Empty list when the select is
+    absent (worker not eligible)."""
+    _open_worker_action_page(page, lastname, base_url)
+    if page.locator("select#disciplineSelect").count() == 0:
+        return []
+    options = page.locator("select#disciplineSelect option").all()
+    return [_power_name_from_option_text(o.inner_text()) for o in options
+            if (o.get_attribute("value") or "")]
+
+
+def ui_transform_options(page: Page, lastname: str, base_url: str = None) -> list:
+    """Return the transformation names (suffix stripped) from the
+    rendered transformation select on workers/view.php. Empty list when
+    the select is absent (transform UI not rendered)."""
+    _open_worker_action_page(page, lastname, base_url)
+    if page.locator("select#transformationSelect").count() == 0:
+        return []
+    options = page.locator("select#transformationSelect option").all()
+    return [_power_name_from_option_text(o.inner_text()) for o in options
+            if (o.get_attribute("value") or "")]
+
+
+def ui_teach_discipline_click(page: Page, lastname: str, discipline_name: str,
+                              base_url: str = None):
+    """Click the 'Enseigner' button after selecting `discipline_name` from
+    the discipline dropdown. Worker must be age-eligible (teach button
+    visible) before calling."""
+    _open_worker_action_page(page, lastname, base_url)
+    _wait_loaded(page, "input[name='teach_discipline']")
+    _select_option_value_by_power_name(page, "select#disciplineSelect", discipline_name)
+    page.locator("input[name='teach_discipline']").click()
+    page.wait_for_load_state("load")
+
+
+def ui_transform_click(page: Page, lastname: str, transformation_name: str,
+                       base_url: str = None):
+    """Click the 'Ajouter' transformation button after selecting
+    `transformation_name` from the transformation dropdown."""
+    _open_worker_action_page(page, lastname, base_url)
+    _wait_loaded(page, "input[name='transform']")
+    _select_option_value_by_power_name(page, "select#transformationSelect", transformation_name)
+    page.locator("input[name='transform']").click()
+    page.wait_for_load_state("load")
+
+
 def ui_claim(page: Page, lastname: str, claim_controller_lastname: str,
              base_url: str = None):
     """Queue a claim action targeting `claim_controller_lastname`."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -891,6 +891,36 @@ def ui_transform_click(page: Page, lastname: str, transformation_name: str,
     page.wait_for_load_state("load")
 
 
+def ui_mass_move_click(page: Page, controller_lastname: str,
+                       worker_lastnames: list, target_zone_name: str,
+                       base_url: str = None):
+    """UI-button-click for the Mass Move form on workers/viewAll.php.
+    Switches to `controller_lastname`, opens viewAll, checks the
+    `worker_ids[]` checkbox for each worker in `worker_lastnames`,
+    selects `target_zone_name` in the zone dropdown, then clicks the
+    'Déplacer les agents sélectionnés' submit button. Form posts to
+    /workers/massAction.php (GET) which loops over worker_ids[] and
+    calls moveWorker for each."""
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    # Pre-resolve all IDs BEFORE navigating to viewAll — the lookup
+    # helpers (ui_controller_id, ui_zone_id, _cached_wid) navigate to
+    # management pages, which would discard the checked-checkbox state
+    # if interleaved with the click flow.
+    cid = ui_controller_id(page, controller_lastname, base_url=url)
+    target_zid = ui_zone_id(page, target_zone_name, base_url=url)
+    worker_ids = [_cached_wid(page, ln, base_url) for ln in worker_lastnames]
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={cid}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    safe_goto(page, f"{url}/workers/viewAll.php")
+    _wait_loaded(page, "input[name='mass_move']")
+    for wid in worker_ids:
+        page.locator(f"input[name='worker_ids[]'][value='{wid}']").check()
+    page.locator("select[name='zone_id']").select_option(value=str(target_zid))
+    page.locator("input[name='mass_move']").click()
+    page.wait_for_load_state("load")
+
+
 def ui_claim(page: Page, lastname: str, claim_controller_lastname: str,
              base_url: str = None):
     """Queue a claim action targeting `claim_controller_lastname`."""

--- a/tests/test_actions_evolution_e2e.py
+++ b/tests/test_actions_evolution_e2e.py
@@ -1,0 +1,215 @@
+"""Playwright E2E tests for the 'Evolutions' section on workers/view.php:
+Teach Discipline + Transform.
+
+Audit gap (Slice 14, once-per-file UI-click rule):
+  - Teach: age gate (`age_discipline`) hides/shows the button; dropdown
+    must contain common (basePowerNames=Focused Mind) + own-faction
+    discipline (Offensive Stance for Alpha) and exclude other faction
+    (Defensive Posture for Beta).
+  - Transform: NO age gate (`age_transformation`={'action':'check'} is
+    enough); location gate (worker_in_zone) filters Combat Vest.
+  - Click-through: ui_transform_click and ui_teach_discipline_click
+    persist the new power (post-click dropdown excludes the chosen one).
+
+Status gate is intentionally NOT covered here — see
+`tests/AUDIT_next_steps.md` for the planned follow-up issue
+(`worker_is_alive='0'` semantic + γ/δ red-green TDD).
+
+Subjects:
+  Transform_Subject : Alpha controller, passive, Beta-Combat zone
+                      → matches Combat Vest's location gate.
+  Bystander_1       : Beta, passive, Alpha-Investigation
+                      → fails Combat Vest's location gate.
+
+CSV additions for this slice (setupTestConfig):
+  textes:           age_discipline, age_transformation, recrutement_disciplines
+  transformations:  Combat Vest (worker_in_zone gate)
+  advanced:         Transform_Subject
+
+Run:
+    python3 -m pytest tests/test_actions_evolution_e2e.py -v
+"""
+import pytest
+from playwright.sync_api import Page
+
+from conftest import PHP_BASE_URL, ensure_gm_login
+from helpers import (
+    DB_AVAILABLE, load_minimal_data, safe_goto,
+    register_php_error_listener, assert_no_collected_php_errors,
+    ui_teach_button_visible, ui_teach_discipline_options,
+    ui_transform_options, ui_teach_discipline_click, ui_transform_click,
+    end_turn,
+)
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_test_config(browser):
+    """Load TestConfig with the new evolution rows (age_discipline,
+    age_transformation, recrutement_disciplines + Combat Vest +
+    Transform_Subject)."""
+    if DB_AVAILABLE:
+        load_minimal_data()
+
+    context = browser.new_context()
+    page = context.new_page()
+    register_php_error_listener(page)
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
+    page.wait_for_load_state("load")
+    page.locator("input[name='username']").fill("gm")
+    page.locator("input[name='passwd']").fill("orga")
+    page.locator("input[type='submit']").first.click()
+    page.wait_for_load_state("load")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
+    page.wait_for_load_state("load")
+    page.locator("select[name='config_name']").select_option("TestConfig")
+    page.locator("input[name='submit'][value='Submit']").click()
+    page.wait_for_timeout(5000)
+    page.wait_for_load_state("load", timeout=90000)
+    assert_no_collected_php_errors(page)
+    context.close()
+    yield
+
+
+@pytest.fixture(scope="module")
+def evolution_state(browser):
+    """Capture transform + teach state across two phases:
+      Phase 1 (age=0): transform dropdown options for Transform_Subject
+                       and Bystander_1, teach button visibility on
+                       Transform_Subject (must be hidden), then click
+                       transform once to prove no-age-gate.
+      Phase 2 (age>=2 after 2 end-turns): teach button visibility (now
+                       visible), teach dropdown contents, then click
+                       teach once to prove the form persists state."""
+    context = browser.new_context()
+    page = context.new_page()
+    register_php_error_listener(page)
+    ensure_gm_login(page, PHP_BASE_URL)
+
+    # --- Phase 1: age = 0 ---------------------------------------------
+    age0_teach_visible_subject = ui_teach_button_visible(page, "Transform_Subject")
+    age0_transform_subject = set(ui_transform_options(page, "Transform_Subject"))
+    age0_transform_bystander = set(ui_transform_options(page, "Bystander_1"))
+
+    # Click transform at age=0 — proves transform has NO age gate.
+    ui_transform_click(page, "Transform_Subject", "Combat Vest")
+    after_transform_click = set(ui_transform_options(page, "Transform_Subject"))
+
+    # --- Phase 2: age up to 2 -----------------------------------------
+    end_turn(page)
+    end_turn(page)
+
+    age2_teach_visible_subject = ui_teach_button_visible(page, "Transform_Subject")
+    age2_teach_options_subject = set(ui_teach_discipline_options(page, "Transform_Subject"))
+
+    # Click teach — verify the discipline persists (post-click dropdown
+    # no longer offers Focused Mind because the worker now possesses it).
+    ui_teach_discipline_click(page, "Transform_Subject", "Focused Mind")
+    after_teach_click = set(ui_teach_discipline_options(page, "Transform_Subject"))
+
+    assert_no_collected_php_errors(page)
+    context.close()
+
+    return {
+        "age0_teach_visible_subject": age0_teach_visible_subject,
+        "age0_transform_subject": age0_transform_subject,
+        "age0_transform_bystander": age0_transform_bystander,
+        "after_transform_click": after_transform_click,
+        "age2_teach_visible_subject": age2_teach_visible_subject,
+        "age2_teach_options_subject": age2_teach_options_subject,
+        "after_teach_click": after_teach_click,
+    }
+
+
+class TestTransformAtAgeZero:
+    """Transform UI is gated only by `age_transformation`={'action':'check'},
+    not by worker age. With a fresh seeded worker (age=0), the transform
+    select must render and click-through must succeed."""
+
+    def test_transform_select_visible_no_age_gate(self, evolution_state):
+        """Transform dropdown rendered for an age-0 worker — proves
+        absence of an age gate on transform."""
+        assert evolution_state["age0_transform_subject"], (
+            "Transform select should render for Transform_Subject at age=0; "
+            "got empty options"
+        )
+
+    def test_transform_location_gate_filters_combat_vest(self, evolution_state):
+        """Combat Vest carries `on_transformation.worker_in_zone='Beta-Combat'`.
+        Transform_Subject (Beta-Combat) must see it; Bystander_1
+        (Alpha-Investigation) must not."""
+        assert "Combat Vest" not in evolution_state["age0_transform_bystander"], (
+            f"Bystander_1 (Alpha-Investigation) must NOT see Combat Vest "
+            f"(Beta-Combat-gated); got {evolution_state['age0_transform_bystander']}"
+        )
+        assert "Combat Vest" in evolution_state["age0_transform_subject"], (
+            f"Transform_Subject (Beta-Combat) must see Combat Vest before "
+            f"the click; got {evolution_state['age0_transform_subject']}"
+        )
+
+    def test_transform_click_persists_combat_vest(self, evolution_state):
+        """After ui_transform_click('Combat Vest'), the worker possesses
+        Combat Vest — `cleanPowerListFromJsonConditions` skips powers
+        already on the worker, so the post-click dropdown must NOT
+        offer Combat Vest again."""
+        assert "Combat Vest" not in evolution_state["after_transform_click"], (
+            f"Combat Vest should be removed from the dropdown after the "
+            f"click (worker already possesses it); got "
+            f"{evolution_state['after_transform_click']}"
+        )
+
+
+class TestTeachAtAgeTwo:
+    """Teach button is gated by `age_discipline.age <= worker.age` AND
+    `nb_current_disciplines < nb_disciplines` (workers/view.php:359-372).
+    With recrutement_disciplines=0 and age_discipline={'age':['2']}:
+      age 0: nb_disciplines=0 → teach hidden.
+      age 2: nb_disciplines=1 → teach visible (worker has 0 disciplines)."""
+
+    def test_teach_hidden_when_too_young(self, evolution_state):
+        """Transform_Subject at age=0 has 0 discipline slots → teach
+        button is not rendered."""
+        assert evolution_state["age0_teach_visible_subject"] is False, (
+            "Teach button should be hidden at age=0 when "
+            "recrutement_disciplines=0 and no age threshold met"
+        )
+
+    def test_teach_visible_at_age_threshold(self, evolution_state):
+        """After 2 end-turns, Transform_Subject reaches age=2 → 1 slot
+        granted via age_discipline → teach button rendered."""
+        assert evolution_state["age2_teach_visible_subject"] is True, (
+            "Teach button should be visible once age >= "
+            "age_discipline threshold (2)"
+        )
+
+    def test_teach_dropdown_includes_common_and_own_faction(self, evolution_state):
+        """Alpha-controlled subject's teach dropdown must contain
+        Focused Mind (basePowerNames common) AND Offensive Stance
+        (FactionAlpha-exclusive); must NOT contain Defensive Posture
+        (FactionBeta-exclusive)."""
+        opts = evolution_state["age2_teach_options_subject"]
+        assert "Focused Mind" in opts, (
+            f"Alpha teach dropdown should include common 'Focused Mind'; "
+            f"got {opts}"
+        )
+        assert "Offensive Stance" in opts, (
+            f"Alpha teach dropdown should include own-faction "
+            f"'Offensive Stance'; got {opts}"
+        )
+        assert "Defensive Posture" not in opts, (
+            f"Alpha teach dropdown must NOT include Beta's "
+            f"'Defensive Posture'; got {opts}"
+        )
+
+    def test_teach_click_persists_focused_mind(self, evolution_state):
+        """After teaching Focused Mind, the worker possesses it;
+        `cleanPowerListFromJsonConditions` removes it from subsequent
+        renderings of the dropdown."""
+        assert "Focused Mind" not in evolution_state["after_teach_click"], (
+            f"Focused Mind should be removed from the teach dropdown "
+            f"after the click; got {evolution_state['after_teach_click']}"
+        )

--- a/tests/test_actions_mise_en_place_e2e.py
+++ b/tests/test_actions_mise_en_place_e2e.py
@@ -1,0 +1,141 @@
+"""Playwright E2E tests for the three "Action de mise en place" buttons on
+workers/view.php: Investigate, Passive, Hide.
+
+Covers two contracts per button (audit gap — workers/view.php):
+  (a) Click → action_choice flips to the chosen action (immediate).
+  (b) After end-turn, the life_report stats reflect the action's
+      contribution to enquete/attack/defence (calculateVals math).
+
+Bystander_1 (Beta, passive, Alpha-Investigation) is the test subject.
+Powers: Dark Impulse (e=-1, a=1, d=-1) + Patrol Warden (e=1, a=0, d=0).
+Power totals: e=0, a=1, d=-1.
+
+Under TestConfig (PASSIVEVAL=3, MINROLL=MAXROLL=3, no zone bonus,
+HIDE_ENQUETE_FLAT_BONUS=4, HIDE_DEFENCE_FLAT_BONUS=1):
+  passive     → enquete=3   attack=4   defence=2
+  hide        → enquete=7   attack=4   defence=3
+  investigate → enquete=3   attack=4   defence=2  (dice=3 ≡ PASSIVEVAL)
+
+The class fixture runs Bystander_1 through 3 turns (one action per turn),
+capturing the action_choice immediately after each click and the
+life_report stats after each end-turn.
+
+Run:
+    python3 -m pytest tests/test_actions_mise_en_place_e2e.py -v
+"""
+import pytest
+from playwright.sync_api import Page
+
+from conftest import PHP_BASE_URL, ensure_gm_login
+from helpers import (
+    DB_AVAILABLE, load_minimal_data, login_as, logout, safe_goto,
+    register_php_error_listener, assert_no_collected_php_errors,
+    ui_hide_click, ui_passive_click, ui_investigate_click,
+    ui_worker_action_state, ui_worker_stats, end_turn,
+)
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_test_config(browser):
+    """Load TestConfig so Bystander_1 + the 'Action de mise en place'
+    config rows exist."""
+    if DB_AVAILABLE:
+        load_minimal_data()
+
+    context = browser.new_context()
+    page = context.new_page()
+    register_php_error_listener(page)
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
+    page.wait_for_load_state("load")
+    page.locator("input[name='username']").fill("gm")
+    page.locator("input[name='passwd']").fill("orga")
+    page.locator("input[type='submit']").first.click()
+    page.wait_for_load_state("load")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
+    page.wait_for_load_state("load")
+    page.locator("select[name='config_name']").select_option("TestConfig")
+    page.locator("input[name='submit'][value='Submit']").click()
+    page.wait_for_timeout(5000)
+    page.wait_for_load_state("load", timeout=90000)
+    assert_no_collected_php_errors(page)
+    context.close()
+    yield
+
+
+@pytest.fixture(scope="class")
+def turn_results(browser):
+    """Run Bystander_1 through 3 turns: passive (turn 0→1), hide (1→2),
+    investigate (2→3). For each: click the button, capture the post-click
+    action_choice, end-turn, capture the post-end-turn life_report stats.
+
+    Returns dict[action] = {'action_choice': str, 'stats': {...}}."""
+    context = browser.new_context()
+    page = context.new_page()
+    register_php_error_listener(page)
+    ensure_gm_login(page, PHP_BASE_URL)
+
+    results = {}
+    sequence = [
+        ("passive", ui_passive_click),
+        ("hide", ui_hide_click),
+        ("investigate", ui_investigate_click),
+    ]
+    for action_name, click_fn in sequence:
+        click_fn(page, "Bystander_1")
+        action_state = ui_worker_action_state(page, "Bystander_1")
+        end_turn(page)
+        stats = ui_worker_stats(page, "Bystander_1")
+        results[action_name] = {
+            "action_choice": action_state["action_choice"],
+            "stats": stats,
+        }
+
+    assert_no_collected_php_errors(page)
+    context.close()
+    return results
+
+
+# Bystander_1 power totals: Dark Impulse (e=-1, a=1, d=-1)
+# + Patrol Warden (e=1, a=0, d=0) = (e=0, a=1, d=-1).
+# TestConfig: PASSIVEVAL=3, MINROLL=MAXROLL=3, ENQUETE_ZONE_BONUS=0,
+# ATTACK_ZONE_BONUS=0, DEFENCE_ZONE_BONUS=1 (only applies if zone held —
+# Alpha-Investigation is unheld, so no zone bonus applies),
+# HIDE_ENQUETE_FLAT_BONUS=4, HIDE_DEFENCE_FLAT_BONUS=1.
+
+class TestActionMiseEnPlaceClicks:
+    """Verify both the click → action_choice flip AND the post-end-turn
+    calculateVals math for each of the three 'Action de mise en place'
+    buttons on workers/view.php."""
+
+    def test_passive_click_and_stats(self, turn_results):
+        r = turn_results["passive"]
+        assert r["action_choice"] == "passive", \
+            f"Passive click should set action_choice='passive'; got {r['action_choice']!r}"
+        # passive: vals = powers + PASSIVEVAL(3); no flat bonuses, no zone bonus
+        assert r["stats"]["enquete_val"] == 3, r["stats"]
+        assert r["stats"]["attack_val"] == 4, r["stats"]
+        assert r["stats"]["defence_val"] == 2, r["stats"]
+
+    def test_hide_click_and_stats(self, turn_results):
+        r = turn_results["hide"]
+        assert r["action_choice"] == "hide", \
+            f"Hide click should set action_choice='hide'; got {r['action_choice']!r}"
+        # hide: enquete += HIDE_ENQUETE_FLAT_BONUS=4, defence += HIDE_DEFENCE_FLAT_BONUS=1
+        assert r["stats"]["enquete_val"] == 7, r["stats"]   # 0 + 3 + 4
+        assert r["stats"]["attack_val"] == 4, r["stats"]    # 1 + 3
+        assert r["stats"]["defence_val"] == 3, r["stats"]   # -1 + 3 + 1
+
+    def test_investigate_click_and_stats(self, turn_results):
+        r = turn_results["investigate"]
+        assert r["action_choice"] == "investigate", \
+            f"Investigate click should set action_choice='investigate'; got {r['action_choice']!r}"
+        # investigate: uses dice (active) for enquete; under TestConfig MINROLL=MAXROLL=3
+        # so dice ≡ PASSIVEVAL → numerically equal to passive but via active code path.
+        assert r["stats"]["enquete_val"] == 3, r["stats"]   # 0 + dice(3)
+        assert r["stats"]["attack_val"] == 4, r["stats"]    # 1 + 3 (passive group)
+        assert r["stats"]["defence_val"] == 2, r["stats"]   # -1 + 3 (passive group)

--- a/tests/test_admin_csv_load_e2e.py
+++ b/tests/test_admin_csv_load_e2e.py
@@ -57,12 +57,14 @@ def ensure_base_data():
 def logged_in_page(page: Page, base_url):
     """Login as game master (gm/orga) and return the page."""
     safe_goto(page, f"{base_url}/connection/loginForm.php")
-    page.wait_for_load_state("networkidle")
+    page.wait_for_load_state("load")
+    page.locator("input[name='username']").wait_for(state="visible", timeout=30000)
 
     page.locator("input[name='username']").fill("gm")
     page.locator("input[name='passwd']").fill("orga")
     page.locator("input[type='submit']").first.click()
-    page.wait_for_load_state("networkidle")
+    page.wait_for_load_state("load")
+    page.locator("a.logout-btn").wait_for(state="visible", timeout=30000)
 
     return page
 

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -57,7 +57,8 @@ from helpers import (
     end_turn, load_minimal_data,
     ui_all_workers, ui_controller_id, ui_worker_id, ui_worker_controller_id,
     ui_workers_by_lastname, ui_faction_sections, ui_zone_id,
-    clear_ui_caches, ui_attack, ui_attack_click, ui_investigate, ui_claim, ui_move,
+    clear_ui_caches, ui_attack, ui_attack_click,
+    ui_investigate, ui_investigate_click, ui_claim, ui_move,
     worker_report_html, cached_faction_sections, ui_worker_action_state,
     safe_goto, register_php_error_listener, assert_no_collected_php_errors,
 )
@@ -145,7 +146,9 @@ def combat_scenario(browser):
     # Blocked investigate: attackers attack, defenders investigate
     ui_attack(page, 'Inv_Atk_1', 'Inv_Def_1')
     ui_attack(page, 'Inv_Atk_2', 'Inv_Def_2')
-    ui_investigate(page, 'Inv_Def_1')
+    # First investigate in this file → exercised via the UI button
+    # (per once-per-file rule); subsequent calls reuse the URL-driver.
+    ui_investigate_click(page, 'Inv_Def_1')
     ui_investigate(page, 'Inv_Def_2')
 
     # Blocked claim: attackers attack, defenders claim their own controller

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -55,11 +55,12 @@ from conftest import (
 from helpers import (
     DB_AVAILABLE, get_db_connection as get_db,
     end_turn, load_minimal_data,
-    ui_all_workers, ui_controller_id, ui_worker_id, ui_worker_controller_id,
-    ui_workers_by_lastname, ui_faction_sections, ui_zone_id,
+    ui_all_workers, ui_controller_id, ui_worker_id,
+    ui_workers_by_lastname,
     clear_ui_caches, ui_attack, ui_attack_click,
     ui_investigate, ui_investigate_click,
-    ui_claim, ui_claim_click, ui_move,
+    ui_claim, ui_claim_click,
+    ui_move, ui_move_click,
     worker_report_html, cached_faction_sections, ui_worker_action_state,
     safe_goto, register_php_error_listener, assert_no_collected_php_errors,
 )
@@ -164,7 +165,9 @@ def combat_scenario(browser):
     # queued attack still lands. With LIMIT_ATTACK_BY_ZONE=0 (TestConfig
     # default) the attack-pair SQL has no zone filter. moveWorker()
     # clobbers Runner's action to 'passive' but doesn't touch Hunter's.
-    ui_move(page, 'Runner_Cross', 'Delta-Disputed')
+    # First move in this file → exercised via the UI 'Déménager' button
+    # (per once-per-file rule); subsequent calls reuse the URL-driver.
+    ui_move_click(page, 'Runner_Cross', 'Delta-Disputed')
     ui_attack(page, 'Hunter_Cross', 'Runner_Cross')
 
     # Move-clears-action-params: Mover_Test queues an attack THEN moves.

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -57,7 +57,7 @@ from helpers import (
     end_turn, load_minimal_data,
     ui_all_workers, ui_controller_id, ui_worker_id, ui_worker_controller_id,
     ui_workers_by_lastname, ui_faction_sections, ui_zone_id,
-    clear_ui_caches, ui_attack, ui_investigate, ui_claim, ui_move,
+    clear_ui_caches, ui_attack, ui_attack_click, ui_investigate, ui_claim, ui_move,
     worker_report_html, cached_faction_sections, ui_worker_action_state,
     safe_goto, register_php_error_listener, assert_no_collected_php_errors,
 )
@@ -129,7 +129,9 @@ def combat_scenario(browser):
 
     # Set all combat actions via UI for turn 1
     # Chain: A→B, B→C, C→D, D→E, E→F, F→G
-    ui_attack(page, 'Chain_A', 'Chain_B')
+    # First attack in this file → exercised via the UI 'Attaquer' button
+    # (per once-per-file rule); subsequent attacks reuse the URL-driver.
+    ui_attack_click(page, 'Chain_A', 'Chain_B')
     ui_attack(page, 'Chain_B', 'Chain_C')
     ui_attack(page, 'Chain_C', 'Chain_D')
     ui_attack(page, 'Chain_D', 'Chain_E')

--- a/tests/test_agent_combat_e2e.py
+++ b/tests/test_agent_combat_e2e.py
@@ -58,7 +58,8 @@ from helpers import (
     ui_all_workers, ui_controller_id, ui_worker_id, ui_worker_controller_id,
     ui_workers_by_lastname, ui_faction_sections, ui_zone_id,
     clear_ui_caches, ui_attack, ui_attack_click,
-    ui_investigate, ui_investigate_click, ui_claim, ui_move,
+    ui_investigate, ui_investigate_click,
+    ui_claim, ui_claim_click, ui_move,
     worker_report_html, cached_faction_sections, ui_worker_action_state,
     safe_goto, register_php_error_listener, assert_no_collected_php_errors,
 )
@@ -154,7 +155,9 @@ def combat_scenario(browser):
     # Blocked claim: attackers attack, defenders claim their own controller
     ui_attack(page, 'Claim_Atk_1', 'Claim_Def_1')
     ui_attack(page, 'Claim_Atk_2', 'Claim_Def_2')
-    ui_claim(page, 'Claim_Def_1', 'Beta')
+    # First claim in this file → exercised via the UI button
+    # (per once-per-file rule); subsequent calls reuse the URL-driver.
+    ui_claim_click(page, 'Claim_Def_1', 'Beta')
     ui_claim(page, 'Claim_Def_2', 'Delta')
 
     # Cross-zone attack: Runner flees to Delta-Disputed, but Hunter's

--- a/tests/test_configuration_e2e.py
+++ b/tests/test_configuration_e2e.py
@@ -1,0 +1,88 @@
+"""Playwright E2E tests for /base/configuration.php Add/Update/Delete buttons.
+
+Covers UI buttons previously NOT COVERED in
+tests/AUDIT_ui_buttons_outside_management.md (base/configuration.php).
+
+Sequential CRUD on a unique row: add → update → delete. Tests run in
+definition order (pytest default); the class-scope browser context +
+config_name keep the chain pointed at the same row.
+
+Run:
+    python3 -m pytest tests/test_configuration_e2e.py -v
+"""
+import time
+import pytest
+from playwright.sync_api import Page, expect
+
+from conftest import PHP_BASE_URL
+from helpers import DB_AVAILABLE, load_minimal_data, login_as, safe_goto
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+@pytest.fixture(autouse=True)
+def ensure_base_data():
+    if DB_AVAILABLE:
+        load_minimal_data()
+    yield
+
+
+@pytest.fixture(scope="class")
+def config_name():
+    """Unique name per class run — avoids collision with existing config rows."""
+    return f"test_slice9_config_{int(time.time() * 1000)}"
+
+
+@pytest.fixture(scope="class")
+def gm_session(browser):
+    """Class-scope gm browser context so the add → update → delete chain
+    runs against a single session/row."""
+    context = browser.new_context()
+    page = context.new_page()
+    login_as(page, PHP_BASE_URL, "gm", "orga")
+    yield page
+    context.close()
+
+
+class TestConfigurationCRUD:
+    """Add a row, update its value, delete it — exercising all three submit
+    buttons on /base/configuration.php."""
+
+    def test_add_config_value(self, gm_session: Page, base_url, config_name):
+        safe_goto(gm_session, f"{base_url}/base/configuration.php")
+        add_form = gm_session.locator("form:has(input[name='add_config'])")
+        add_form.locator("input[name='name']").fill(config_name)
+        add_form.locator("input[name='value']").fill("initial_value")
+        add_form.locator("input[name='add_config']").click()
+        gm_session.wait_for_load_state("load")
+        expect(
+            gm_session.locator(f"td:has-text('{config_name}')")
+        ).to_have_count(1)
+
+    def test_update_config_value(self, gm_session: Page, base_url, config_name):
+        # Note: the row's `<form>` is inside `<tr>`, which is invalid HTML —
+        # the parser strips/repositions it. Locate by the row's tr/td
+        # instead; clicking the named submit still POSTs the row.
+        safe_goto(gm_session, f"{base_url}/base/configuration.php")
+        row = gm_session.locator(f"tr:has(td:has-text('{config_name}'))")
+        expect(row).to_have_count(1)
+        row.locator("input[name='value']").fill("updated_value")
+        row.locator("input[name='update_config']").click()
+        gm_session.wait_for_load_state("load")
+        row_after = gm_session.locator(f"tr:has(td:has-text('{config_name}'))")
+        expect(row_after.locator("input[name='value']")).to_have_value(
+            "updated_value"
+        )
+
+    def test_delete_config_value(self, gm_session: Page, base_url, config_name):
+        safe_goto(gm_session, f"{base_url}/base/configuration.php")
+        row = gm_session.locator(f"tr:has(td:has-text('{config_name}'))")
+        expect(row).to_have_count(1)
+        row.locator("input[name='delete_config']").click()
+        gm_session.wait_for_load_state("load")
+        expect(
+            gm_session.locator(f"td:has-text('{config_name}')")
+        ).to_have_count(0)

--- a/tests/test_controller_recruitment_and_bases_e2e.py
+++ b/tests/test_controller_recruitment_and_bases_e2e.py
@@ -167,6 +167,40 @@ def _create_base_click(page, controller_lastname, zone_name):
     page.wait_for_load_state("load")
 
 
+def _move_base_click(page, controller_lastname, target_zone_name):
+    """UI-button-click for the Move Base form on controllers/view.php.
+    Switches to the controller and clicks the rendered 'Déménager' button
+    after picking the target zone in the per-base zone select. Pre-resolves
+    zone_id BEFORE the controllers/view.php navigation — same pattern as
+    ui_mass_move_click, since lookup helpers navigate to management
+    pages and would discard the populated form."""
+    ensure_gm_login(page, PHP_BASE_URL)
+    target_zid = ui_zone_id(page, target_zone_name)
+    _switch_controller(page, controller_lastname)
+    safe_goto(page, f"{PHP_BASE_URL}/controllers/action.php")
+    page.wait_for_load_state("load")
+    page.locator("input[name='moveBase']").wait_for(state="visible", timeout=30000)
+    # The form is rendered per base; for Alpha there's only one base, so
+    # `.first` is sufficient. The select shows the base's current zone
+    # pre-selected; we override to the target.
+    page.locator("select[name='zone_id']").first.select_option(value=str(target_zid))
+    page.locator("input[name='moveBase']").click()
+    page.wait_for_load_state("load")
+
+
+def _controller_base_zone_via_ui(page, controller_lastname):
+    """Read the controller's base zone via controllers/action.php
+    rendering of view.php (line 155: 'Votre <basename> à <zone_name>').
+    Returns the zone name string, or None if no base section rendered."""
+    _switch_controller(page, controller_lastname)
+    safe_goto(page, f"{PHP_BASE_URL}/controllers/action.php")
+    page.wait_for_load_state("load")
+    html = page.content()
+    import re
+    m = re.search(r"Votre\s+\S[^<]*?\s+à\s+([\w\-]+)", html)
+    return m.group(1) if m else None
+
+
 def _do_first_come(page, controller_lastname):
     """Submit a first-come recruitment (picks first available zone + discipline)."""
     ensure_gm_login(page, PHP_BASE_URL)
@@ -639,3 +673,92 @@ class TestCharlieCannotRecruit:
         """Charlie should not have the recruit button."""
         html = _snapshot['charlie_t0_html']
         assert "Recruter un serviteur" not in html
+
+
+# ---------------------------------------------------------------------------
+# TestMoveBase — controllers/view.php Move Base + controllers/action.php
+# moveBase handler.
+#
+# Slice 16 audit gap: moveBase was untested. Adds two tests:
+#  - positive: Alpha's base (created in Epsilon-Controlled by the module
+#    fixture's Phase 3) is moved via the rendered 'Déménager' button to
+#    Gamma-Claims; assert post-move zone via controllers/view.php
+#    re-render.
+#  - negative (resource gate): Echo (pre-seeded base at Theta-Artefacts;
+#    controller_ressources amount=4 < base_moving_cost=5) navigates to
+#    controllers/action.php; the move form is replaced by the 'ressources
+#    nécessaires' notification and no input[name='moveBase'] is rendered.
+#
+# CSV additions for this slice:
+#   textes:                   ressource_management = TRUE
+#   controller_ressources:    Echo,Gold,4,0,0
+# ---------------------------------------------------------------------------
+
+class TestMoveBase:
+    """Move Base UI click + resource-gate negative path."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def move_base_state(self, browser):
+        """Capture Alpha's base zone before + after the click-driven
+        move from Epsilon-Controlled to Gamma-Claims. Also capture
+        Echo's controllers/view.php HTML to verify the resource-gate
+        negative path renders the danger notification + omits the
+        moveBase submit."""
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+
+        # Positive: Alpha's existing base (from module fixture phase 3)
+        # is currently in Epsilon-Controlled. Move it to Gamma-Claims.
+        pre_zone = _controller_base_zone_via_ui(page, 'Alpha')
+        _move_base_click(page, 'Alpha', 'Gamma-Claims')
+        post_zone = _controller_base_zone_via_ui(page, 'Alpha')
+
+        # Negative: Echo (pre-seeded Echo-Base at Theta-Artefacts,
+        # amount=4 < base_moving_cost=5).
+        _switch_controller(page, 'Echo')
+        safe_goto(page, f"{PHP_BASE_URL}/controllers/action.php")
+        page.wait_for_load_state("load")
+        echo_move_button_count = page.locator("input[name='moveBase']").count()
+        echo_html = page.content()
+
+        assert_no_collected_php_errors(page)
+        context.close()
+        type(self)._pre_zone = pre_zone
+        type(self)._post_zone = post_zone
+        type(self)._echo_move_button_count = echo_move_button_count
+        type(self)._echo_html = echo_html
+        yield
+
+    def test_alpha_base_starts_in_epsilon_controlled(self):
+        """Sanity: module fixture left Alpha's base in Epsilon-Controlled."""
+        assert self._pre_zone == "Epsilon-Controlled", (
+            f"Alpha's base should start in Epsilon-Controlled (created by "
+            f"module fixture Phase 3); got {self._pre_zone!r}"
+        )
+
+    def test_alpha_base_zone_changes_after_move(self):
+        """After ui-click move, Alpha's base zone is Gamma-Claims."""
+        assert self._post_zone == "Gamma-Claims", (
+            f"Alpha's base should be in Gamma-Claims after _move_base_click; "
+            f"got {self._post_zone!r}"
+        )
+
+    def test_echo_move_button_hidden_when_drained(self):
+        """Echo (amount=4 < base_moving_cost=5) → resource gate fails →
+        the move form is replaced by the danger notification, so no
+        moveBase submit is rendered."""
+        assert self._echo_move_button_count == 0, (
+            f"Echo's controllers/view should NOT render the moveBase button "
+            f"when ressources are insufficient; found {self._echo_move_button_count}"
+        )
+
+    def test_echo_resource_warning_rendered(self):
+        """Resource-gate UI message is the user-visible signal that the
+        move is blocked. Asserts the French text present in the danger
+        notification (controllers/view.php:146)."""
+        assert "ressources nécessaires" in self._echo_html, (
+            "Echo's controllers/view should render the 'ressources "
+            "nécessaires' danger notification when the move is blocked"
+        )

--- a/tests/test_controller_recruitment_and_bases_e2e.py
+++ b/tests/test_controller_recruitment_and_bases_e2e.py
@@ -167,6 +167,88 @@ def _create_base_click(page, controller_lastname, zone_name):
     page.wait_for_load_state("load")
 
 
+def _location_id_via_management(page, location_name):
+    """Look up a location's id by scraping zones/management_locations.php.
+    The page renders one block per location with `<h3>NAME (discovery N)</h3>`
+    followed by a `toggle_destruction` form whose hidden input carries the id.
+    Returns int id, raises if not found."""
+    import re
+    safe_goto(page, f"{PHP_BASE_URL}/zones/management_locations.php")
+    page.wait_for_load_state("load")
+    html = page.content()
+    m = re.search(
+        rf'<h3>{re.escape(location_name)}\s+\(discovery[^<]+</h3>'
+        rf'.*?name="toggle_destruction"\s+value="(\d+)"',
+        html,
+        re.DOTALL
+    )
+    if not m:
+        raise AssertionError(
+            f"toggle_destruction form for '{location_name}' not found on "
+            f"management_locations.php"
+        )
+    return int(m.group(1))
+
+
+def _seed_ckl_admin(page, controller_lastname, location_name):
+    """Seed `controller_known_locations` for a controller-location pair
+    via the admin `giftInformationLocation` flow (controllers/management.php:91-97).
+    Required because `createBase()` does NOT call `addLocationToCKL` and
+    CSV-seeded bases don't acquire a CKL row for their owner either — so
+    repair-eligibility (which joins CKL) never resolves without this seed.
+    See investigation TODO above TestRepairLocation."""
+    ensure_gm_login(page, PHP_BASE_URL)
+    cid = ui_controller_id(page, controller_lastname)
+    location_id = _location_id_via_management(page, location_name)
+    safe_goto(
+        page,
+        f"{PHP_BASE_URL}/controllers/management.php"
+        f"?giftInformationLocation=1&target_controller_id={cid}&location_id={location_id}"
+    )
+    page.wait_for_load_state("load")
+
+
+def _toggle_destruction_admin(page, location_name):
+    """POST the management-page toggle_destruction form for the named
+    location. Toggles the location between repaired/destroyed states by
+    swapping the activate_json.update_location payload (zones/functions.php
+    updateLocation). Requires gm session (page is admin-only).
+
+    The toggle button lives inside a `<span style="display:none;">`
+    collapsed actions section. `display:none` elements have no box, so
+    even `click(force=True)` fails ("Element is not visible" → scroll-
+    into-view aborts). Instead, submit the form directly via JS — the
+    page navigation that follows is observed identically to a real click."""
+    location_id = _location_id_via_management(page, location_name)
+    # Already on management_locations.php from the lookup above.
+    page.evaluate(
+        f"""
+        const inp = document.querySelector(
+            'input[name="toggle_destruction"][value="{location_id}"]'
+        );
+        if (inp && inp.form) inp.form.submit();
+        """
+    )
+    page.wait_for_load_state("load")
+    return location_id
+
+
+def _repair_location_click(page, controller_lastname, target_location_name):
+    """UI-button-click for the Repair Location form on
+    controllers/view.php. Pre-resolves location_id BEFORE switching
+    controller (lookup helpers navigate to admin pages — interleaving
+    would clobber the controller's view.php form state, Slice 15 pattern)."""
+    ensure_gm_login(page, PHP_BASE_URL)
+    location_id = _location_id_via_management(page, target_location_name)
+    _switch_controller(page, controller_lastname)
+    safe_goto(page, f"{PHP_BASE_URL}/controllers/action.php")
+    page.wait_for_load_state("load")
+    page.locator("input[name='repairLocation']").wait_for(state="visible", timeout=30000)
+    page.locator("select#repairLocationSelect").select_option(value=str(location_id))
+    page.locator("input[name='repairLocation']").click()
+    page.wait_for_load_state("load")
+
+
 def _move_base_click(page, controller_lastname, target_zone_name):
     """UI-button-click for the Move Base form on controllers/view.php.
     Switches to the controller and clicks the rendered 'Déménager' button
@@ -761,4 +843,129 @@ class TestMoveBase:
         assert "ressources nécessaires" in self._echo_html, (
             "Echo's controllers/view should render the 'ressources "
             "nécessaires' danger notification when the move is blocked"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestRepairLocation — controllers/view.php Repair Location +
+# controllers/action.php repairLocation handler.
+#
+# Slice 17 audit gap: repairLocation was untested. Setup uses the admin
+# `zones/management_locations.php` toggle_destruction button to flip a
+# location into can_be_repaired=1 state via updateLocation's
+# activate_json.update_location swap (zones/functions.php:656).
+#
+# CSV additions for this slice:
+#   locations:               Foxtrot-Outpost & Echo-Base now carry an
+#                            activate_json.update_location swap-state.
+#   controller_ressources:   Echo amount lowered 4→2 (still fails Slice 16
+#                            move gate at cost=5; now also fails repair
+#                            gate at cost=3).
+#
+# TODO — CKL gap (β fallback (a) applied 2026-05-05): the fixture seeds
+# controller_known_locations via `_seed_ckl_admin` (admin
+# giftInformationLocation flow). createBase() does NOT call
+# addLocationToCKL, and there is no CSV for controller_known_locations,
+# so CSV-seeded bases (Foxtrot-Outpost, Echo-Base) don't acquire CKL
+# rows for their owners — owners therefore "don't know" about their own
+# bases until something triggers a seed. The repair UI joins CKL, so
+# repair-eligibility never resolves without it. To investigate as a
+# follow-up: should owned bases auto-seed CKL at load (probably yes —
+# owners ought to know about their own bases), or is the giftInformation
+# flow the intended path?
+# ---------------------------------------------------------------------------
+
+class TestRepairLocation:
+    """Repair Location UI click + resource-gate negative path."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def repair_state(self, browser):
+        """Toggle Foxtrot-Outpost + Echo-Base destruction via the admin
+        management page, then capture per-controller view.php state
+        before and after Foxtrot's repair click. Echo (drained) is
+        captured to verify the resource-gate negative path."""
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+
+        # Admin: seed CKL so the controllers can "see" their own bases
+        # in the repair-eligibility join (CSV-seeded bases don't auto-
+        # populate CKL — see TODO above).
+        _seed_ckl_admin(page, "Foxtrot", "Foxtrot-Outpost")
+        _seed_ckl_admin(page, "Echo", "Echo-Base")
+
+        # Admin: toggle both bases into the destroyed/can_be_repaired=1 state.
+        _toggle_destruction_admin(page, "Foxtrot-Outpost")
+        _toggle_destruction_admin(page, "Echo-Base")
+
+        # Foxtrot pre-click: repair form should be visible.
+        _switch_controller(page, "Foxtrot")
+        safe_goto(page, f"{PHP_BASE_URL}/controllers/action.php")
+        page.wait_for_load_state("load")
+        foxtrot_button_count_before = page.locator("input[name='repairLocation']").count()
+
+        # Foxtrot clicks repair on the destroyed Foxtrot-Outpost.
+        _repair_location_click(page, "Foxtrot", "Foxtrot-Outpost")
+
+        # Foxtrot post-click: Foxtrot-Outpost was the only repairable
+        # known location, so the repair form is gone now.
+        _switch_controller(page, "Foxtrot")
+        safe_goto(page, f"{PHP_BASE_URL}/controllers/action.php")
+        page.wait_for_load_state("load")
+        foxtrot_button_count_after = page.locator("input[name='repairLocation']").count()
+
+        # Echo (amount=2 < cost=3) sees the danger notification only.
+        _switch_controller(page, "Echo")
+        safe_goto(page, f"{PHP_BASE_URL}/controllers/action.php")
+        page.wait_for_load_state("load")
+        echo_button_count = page.locator("input[name='repairLocation']").count()
+        echo_html = page.content()
+
+        assert_no_collected_php_errors(page)
+        context.close()
+        type(self)._foxtrot_button_count_before = foxtrot_button_count_before
+        type(self)._foxtrot_button_count_after = foxtrot_button_count_after
+        type(self)._echo_button_count = echo_button_count
+        type(self)._echo_html = echo_html
+        yield
+
+    def test_foxtrot_repair_button_visible_after_destruction_toggle(self):
+        """After admin toggles Foxtrot-Outpost destruction, Foxtrot's
+        controllers/view.php renders the repair form (input[name=
+        'repairLocation'] count == 1)."""
+        assert self._foxtrot_button_count_before == 1, (
+            f"Foxtrot should see exactly one repair button after "
+            f"Foxtrot-Outpost is toggled to the destroyed state; got "
+            f"count={self._foxtrot_button_count_before}"
+        )
+
+    def test_repair_click_undamages_foxtrot_outpost(self):
+        """After clicking 'Réparer' on Foxtrot-Outpost, the location's
+        can_be_repaired flips back to 0 (repair re-applies the
+        save_to_json swap). With no other repairable known location,
+        Foxtrot's view.php no longer renders the repair form."""
+        assert self._foxtrot_button_count_after == 0, (
+            f"After repair click, Foxtrot should no longer see a repair "
+            f"button (Foxtrot-Outpost is no longer can_be_repaired); got "
+            f"count={self._foxtrot_button_count_after}"
+        )
+
+    def test_echo_repair_button_hidden_when_drained(self):
+        """Echo (amount=2 < location_repaire_cost=3) → resource gate
+        fails → controllers/view.php renders the danger notification
+        instead of the repair form. No moveBase-style repair button."""
+        assert self._echo_button_count == 0, (
+            f"Echo's controllers/view should NOT render the repairLocation "
+            f"button when ressources are insufficient; found "
+            f"count={self._echo_button_count}"
+        )
+
+    def test_echo_resource_warning_rendered_for_repair(self):
+        """Resource-gate UI signal: the 'ressources nécessaires' danger
+        notification (controllers/view.php:266) appears for Echo when
+        repair is blocked."""
+        assert "ressources nécessaires" in self._echo_html, (
+            "Echo's controllers/view should render the 'ressources "
+            "nécessaires' danger notification when repair is blocked"
         )

--- a/tests/test_controller_recruitment_e2e.py
+++ b/tests/test_controller_recruitment_e2e.py
@@ -195,6 +195,41 @@ def _do_regular_recruit(page, controller_lastname):
     page.wait_for_load_state("load")
 
 
+def _do_first_come_via_viewAll(page, controller_lastname):
+    """UI-button-click variant of _do_first_come. Navigates to
+    /workers/viewAll.php and clicks the rendered 'Prendre le premier
+    venu' button (input[name='first_come']) — covering the viewAll
+    button rendering + form-action contract — then completes the
+    workers/new.php form submission. Use on the FIRST first-come call
+    in this file (per once-per-file rule); subsequent calls can use
+    the URL-driver _do_first_come."""
+    ensure_gm_login(page, PHP_BASE_URL)
+    _switch_controller(page, controller_lastname)
+    safe_goto(page, f"{PHP_BASE_URL}/workers/viewAll.php")
+    page.wait_for_load_state("load")
+    page.locator("input[name='first_come']").click()
+    page.wait_for_load_state("load")
+    page.locator("select[name='zone_id']").first.select_option(index=0)
+    page.locator("input[name='chosir']").first.click()
+    page.wait_for_load_state("load")
+
+
+def _do_regular_recruit_via_viewAll(page, controller_lastname):
+    """UI-button-click variant of _do_regular_recruit. Same flow as
+    _do_first_come_via_viewAll but clicks 'Recruter un serviteur'
+    (input[name='recrutement']). Use on the FIRST regular-recruit call
+    in this file."""
+    ensure_gm_login(page, PHP_BASE_URL)
+    _switch_controller(page, controller_lastname)
+    safe_goto(page, f"{PHP_BASE_URL}/workers/viewAll.php")
+    page.wait_for_load_state("load")
+    page.locator("input[name='recrutement']").click()
+    page.wait_for_load_state("load")
+    page.locator("select[name='zone_id']").first.select_option(index=0)
+    page.locator("input[name='chosir']").first.click()
+    page.wait_for_load_state("load")
+
+
 
 
 # ---------------------------------------------------------------------------
@@ -252,8 +287,11 @@ def recruitment_scenario(browser):
     # Charlie has no base and no start_workers
     _snapshot['charlie_t0_html'] = _workers_page_html(page, 'Charlie')
 
-    # Phase 2: Alpha uses first-come (no base required)
-    _do_first_come(page, 'Alpha')
+    # Phase 2: Alpha uses first-come (no base required).
+    # First first-come in this file → exercised via the UI button on
+    # /workers/viewAll.php (per once-per-file rule); the turn-1 call below
+    # keeps using the URL-driver _do_first_come.
+    _do_first_come_via_viewAll(page, 'Alpha')
     _snapshot['alpha_t0_after_first_come_counters'] = ui_controller_counters(page, 'Alpha')
     _snapshot['alpha_t0_after_first_come_html'] = _workers_page_html(page, 'Alpha')
     _snapshot['alpha_t0_after_first_come_workers_ui'] = _count_worker_cards_in_html(
@@ -309,7 +347,10 @@ def recruitment_scenario(browser):
     _do_first_come(page, 'Alpha')
     _snapshot['alpha_t1_after_first_come_counters'] = ui_controller_counters(page, 'Alpha')
 
-    _do_regular_recruit(page, 'Alpha')
+    # First regular-recruit in this file → exercised via the UI button
+    # on /workers/viewAll.php (per once-per-file rule); subsequent calls
+    # would use the URL-driver _do_regular_recruit.
+    _do_regular_recruit_via_viewAll(page, 'Alpha')
     _snapshot['alpha_t1_after_recruit_counters'] = ui_controller_counters(page, 'Alpha')
     # UI-side final worker count (post all recruitment phases).
     _snapshot['alpha_t1_final_workers_ui'] = _count_worker_cards_in_html(

--- a/tests/test_controller_recruitment_e2e.py
+++ b/tests/test_controller_recruitment_e2e.py
@@ -150,6 +150,23 @@ def _create_base(page, controller_lastname, zone_name):
     page.wait_for_load_state("load")
 
 
+def _create_base_click(page, controller_lastname, zone_name):
+    """UI-button-click variant of _create_base. Navigates to the
+    controller's faction page, selects the zone in the zone_id dropdown,
+    and clicks the rendered 'Créer' button. Use on the FIRST createBase
+    call in this file (per audit's once-per-file rule); subsequent calls
+    can use the URL-driver _create_base."""
+    ensure_gm_login(page, PHP_BASE_URL)
+    zid = ui_zone_id(page, zone_name)
+    _switch_controller(page, controller_lastname)
+    safe_goto(page, f"{PHP_BASE_URL}/controllers/action.php")
+    page.wait_for_load_state("load")
+    page.locator("input[name='createBase']").wait_for(state="visible", timeout=30000)
+    page.locator("select[name='zone_id']").first.select_option(value=str(zid))
+    page.locator("input[name='createBase']").click()
+    page.wait_for_load_state("load")
+
+
 def _do_first_come(page, controller_lastname):
     """Submit a first-come recruitment (picks first available zone + discipline)."""
     ensure_gm_login(page, PHP_BASE_URL)
@@ -243,8 +260,10 @@ def recruitment_scenario(browser):
         _snapshot['alpha_t0_after_first_come_html']
     )
 
-    # Phase 3: Alpha creates a base in Epsilon-Controlled
-    _create_base(page, 'Alpha', 'Epsilon-Controlled')
+    # Phase 3: Alpha creates a base in Epsilon-Controlled.
+    # First createBase in this file → exercised via the UI 'Créer' button
+    # (per once-per-file rule); subsequent calls reuse the URL-driver.
+    _create_base_click(page, 'Alpha', 'Epsilon-Controlled')
     _snapshot['alpha_t0_after_base_html'] = _workers_page_html(page, 'Alpha')
     # UI-side: accueil page shows the base under "Votre Base :" section.
     _snapshot['alpha_t0_after_base_accueil_html'] = _accueil_html(page, 'Alpha')

--- a/tests/test_csv_features_e2e.py
+++ b/tests/test_csv_features_e2e.py
@@ -122,11 +122,11 @@ class TestLinkTableFeature:
             f"Discipline dropdown mismatch — expected {expected}, got {disciplines}"
 
     def test_transformations_linked_to_transformation_type(self, page: Page, base_url):
-        """The 2 transformation CSV powers appear in the Transformation dropdown."""
+        """The 3 transformation CSV powers appear in the Transformation dropdown."""
         ensure_gm_login(page, base_url)
         options_by_type = ui_power_options_by_type(page, base_url=base_url)
         transformations = set(options_by_type['Transformation'])
-        expected = {'War Gear', 'Shadow Cloak'}
+        expected = {'War Gear', 'Shadow Cloak', 'Combat Vest'}
         assert transformations == expected, \
             f"Transformation dropdown mismatch — expected {expected}, got {transformations}"
 
@@ -135,7 +135,7 @@ class TestLinkTableFeature:
         ensure_gm_login(page, base_url)
         options_by_type = ui_power_options_by_type(page, base_url=base_url)
         counts = {t: len(names) for t, names in options_by_type.items()}
-        expected = {'Hobby': 13, 'Metier': 13, 'Discipline': 3, 'Transformation': 2}
+        expected = {'Hobby': 13, 'Metier': 13, 'Discipline': 3, 'Transformation': 3}
         assert counts == expected, f"Power type counts mismatch: {counts}"
 
 
@@ -391,6 +391,8 @@ class TestLoadWorkersCSV:
             # path), not by the CSV loader.
             'DA_Captor_Alpha': 'Alpha', 'DA_Captor_Echo': 'Echo',
             'DA_Killer': 'Foxtrot',
+            # Slice 14 — discipline/transform Evolutions tests subject
+            'Transform_Subject': 'Alpha',
         }
         assert mapping == expected, f"Worker-controller mapping wrong: got {mapping}"
 

--- a/tests/test_static_pages_e2e.py
+++ b/tests/test_static_pages_e2e.py
@@ -1,0 +1,105 @@
+"""Smoke tests for static / sidebar / external-link UI.
+
+Covers buttons whose code path is render-only (no server mutation):
+- the three external links on /base/systemPresentation.php (anon-accessible)
+- the 'Le Système' sidebar link click (logged-in)
+- the sidebar open/close toggle (toggleSidebar() in baseScript.php)
+
+Run:
+    python3 -m pytest tests/test_static_pages_e2e.py -v
+"""
+import pytest
+from playwright.sync_api import Page, expect
+
+from conftest import PHP_BASE_URL
+from helpers import DB_AVAILABLE, load_minimal_data, login_as, logout, safe_goto
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+@pytest.fixture(autouse=True)
+def ensure_base_data():
+    if DB_AVAILABLE:
+        load_minimal_data()
+    yield
+
+
+@pytest.fixture
+def gm_page(page: Page, base_url):
+    login_as(page, base_url, "gm", "orga")
+    yield page
+    logout(page, base_url)
+
+
+# ---------------------------------------------------------------------------
+# /base/systemPresentation.php — three external links (anon-accessible)
+# ---------------------------------------------------------------------------
+
+class TestSystemPresentationLinks:
+    @pytest.fixture(autouse=True)
+    def _open_page(self, page: Page, base_url):
+        safe_goto(page, f"{base_url}/base/systemPresentation.php")
+        yield
+
+    def test_pdf_tutorial_link(self, page: Page):
+        link = page.locator(
+            'a[href*="drive.google.com/file/d/1oRmi4oy_D6cPm3zzd7wn-3uEVQ1u-XsP"]'
+        )
+        expect(link).to_have_count(1)
+        expect(link).to_have_attribute("target", "_blank")
+
+    def test_github_repo_link(self, page: Page):
+        link = page.locator(
+            'a[href="https://github.com/Edward-Croc/RPGConquestGame"]'
+        )
+        expect(link).to_have_count(1)
+        expect(link).to_have_attribute("target", "_blank")
+
+    def test_github_issues_link(self, page: Page):
+        link = page.locator(
+            'a[href="https://github.com/Edward-Croc/RPGConquestGame/issues"]'
+        )
+        expect(link).to_have_count(1)
+        expect(link).to_have_attribute("target", "_blank")
+
+
+# ---------------------------------------------------------------------------
+# 'Le Système' sidebar link — UI click navigates to systemPresentation.php
+# ---------------------------------------------------------------------------
+
+class TestLeSystemeSidebarClick:
+    def test_sidebar_link_navigates_to_system_presentation(
+        self, gm_page: Page, base_url
+    ):
+        safe_goto(gm_page, f"{base_url}/base/accueil.php")
+        # Sidebar is hidden by default — open it via the ☰ button first
+        gm_page.locator("span.openbtn").click()
+        gm_page.locator("a[href$='/base/systemPresentation.php']").click()
+        gm_page.wait_for_load_state("load")
+        assert "systemPresentation.php" in gm_page.url, (
+            f"Sidebar 'Le Système' click did not navigate to "
+            f"systemPresentation.php; current URL: {gm_page.url}"
+        )
+        expect(
+            gm_page.locator("h2", has_text="Présentation du système")
+        ).to_be_visible()
+
+
+# ---------------------------------------------------------------------------
+# Sidebar open/close toggle — toggleSidebar() flips '.active' class on #sidebar
+# ---------------------------------------------------------------------------
+
+class TestSidebarToggle:
+    def test_openbtn_toggles_active_class(self, gm_page: Page, base_url):
+        safe_goto(gm_page, f"{base_url}/base/accueil.php")
+        sidebar = gm_page.locator("#sidebar")
+        had_active = "active" in (sidebar.get_attribute("class") or "").split()
+        gm_page.locator("span.openbtn").click()
+        has_active = "active" in (sidebar.get_attribute("class") or "").split()
+        assert has_active != had_active, (
+            f"Sidebar '.active' class should toggle on openbtn click "
+            f"(before={had_active}, after={has_active})"
+        )

--- a/tests/test_workers_special_e2e.py
+++ b/tests/test_workers_special_e2e.py
@@ -31,7 +31,7 @@ from helpers import (
     DB_AVAILABLE, load_minimal_data, login_as, logout, safe_goto,
     register_php_error_listener, assert_no_collected_php_errors,
     ui_worker_id, ui_workers_by_lastname, ui_detected_enemies_of,
-    ui_attack, ui_claim, ui_gift, ui_zone_id, end_turn,
+    ui_attack, ui_claim, ui_gift_click, ui_zone_id, end_turn,
     cached_faction_sections, clear_ui_caches,
 )
 
@@ -127,7 +127,7 @@ class TestGiftWorker:
         dropdown must be present on a passive worker's action page, and
         the dropdown must include the intended gift target.
 
-        Locks in the UI surface that the URL-only `ui_gift` driver
+        Locks in the UI surface that the URL-only `ui_gift_click` driver
         bypasses — guards against the form silently disappearing or
         the target option being filtered out by future changes.
 
@@ -167,8 +167,12 @@ class TestGiftWorker:
 
     def test_gift_creates_two_rows_live_and_trace(self, gm_page: Page, base_url):
         """After gift, lastname 'Gift_Source_Foxtrot' has 2 rows: live (Echo,
-        passive) + trace (Foxtrot, trace)."""
-        ui_gift(gm_page, "Gift_Source_Foxtrot", "Echo", base_url=base_url)
+        passive) + trace (Foxtrot, trace).
+
+        First gift call in this file → exercised via the UI 'Donner' button
+        (per once-per-file rule). Subsequent gift tests reuse the URL-driver
+        ui_gift_click since the click contract is now covered."""
+        ui_gift_click(gm_page, "Gift_Source_Foxtrot", "Echo", base_url=base_url)
         rows = ui_workers_by_lastname(gm_page, "Gift_Source_Foxtrot", base_url=base_url)
         assert len(rows) == 2, \
             f"Gift should produce 2 Gift_Source_Foxtrot rows (live + trace), got {len(rows)}: {rows}"

--- a/tests/test_workers_special_e2e.py
+++ b/tests/test_workers_special_e2e.py
@@ -31,7 +31,7 @@ from helpers import (
     DB_AVAILABLE, load_minimal_data, login_as, logout, safe_goto,
     register_php_error_listener, assert_no_collected_php_errors,
     ui_worker_id, ui_workers_by_lastname, ui_detected_enemies_of,
-    ui_attack, ui_claim, ui_gift_click, ui_zone_id, end_turn,
+    ui_attack, ui_attack_click, ui_claim, ui_gift_click, ui_zone_id, end_turn,
     cached_faction_sections, clear_ui_caches,
 )
 
@@ -829,7 +829,12 @@ class TestDoubleAgentLifecycle:
         page.wait_for_load_state("load")
 
         # Queue the kill on DA_Lifecycle_Death and resolve at end-turn.
-        ui_attack(page, "DA_Killer", "DA_Lifecycle_Death")
+        # First UI-click attack in this file (per once-per-file rule). This
+        # is the FIRST ui_attack call after detection has fired — earlier
+        # ui_attack calls in TestGiftPrisoner / TestUntestedAttackResults
+        # run pre-detection where the attack form does not render, so they
+        # must keep the URL-driver.
+        ui_attack_click(page, "DA_Killer", "DA_Lifecycle_Death")
         end_turn(page)
 
         # Module-level faction-sections cache may have been populated by

--- a/tests/test_workers_special_e2e.py
+++ b/tests/test_workers_special_e2e.py
@@ -33,6 +33,7 @@ from helpers import (
     ui_worker_id, ui_workers_by_lastname, ui_detected_enemies_of,
     ui_attack, ui_attack_click, ui_claim, ui_gift_click, ui_zone_id, end_turn,
     cached_faction_sections, clear_ui_caches,
+    ui_mass_move_click, ui_all_workers,
 )
 
 
@@ -1219,4 +1220,77 @@ class TestReturnPrisonerReinstatesSecondary:
             f"Echo's capture-trace of DA_ReturnPrisoner_W must be "
             f"destroyed by returnPrisoner (6b spec); got "
             f"ancients={echo['ancients']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestMassMoveBetaCombatWorkers — workers/viewAll.php Mass Move +
+# workers/massAction.php handler.
+#
+# Slice 15 audit gap: massAction.php was completely untested. Handler
+# reads worker_ids[] (checkbox array) + zone_id + mass_move flag, loops
+# moveWorker() per worker (massAction.php:16-20).
+#
+# Subjects: Beta's three combat-row workers (Chain_B, Inv_Def_1,
+# Keep_Def) all start in Beta-Combat. Mass-move them in a single submit
+# to Delta-Disputed (Beta-claimed) and assert each ended up there.
+# ---------------------------------------------------------------------------
+
+_MASS_MOVE_BETA_WORKERS = ["Chain_B", "Inv_Def_1", "Keep_Def"]
+_MASS_MOVE_TARGET_ZONE = "Delta-Disputed"
+
+
+class TestMassMoveBetaCombatWorkers:
+    """Mass move 3 Beta combat-row workers from Beta-Combat to
+    Delta-Disputed in a single form submit; massAction.php loops over
+    worker_ids[] and calls moveWorker() per worker."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def mass_move_state(self, browser):
+        """Capture pre-move zones, click mass-move (3 workers selected
+        → Delta-Disputed), capture post-move zones."""
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+
+        pre = {w["lastname"]: w["zone_name"]
+               for w in ui_all_workers(page)
+               if w["lastname"] in _MASS_MOVE_BETA_WORKERS}
+
+        ui_mass_move_click(page, "Beta", _MASS_MOVE_BETA_WORKERS,
+                           _MASS_MOVE_TARGET_ZONE)
+
+        post = {w["lastname"]: w["zone_name"]
+                for w in ui_all_workers(page)
+                if w["lastname"] in _MASS_MOVE_BETA_WORKERS}
+
+        assert_no_collected_php_errors(page)
+        context.close()
+        type(self)._pre = pre
+        type(self)._post = post
+        yield
+
+    def test_pre_move_all_in_beta_combat(self):
+        for w in _MASS_MOVE_BETA_WORKERS:
+            assert self._pre[w] == "Beta-Combat", (
+                f"{w} should start in Beta-Combat; got {self._pre[w]}"
+            )
+
+    def test_chain_b_moved_to_delta_disputed(self):
+        assert self._post["Chain_B"] == _MASS_MOVE_TARGET_ZONE, (
+            f"Chain_B should be in {_MASS_MOVE_TARGET_ZONE} after mass-move; "
+            f"got {self._post['Chain_B']}"
+        )
+
+    def test_inv_def_1_moved_to_delta_disputed(self):
+        assert self._post["Inv_Def_1"] == _MASS_MOVE_TARGET_ZONE, (
+            f"Inv_Def_1 should be in {_MASS_MOVE_TARGET_ZONE} after mass-move; "
+            f"got {self._post['Inv_Def_1']}"
+        )
+
+    def test_keep_def_moved_to_delta_disputed(self):
+        assert self._post["Keep_Def"] == _MASS_MOVE_TARGET_ZONE, (
+            f"Keep_Def should be in {_MASS_MOVE_TARGET_ZONE} after mass-move; "
+            f"got {self._post['Keep_Def']}"
         )

--- a/tests/test_workers_special_e2e.py
+++ b/tests/test_workers_special_e2e.py
@@ -816,16 +816,17 @@ class TestDoubleAgentLifecycle:
         # find DA_Lifecycle_Death in the enemy dropdown.
         end_turn(page)
 
-        # Recall DA_Lifecycle_Recall to its secondary (Echo). Instant
-        # URL action; advances trace creation + primary swap immediately.
+        # Recall DA_Lifecycle_Recall to its secondary (Echo) via the
+        # rendered 'Le rappeler a notre service !' button on workers/view.php.
+        # The button's hidden recall_controller_id is the session
+        # controller's id — so we must view as Echo (the secondary) to
+        # send recall_controller_id=Echo. Echo's view of the worker shows
+        # workerStatus='double_agent' and renders the recall button.
         recall_wid = ui_worker_id(page, "DA_Lifecycle_Recall", base_url=PHP_BASE_URL)
-        recall_url = (
-            f"{PHP_BASE_URL}/workers/action.php"
-            f"?worker_id={recall_wid}"
-            f"&recallDoubleAgent=Rappeler"
-            f"&recall_controller_id={echo_id}"
-        )
-        page.goto(recall_url)
+        _select_controller(page, PHP_BASE_URL, "Echo")
+        safe_goto(page, f"{PHP_BASE_URL}/workers/action.php?worker_id={recall_wid}")
+        page.wait_for_load_state("load")
+        page.locator("input[name='recallDoubleAgent']").click()
         page.wait_for_load_state("load")
 
         # Queue the kill on DA_Lifecycle_Death and resolve at end-turn.

--- a/tests/test_workers_special_e2e.py
+++ b/tests/test_workers_special_e2e.py
@@ -1164,24 +1164,21 @@ class TestReturnPrisonerReinstatesSecondary:
         ui_attack(page, "DA_Captor_Alpha", "DA_ReturnPrisoner_W")
         end_turn(page)
 
-        # returnPrisoner from Alpha back to Charlie. URL form fields are
-        # the same ones the prisoner-release form posts (see
-        # workers/action.php:149-157). PHP only checks isset() on
-        # returnPrisoner, so any non-empty value works.
+        # returnPrisoner from Alpha back to Charlie via the rendered
+        # release-to-original-owner button. When the prisoner has a
+        # double_agent_controller_id in action_params (this case, where
+        # the worker was a Charlie/Echo double-agent), the FIRST
+        # returnPrisoner form (workers/view.php:295-301) injects a hidden
+        # double_controller_id={Echo} input — clicking it triggers the
+        # secondary-link reinstate branch at workers/functions.php:1163-1173.
         target_wid = ui_worker_id(
             page, "DA_ReturnPrisoner_W", base_url=PHP_BASE_URL,
             prefer_non_trace=True,
         )
-        echo_id = _controller_ids["Echo"]
-        return_url = (
-            f"{PHP_BASE_URL}/workers/action.php"
-            f"?worker_id={target_wid}"
-            f"&returnPrisoner=Relacher"
-            f"&recall_controller_id={alpha_id}"
-            f"&return_controller_id={charlie_id}"
-            f"&double_controller_id={echo_id}"
-        )
-        page.goto(return_url)
+        _select_controller(page, PHP_BASE_URL, "Alpha")
+        safe_goto(page, f"{PHP_BASE_URL}/workers/action.php?worker_id={target_wid}")
+        page.wait_for_load_state("load")
+        page.locator("input[name='returnPrisoner']").first.click()
         page.wait_for_load_state("load")
 
         clear_ui_caches()

--- a/tests/test_zones_e2e.py
+++ b/tests/test_zones_e2e.py
@@ -134,3 +134,32 @@ class TestZonesPageControllers:
         danger_tags = gm_page.locator("span.tag.is-danger")
         assert danger_tags.count() >= 1, \
             "Expected at least 1 'our control' tag for controller Alpha's zone"
+
+
+class TestZoneToggleClicks:
+    """toggleDescription(id) flips inline `display` on collapsible sections.
+    PHP renders the description divs with style='display:none;'; clicking the
+    header should set display:block, clicking again should set display:none."""
+
+    def test_carte_header_toggles_map(self, gm_page: Page, base_url):
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
+        carte = gm_page.locator("#description-carte")
+        assert carte.evaluate("el => el.style.display") == "none"
+        gm_page.locator("h4[onclick=\"toggleDescription('carte')\"]").click()
+        assert carte.evaluate("el => el.style.display") == "block"
+        gm_page.locator("h4[onclick=\"toggleDescription('carte')\"]").click()
+        assert carte.evaluate("el => el.style.display") == "none"
+
+    def test_zone_header_toggles_description(self, gm_page: Page, base_url):
+        safe_goto(gm_page, f"{base_url}/zones/action.php")
+        first_desc = gm_page.locator(
+            "div[id^='description-']:not([id='description-carte'])"
+        ).first
+        zone_id = (first_desc.get_attribute("id") or "").replace("description-", "")
+        assert zone_id, "Could not extract zone_id from first description div"
+        assert first_desc.evaluate("el => el.style.display") == "none"
+        header = gm_page.locator(
+            f"h3[onclick=\"toggleDescription('{zone_id}')\"]"
+        )
+        header.click()
+        assert first_desc.evaluate("el => el.style.display") == "block"

--- a/var/csv/setupTestConfig_advanced.csv
+++ b/var/csv/setupTestConfig_advanced.csv
@@ -42,3 +42,4 @@ combat,Riposte_R3_C,origine Accessible,Beta-Combat,Foxtrot,passive,{},Blank Slat
 combat,DA_Captor_Alpha,origine Accessible,Beta-Combat,Alpha,passive,{},Brute Force|Veteran Tactician
 combat,DA_Captor_Echo,origine Accessible,Beta-Combat,Echo,passive,{},Brute Force|Veteran Tactician
 combat,DA_Killer,origine Accessible,Beta-Combat,Foxtrot,passive,{},Eagle Scout|Common Folk
+combat,Transform_Subject,origine Accessible,Beta-Combat,Alpha,passive,{},Blank Slate|Common Folk

--- a/var/csv/setupTestConfig_controller_ressources.csv
+++ b/var/csv/setupTestConfig_controller_ressources.csv
@@ -1,4 +1,4 @@
 controllers__lastname->controller_id,ressources_config__ressource_name->ressource_id,amount,amount_stored,end_turn_gain
 Alpha,Gold,100,50,10
 Beta,Gold,80,30,8
-Echo,Gold,4,0,0
+Echo,Gold,2,0,0

--- a/var/csv/setupTestConfig_controller_ressources.csv
+++ b/var/csv/setupTestConfig_controller_ressources.csv
@@ -1,3 +1,4 @@
 controllers__lastname->controller_id,ressources_config__ressource_name->ressource_id,amount,amount_stored,end_turn_gain
 Alpha,Gold,100,50,10
 Beta,Gold,80,30,8
+Echo,Gold,4,0,0

--- a/var/csv/setupTestConfig_locations.csv
+++ b/var/csv/setupTestConfig_locations.csv
@@ -1,5 +1,5 @@
 "name","description","hidden_description","discovery_diff","zones__name->zone_id","controllers__lastname->controller_id","is_base","can_be_destroyed","can_be_repaired","activate_json"
 "Location A","A test location for discovery testing","Secret details of Location A visible at high investigation",4,"Alpha-Investigation","",0,0,0,""
-"Echo-Base","Echo's secret base","Hidden tactical details only owner sees",0,"Theta-Artefacts","Echo",1,1,0,""
-"Foxtrot-Outpost","Foxtrot's forward outpost","Hidden tactical details only owner sees",0,"Theta-Artefacts","Foxtrot",1,1,0,""
+"Echo-Base","Echo's secret base","Hidden tactical details only owner sees",0,"Theta-Artefacts","Echo",1,1,0,"{""update_location"":{""can_be_destroyed"":0,""can_be_repaired"":1,""save_to_json"":""TRUE""}}"
+"Foxtrot-Outpost","Foxtrot's forward outpost","Hidden tactical details only owner sees",0,"Theta-Artefacts","Foxtrot",1,1,0,"{""update_location"":{""can_be_destroyed"":0,""can_be_repaired"":1,""save_to_json"":""TRUE""}}"
 "Civic-Site","Public civic structure","No hidden info",0,"Theta-Artefacts","",0,0,0,""

--- a/var/csv/setupTestConfig_textes.csv
+++ b/var/csv/setupTestConfig_textes.csv
@@ -46,3 +46,6 @@
 "TEXT_LOCATION_ATTACK_AGENT_REPORT_FAIL","[""Agent report: location attack fail.""]","Agent report location fail"
 "TEXT_LOCATION_DEFENCE_AGENT_REPORT_SUCCESS","[""Defence report: location defended.""]","Defence report location success"
 "TEXT_LOCATION_DEFENCE_AGENT_REPORT_FAIL","[""Defence report: location fell.""]","Defence report location fail"
+"age_discipline","{""age"": [""2""]}","Discipline teach gating: extra slot at age >= 2"
+"age_transformation","{""action"": ""check""}","Transform UI gate (must equal 'check' to render)"
+"recrutement_disciplines","0","Base discipline slot count granted at recruitment (0 forces age-based gating)"

--- a/var/csv/setupTestConfig_textes.csv
+++ b/var/csv/setupTestConfig_textes.csv
@@ -49,3 +49,4 @@
 "age_discipline","{""age"": [""2""]}","Discipline teach gating: extra slot at age >= 2"
 "age_transformation","{""action"": ""check""}","Transform UI gate (must equal 'check' to render)"
 "recrutement_disciplines","0","Base discipline slot count granted at recruitment (0 forces age-based gating)"
+"ressource_management","TRUE","Activate resource accounting (createBase/moveBase costs, end_turn_gain accrual)"

--- a/var/csv/setupTestConfig_transformations.csv
+++ b/var/csv/setupTestConfig_transformations.csv
@@ -1,3 +1,4 @@
 name,description,enquete,attack,defence,other,linkTable_power_types__name->link_power_type__power_type_id
 "War Gear"," combat equipment",0,2,1,"{""on_recrutment"": ""FALSE""}",Transformation
 "Shadow Cloak"," stealth equipment",1,0,1,"{""on_recrutment"": ""FALSE""}",Transformation
+"Combat Vest"," location-locked vest",0,1,1,"{""on_recrutment"": ""FALSE"", ""on_transformation"": {""worker_in_zone"": ""Beta-Combat""}}",Transformation


### PR DESCRIPTION
  ## Summary
  - Replaces `networkidle` waits in helpers + the named-flake fixture with `load` + element-presence checks
  - Adds `_wait_loaded(page, selector)` helper + 5 UI-click variants of action drivers
    (`ui_gift_click`, `ui_attack_click`, `ui_investigate_click`, `ui_claim_click`, `ui_move_click`)
    plus `_create_base_click` in test_controller_recruitment_e2e.py
  - Converts the first call of each action per file to the click variant (per the
    once-per-file UI-click compromise rule); the URL-drivers stay for subsequent calls
  - Adds 7 smoke tests (systemPresentation external links, sidebar toggle, zone collapsibles)
