### PR TITLE
fix : guard save_to_json read in updateLocation against undefined key

### DIFF
--- a/tests/test_zones_management_locations_e2e.py
+++ b/tests/test_zones_management_locations_e2e.py
@@ -1,0 +1,144 @@
+"""Regression test for the undefined-`save_to_json` warning at
+zones/functions.php:665 (management_locations toggle path).
+
+Surfaced 2026-05-06 in production when toggling destruction on
+`chemin de l'illumination` via /zones/management_locations.php under
+Japan1555-SQL config:
+
+    Warning: Undefined array key "save_to_json" in zones/functions.php
+    on line 665
+
+Root cause: `updateLocation` reads
+`$update_location_data['save_to_json']` unconditionally. Some scenario
+seeds put `save_to_json` only inside a nested `future_location` block;
+when `update_location` lacks the key at its top level the read warns,
+even though the function falls through correctly to the elseif
+`future_location` branch.
+
+Fix: 1-line null-coalesce. Behaviour unchanged; only the warning
+suppressed.
+
+Self-contained TestConfig fixture: a dedicated unowned seed location
+`Test-Future-Location` carries the `update_location` + nested
+`future_location` shape (no top-level `save_to_json`). Toggling its
+destruction via /zones/management_locations.php exercises the path
+that warned pre-fix.
+
+Run:
+    python3 -m pytest tests/test_zones_management_locations_e2e.py -v
+"""
+import re
+
+import pytest
+from playwright.sync_api import Page
+
+from conftest import PHP_BASE_URL, ensure_gm_login
+from helpers import (
+    DB_AVAILABLE, load_minimal_data, safe_goto,
+    register_php_error_listener, assert_no_collected_php_errors,
+)
+
+
+# Seeded in setupTestConfig_locations.csv with an `update_location`
+# block that carries a nested `future_location` (no top-level
+# `save_to_json`) — the shape that triggered the warning before the fix.
+_FUTURE_LOCATION_SHAPED_NAME = "Test-Future-Location"
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_test_config(browser):
+    """Load TestConfig so `Test-Future-Location` (the
+    future_location-shaped seed) is available for the toggle test."""
+    if DB_AVAILABLE:
+        load_minimal_data()
+
+    context = browser.new_context()
+    page = context.new_page()
+    register_php_error_listener(page)
+    safe_goto(page, f"{PHP_BASE_URL}/connection/loginForm.php")
+    page.wait_for_load_state("load")
+    page.locator("input[name='username']").fill("gm")
+    page.locator("input[name='passwd']").fill("orga")
+    page.locator("input[type='submit']").first.click()
+    page.wait_for_load_state("load")
+    safe_goto(page, f"{PHP_BASE_URL}/base/admin.php")
+    page.wait_for_load_state("load")
+    page.locator("select[name='config_name']").select_option("TestConfig")
+    page.locator("input[name='submit'][value='Submit']").click()
+    page.wait_for_timeout(5000)
+    page.wait_for_load_state("load", timeout=90000)
+    assert_no_collected_php_errors(page)
+    context.close()
+    yield
+
+
+def _toggle_destruction_first_match(page, name_substring):
+    """Find the first management_locations row whose <h3> contains
+    `name_substring` and submit its toggle_destruction form via
+    JS (the button sits inside `display:none;`, so click(force=True)
+    fails — page.evaluate triggers the form submission directly)."""
+    safe_goto(page, f"{PHP_BASE_URL}/zones/management_locations.php")
+    page.wait_for_load_state("load")
+    html = page.content()
+    m = re.search(
+        rf'<h3>[^<]*{re.escape(name_substring)}[^<]*\(discovery[^<]+</h3>'
+        rf'.*?name="toggle_destruction"\s+value="(\d+)"',
+        html,
+        re.DOTALL,
+    )
+    if not m:
+        raise AssertionError(
+            f"toggle_destruction form for a location matching "
+            f"'{name_substring}' not found on management_locations.php"
+        )
+    location_id = int(m.group(1))
+    page.evaluate(
+        f"""
+        const inp = document.querySelector(
+            'input[name="toggle_destruction"][value="{location_id}"]'
+        );
+        if (inp && inp.form) inp.form.submit();
+        """
+    )
+    page.wait_for_load_state("load")
+    return location_id
+
+
+class TestSaveToJsonNullCoalesceFix:
+    """zones/functions.php:665 read save_to_json without a null-coalesce
+    check. Toggling a `future_location`-shaped location warned on the
+    first toggle. The fix swaps to `($update_location_data['save_to_json']
+    ?? '') == "TRUE"` — behaviour unchanged, warning suppressed."""
+
+    def test_first_toggle_no_php_warning(self, browser):
+        """Navigate to management_locations, submit the
+        toggle_destruction form for `Test-Future-Location` (its
+        update_location block carries only a nested future_location, no
+        top-level save_to_json), and assert no `<b>Warning</b>` marker
+        fires across the whole page lifetime (covered by the
+        register_php_error_listener observer)."""
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+
+        location_id = _toggle_destruction_first_match(
+            page, _FUTURE_LOCATION_SHAPED_NAME
+        )
+
+        # Sanity: a location was found + toggled.
+        assert location_id > 0, (
+            f"Expected a positive location_id from the toggle, got {location_id}"
+        )
+
+        # The listener catches PHP_ERROR_MARKERS on every response in
+        # the page lifetime. Under the pre-fix code, the toggle response
+        # contained `<b>Warning</b> Undefined array key "save_to_json"`.
+        assert_no_collected_php_errors(page)
+
+        context.close()

--- a/tests/test_zones_management_locations_e2e.py
+++ b/tests/test_zones_management_locations_e2e.py
@@ -19,10 +19,18 @@ Fix: 1-line null-coalesce. Behaviour unchanged; only the warning
 suppressed.
 
 Self-contained TestConfig fixture: a dedicated unowned seed location
-`Test-Future-Location` carries the `update_location` + nested
-`future_location` shape (no top-level `save_to_json`). Toggling its
-destruction via /zones/management_locations.php exercises the path
-that warned pre-fix.
+`Test-Future-Location` carries an `update_location` block with a
+nested `future_location` (no top-level `save_to_json`). The two halves
+of the swap also differ in `name` so each toggle visibly flips the
+location's heading on /zones/management_locations.php — letting the
+test assert round-trip integrity (toggles 2 and 3) end-to-end:
+
+  Toggle 1 (initial -> ruined):    name = Test-Future-Location-Ruined
+  Toggle 2 (ruined -> restored):   name = Test-Future-Location
+  Toggle 3 (restored -> ruined):   name = Test-Future-Location-Ruined
+
+`register_php_error_listener` covers the `<b>Warning</b>` assertion
+across all three toggles in one go.
 
 Run:
     python3 -m pytest tests/test_zones_management_locations_e2e.py -v
@@ -39,10 +47,11 @@ from helpers import (
 )
 
 
-# Seeded in setupTestConfig_locations.csv with an `update_location`
-# block that carries a nested `future_location` (no top-level
-# `save_to_json`) — the shape that triggered the warning before the fix.
-_FUTURE_LOCATION_SHAPED_NAME = "Test-Future-Location"
+# Two halves of the toggle swap, both seeded in
+# setupTestConfig_locations.csv via update_location.name +
+# update_location.future_location.name.
+_INITIAL_NAME = "Test-Future-Location"
+_RUINED_NAME = "Test-Future-Location-Ruined"
 
 
 @pytest.fixture(scope="session")
@@ -75,6 +84,23 @@ def load_test_config(browser):
     assert_no_collected_php_errors(page)
     context.close()
     yield
+
+
+def _location_name_via_management(page, name_substring):
+    """Scrape /zones/management_locations.php and return the H3
+    location-name text for the row whose name contains
+    `name_substring`. Returns None if not found.
+
+    Stripped of the trailing ` (discovery N)` suffix that the page
+    renders alongside the name."""
+    safe_goto(page, f"{PHP_BASE_URL}/zones/management_locations.php")
+    page.wait_for_load_state("load")
+    html = page.content()
+    m = re.search(
+        rf'<h3>([^<]*{re.escape(name_substring)}[^<]*?)\s*\(discovery[^<]+</h3>',
+        html,
+    )
+    return m.group(1).strip() if m else None
 
 
 def _toggle_destruction_first_match(page, name_substring):
@@ -113,32 +139,65 @@ class TestSaveToJsonNullCoalesceFix:
     """zones/functions.php:665 read save_to_json without a null-coalesce
     check. Toggling a `future_location`-shaped location warned on the
     first toggle. The fix swaps to `($update_location_data['save_to_json']
-    ?? '') == "TRUE"` — behaviour unchanged, warning suppressed."""
+    ?? '') == "TRUE"` — behaviour unchanged, warning suppressed.
 
-    def test_first_toggle_no_php_warning(self, browser):
-        """Navigate to management_locations, submit the
-        toggle_destruction form for `Test-Future-Location` (its
-        update_location block carries only a nested future_location, no
-        top-level save_to_json), and assert no `<b>Warning</b>` marker
-        fires across the whole page lifetime (covered by the
-        register_php_error_listener observer)."""
+    Three sequential toggles verify both: (a) no PHP warning fires on
+    any of the three swaps (covered by register_php_error_listener),
+    and (b) the swap genuinely round-trips — the location's name
+    alternates between the initial and ruined variants without
+    silent corruption of the activate_json on the second swap."""
+
+    def test_round_trip_three_toggles_no_php_warning(self, browser):
+        """Toggle Test-Future-Location three times: initial->ruined
+        ->restored->ruined. After each toggle, scrape the H3 on
+        management_locations.php to confirm the name flipped to the
+        expected half. The PHP-error listener watches all toggle
+        responses for `<b>Warning</b>` markers; the round-trip
+        catches the silent-corruption-on-second-swap class of bug
+        a single-toggle test would miss."""
         context = browser.new_context()
         page = context.new_page()
         register_php_error_listener(page)
         ensure_gm_login(page, PHP_BASE_URL)
 
-        location_id = _toggle_destruction_first_match(
-            page, _FUTURE_LOCATION_SHAPED_NAME
+        # Pre-toggle: row is in its CSV-seeded state.
+        name_before = _location_name_via_management(page, _INITIAL_NAME)
+        assert name_before == _INITIAL_NAME, (
+            f"Pre-toggle H3 should read {_INITIAL_NAME!r}; got {name_before!r}"
         )
 
-        # Sanity: a location was found + toggled.
-        assert location_id > 0, (
-            f"Expected a positive location_id from the toggle, got {location_id}"
+        # Toggle 1: initial -> ruined (the swap that warned pre-fix).
+        _toggle_destruction_first_match(page, _INITIAL_NAME)
+        name_after_1 = _location_name_via_management(page, _INITIAL_NAME)
+        assert name_after_1 == _RUINED_NAME, (
+            f"After toggle 1 H3 should read {_RUINED_NAME!r}; "
+            f"got {name_after_1!r}"
+        )
+
+        # Toggle 2: ruined -> restored. The activate_json now carries
+        # save_to_json=TRUE at the top level; this exercises the IF
+        # branch (save current state into activate_json.update_location)
+        # that the elseif handled on toggle 1.
+        _toggle_destruction_first_match(page, _INITIAL_NAME)
+        name_after_2 = _location_name_via_management(page, _INITIAL_NAME)
+        assert name_after_2 == _INITIAL_NAME, (
+            f"After toggle 2 H3 should read {_INITIAL_NAME!r}; "
+            f"got {name_after_2!r}"
+        )
+
+        # Toggle 3: restored -> ruined. Confirms the swap is idempotent
+        # across cycles and the saved-old payload from toggle 2 is
+        # still well-formed.
+        _toggle_destruction_first_match(page, _INITIAL_NAME)
+        name_after_3 = _location_name_via_management(page, _INITIAL_NAME)
+        assert name_after_3 == _RUINED_NAME, (
+            f"After toggle 3 H3 should read {_RUINED_NAME!r}; "
+            f"got {name_after_3!r}"
         )
 
         # The listener catches PHP_ERROR_MARKERS on every response in
-        # the page lifetime. Under the pre-fix code, the toggle response
-        # contained `<b>Warning</b> Undefined array key "save_to_json"`.
+        # the page lifetime — covers all three toggle responses in
+        # a single assertion.
         assert_no_collected_php_errors(page)
 
         context.close()

--- a/var/csv/setupTestConfig_locations.csv
+++ b/var/csv/setupTestConfig_locations.csv
@@ -3,3 +3,4 @@
 "Echo-Base","Echo's secret base","Hidden tactical details only owner sees",0,"Theta-Artefacts","Echo",1,1,0,"{""update_location"":{""can_be_destroyed"":0,""can_be_repaired"":1,""save_to_json"":""TRUE""}}"
 "Foxtrot-Outpost","Foxtrot's forward outpost","Hidden tactical details only owner sees",0,"Theta-Artefacts","Foxtrot",1,1,0,"{""update_location"":{""can_be_destroyed"":0,""can_be_repaired"":1,""save_to_json"":""TRUE""}}"
 "Civic-Site","Public civic structure","No hidden info",0,"Theta-Artefacts","",0,0,0,""
+"Test-Future-Location","Unowned test location for save_to_json future_location toggle regression","",0,"Theta-Artefacts","",0,1,0,"{""update_location"":{""can_be_destroyed"":0,""can_be_repaired"":1,""future_location"":{""can_be_destroyed"":1,""can_be_repaired"":0,""save_to_json"":""TRUE""}}}"

--- a/var/csv/setupTestConfig_locations.csv
+++ b/var/csv/setupTestConfig_locations.csv
@@ -3,4 +3,4 @@
 "Echo-Base","Echo's secret base","Hidden tactical details only owner sees",0,"Theta-Artefacts","Echo",1,1,0,"{""update_location"":{""can_be_destroyed"":0,""can_be_repaired"":1,""save_to_json"":""TRUE""}}"
 "Foxtrot-Outpost","Foxtrot's forward outpost","Hidden tactical details only owner sees",0,"Theta-Artefacts","Foxtrot",1,1,0,"{""update_location"":{""can_be_destroyed"":0,""can_be_repaired"":1,""save_to_json"":""TRUE""}}"
 "Civic-Site","Public civic structure","No hidden info",0,"Theta-Artefacts","",0,0,0,""
-"Test-Future-Location","Unowned test location for save_to_json future_location toggle regression","",0,"Theta-Artefacts","",0,1,0,"{""update_location"":{""can_be_destroyed"":0,""can_be_repaired"":1,""future_location"":{""can_be_destroyed"":1,""can_be_repaired"":0,""save_to_json"":""TRUE""}}}"
+"Test-Future-Location","Unowned test location for save_to_json future_location toggle regression","",0,"Theta-Artefacts","",0,1,0,"{""update_location"":{""name"":""Test-Future-Location-Ruined"",""can_be_destroyed"":0,""can_be_repaired"":1,""future_location"":{""name"":""Test-Future-Location"",""can_be_destroyed"":1,""can_be_repaired"":0,""save_to_json"":""TRUE""}}}"

--- a/zones/functions.php
+++ b/zones/functions.php
@@ -661,8 +661,8 @@ function updateLocation($pdo, $location, $activate_json) {
     $new_activate_location = $activate_json;
     unset($new_activate_location['update_location']);
 
-    // If the old data must be saved to json, add it to the new activate_json
-    if ($update_location_data['save_to_json'] == "TRUE") {
+    // If the old data must be saved to json, add it to the new activate_json.
+    if (($update_location_data['save_to_json'] ?? '') == "TRUE") {
         // Prepare the old location data
         $update_location = array(
             'name' => $location['name'],


### PR DESCRIPTION
zones/functions.php:665 read $update_location_data['save_to_json'] unconditionally. 
Some scenario JSONs (e.g. Japan1555 SQL temple seeds in setupJapon1555SQL_zones.sql:138-211) put save_to_json only inside a nested future_location block, leaving the top-level key undefined. 
The unguarded read warned on every first toggle from /zones/management_locations.php; behaviour was correct (the elseif fell through to the future_location branch) but the warning leaked to the page.

Null-coalesce on the read suppresses the spurious warning while preserving the existing branch logic. Adds a regression test under TestConfig: a new Test-Future-Location seed carries the update_location + nested future_location shape; toggling its destruction must produce no PHP warning markers.