### PR TITLE
style : reword audit-shorthand 'N2' to plain prose in workers/functions.php

### DIFF
--- a/workers/functions.php
+++ b/workers/functions.php
@@ -539,10 +539,9 @@ function randomWorkerName($pdo, $newWorker) {
 
     // Fetch the results
     $worker_names = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    // Store worker_origins in the array. SQL is LIMIT 2 but small
-    // worker_names pools may return only 1 row — fall back to the
-    // first row so we don't access an undefined index. The 0-rows
-    // case is tracked as audit N2 (proper rollback + UX error).
+    // SQL is LIMIT 2 but small worker_names pools may return 1 row — fall
+    // back to the first row so we don't access an undefined index. The
+    // 0-rows case still needs proper rollback + UX error handling.
     $first_row  = $worker_names[0] ?? null;
     $second_row = $worker_names[1] ?? $first_row;
     $newWorker['firstname'] = $first_row['firstname']  ?? '';


### PR DESCRIPTION

Locked rule bans audit-row refs (M1/N2/A1/...) in source comments since they're meaningless to anyone reading the code outside the audit doc. Last remaining occurrence reworded; surrounding rationale preserved. Comment-only — no behaviour change.