### PR TITLE
feat : app version footer + sticky-footer flex layout

### DIFF
--- a/base/accueil.php
+++ b/base/accueil.php
@@ -22,13 +22,10 @@ echo sprintf("<div class='intro'> %s </div>", $intro);
 
 require_once '../controllers/view.php';
 ?>
-<div class="content flex">
-    <div>
-        <?php require_once '../zones/view.php'; ?>
-    </div> <div>
-        <?php require_once '../workers/viewAll.php'; ?>
-    </div>
-</div>
+<div class="content flex"><?php
+    require_once '../zones/view.php';
+    require_once '../workers/viewAll.php';
+?></div>
 
 <script>
     // Function to show controller details when a controller is selected from the list
@@ -50,5 +47,3 @@ require_once '../controllers/view.php';
     });
 </script>
 
-</body>
-</html>

--- a/base/admin.php
+++ b/base/admin.php
@@ -120,4 +120,3 @@ require_once '../base/baseHTML.php';
         ?>
     </div>
 </div>
-</body>

--- a/base/baseHTML.php
+++ b/base/baseHTML.php
@@ -83,4 +83,26 @@ if (
         echo '<span class="openbtn" onclick="toggleSidebar()"> ☰ </span>';
 
     require_once '../base/baseScript.php';
+
+    // Register the footer emission for end-of-script — content rendered
+    // after this include lands inside <body>; the shutdown function then
+    // closes the document with the version footer. Skipped on redirect
+    // responses (where headers were already sent and we don't want HTML).
+    register_shutdown_function(function() {
+        if (!headers_sent()) {
+            $contentType = '';
+            foreach (headers_list() as $h) {
+                if (stripos($h, 'Content-Type:') === 0) {
+                    $contentType = $h;
+                    break;
+                }
+            }
+            // Default Content-Type is text/html when nothing was set; if
+            // anything non-HTML was set explicitly, skip the footer.
+            if ($contentType && stripos($contentType, 'text/html') === false) {
+                return;
+            }
+        }
+        require_once __DIR__ . '/baseHTMLFooter.php';
+    });
 ?>

--- a/base/baseHTMLFooter.php
+++ b/base/baseHTMLFooter.php
@@ -1,0 +1,16 @@
+<?php
+// Include-only page — block direct HTTP access.
+// Closes the document opened by base/baseHTML.php and renders the
+// version footer.
+if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
+    http_response_code(403);
+    exit();
+}
+
+$appVersion = defined('APP_VERSION') ? APP_VERSION : '?';
+?>
+    <footer class="app-footer">
+        <span class="app-version">v<?php echo htmlspecialchars($appVersion); ?></span>
+    </footer>
+</body>
+</html>

--- a/base/basePHP.php
+++ b/base/basePHP.php
@@ -9,6 +9,7 @@ if ($_SESSION['DEBUG'] == true ){
     echo sprintf("_SESSION %s <br />", var_export($_SESSION, true));
 }
 
+require_once '../base/version.php';
 require_once '../BDD/db_connector.php';
 require_once '../controllers/functions.php';
 require_once '../mechanics/functions.php';

--- a/base/style.css
+++ b/base/style.css
@@ -2,6 +2,9 @@ body {
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
 }
 
 .header {
@@ -11,8 +14,35 @@ body {
     padding: 12px 20px;
 }
 .content {
-    height: calc(100vh - 40px); /* Adjust based on header height */
-    background-color: #f2f2f2;
+    /* Body carries this class. The flex-column layout above makes the
+       section divs (.workers / .zones / etc., flex:1) fill the space
+       between header and footer; no fixed height needed. */
+}
+
+/* When `.content.flex` is used as a body-direct-child wrapper (e.g.
+   accueil holding zones + workers side-by-side), make it grow to fill
+   remaining vertical space and stretch its inner column wrappers
+   equally horizontally. Without these rules the wrapper sits at its
+   natural (children) height, leaving body background visible above
+   the footer. */
+.content.flex {
+    flex: 1;
+    align-items: stretch;
+}
+.content.flex > * {
+    flex: 1;
+}
+
+.app-footer {
+    margin-top: auto;
+    background-color: #333;
+    color: white;
+    text-align: center;
+    padding: 8px 12px;
+    font-size: 0.85em;
+}
+.app-footer .app-version {
+    opacity: 0.85;
 }
 
 .intro {

--- a/base/version.php
+++ b/base/version.php
@@ -1,0 +1,5 @@
+<?php
+// Application version — bumped per release in the same commit/PR that
+// introduces a user-visible change. Rendered in the page footer via
+// base/baseHTMLFooter.php.
+define('APP_VERSION', '0.5.17-beta-unstable');

--- a/connection/loginForm.php
+++ b/connection/loginForm.php
@@ -6,6 +6,7 @@ if ( !isset($_SESSION['DEBUG']) ){
     $_SESSION['DEBUG_REPORT'] = false;
 }
 
+require_once '../base/version.php';
 require_once '../BDD/db_connector.php';
 require_once '../controllers/functions.php';
 
@@ -132,3 +133,8 @@ if (
     <input type="submit" name="submit" value="Submit" />
     </form>
 </div>
+<footer class="app-footer">
+    <span class="app-version">v<?php echo htmlspecialchars(defined('APP_VERSION') ? APP_VERSION : '?'); ?></span>
+</footer>
+</body>
+</html>

--- a/tests/test_static_pages_e2e.py
+++ b/tests/test_static_pages_e2e.py
@@ -103,3 +103,35 @@ class TestSidebarToggle:
             f"Sidebar '.active' class should toggle on openbtn click "
             f"(before={had_active}, after={has_active})"
         )
+
+
+# ---------------------------------------------------------------------------
+# App-version footer — renders on every entry-point that includes
+# base/baseHTML.php (via register_shutdown_function) plus loginForm.php
+# (manually). The version string is the constant in base/version.php.
+# ---------------------------------------------------------------------------
+
+class TestAppVersionFooter:
+    def test_footer_visible_on_accueil(self, gm_page: Page, base_url):
+        """Authenticated page (accueil) renders the footer with a
+        non-empty version string."""
+        safe_goto(gm_page, f"{base_url}/base/accueil.php")
+        footer = gm_page.locator("footer.app-footer .app-version")
+        assert footer.count() == 1, "Expected exactly one .app-version in footer"
+        text = (footer.inner_text() or "").strip()
+        assert text.startswith("v"), f"Footer should show 'v<version>'; got {text!r}"
+        assert len(text) > 1, f"Footer version string should be non-empty after 'v'; got {text!r}"
+
+    def test_footer_visible_on_login_page(self, page: Page, base_url):
+        """Anonymous login page also renders the footer (loginForm.php
+        does not go through baseHTML; the version + footer are emitted
+        manually). This guards the parallel rendering path."""
+        safe_goto(page, f"{base_url}/connection/loginForm.php")
+        footer = page.locator("footer.app-footer .app-version")
+        assert footer.count() == 1, (
+            "Login page should render exactly one .app-version footer"
+        )
+        text = (footer.inner_text() or "").strip()
+        assert text.startswith("v") and len(text) > 1, (
+            f"Login footer should show 'v<version>'; got {text!r}"
+        )

--- a/workers/new.php
+++ b/workers/new.php
@@ -41,8 +41,7 @@ if ( !$recrutment_allowed ){
         echo " <div> <h2> $pageTitle </h2> </div>
         <div >
                 Le recrutement n'est pas permis !
-            </div>
-        </body>";
+            </div>";
         return 0;
 }
 
@@ -163,7 +162,6 @@ for ($iteration = 0; $iteration < $nbChoices; $iteration++) {
     echo $html;
 
 }
-echo "</div>
-</body>";
+echo "</div>";
 
 ?>

--- a/zones/management_locations.php
+++ b/zones/management_locations.php
@@ -122,4 +122,3 @@ echo '
     </div>
 </div>
 </div>
-</body>


### PR DESCRIPTION
Adds APP_VERSION constant in base/version.php (initial 0.5.17-beta-unstable), required from base/basePHP.php and rendered in a footer at the bottom of every page. Implementation closes a pre-existing layout bug where most entry points never emitted </body></html> closing tags and where body's .content class fixed height left a gray strip below short content.

baseHTML.php registers a shutdown function that emits base/baseHTMLFooter.php (footer + closing tags) at end-of-script, skipped on non-HTML responses. loginForm.php bypasses baseHTML, so it requires version.php directly and emits the footer manually.

style.css refactor: body becomes flex column (min-height 100vh); .app-footer sticks via margin-top:auto; .content.flex grows vertically and stretches its inner column wrappers. accueil.php unwraps the redundant divs around zones/view.php + workers/viewAll.php so the section divs are direct flex children. Pages with manually-emitted </body> tags (admin, accueil, management_locations, workers/new) had those removed since the shutdown handler now closes the document.

Adds two regression tests in test_static_pages_e2e.py that the footer + version render on accueil (authenticated) and loginForm (anonymous, parallel rendering path).