### PR TITLE
chore : add phpmyadmin to docker stack on port 8081

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,5 +45,18 @@ services:
       mysql:
         condition: service_healthy
 
+  phpmyadmin:
+    image: phpmyadmin:latest
+    container_name: rpg_pma
+    ports:
+      - "8081:80"
+    environment:
+      PMA_HOST: mysql
+      PMA_USER: root
+      PMA_PASSWORD: root
+    depends_on:
+      mysql:
+        condition: service_healthy
+
 volumes:
   rpg_mysql_data:


### PR DESCRIPTION
Convenience addition for inspecting the dev MySQL via browser GUI. Service uses root credentials, mapped to host port 8081, depends on the existing rpg_mysql healthcheck.