### PR TITLE
feat : add minimal sidebar to login + noConnection pages (#48)

### DIFF
--- a/base/baseHTML.php
+++ b/base/baseHTML.php
@@ -48,6 +48,8 @@ if (
         $isPrivileged = $_SESSION['is_privileged'] ?? false;
 
         if (!$isLoggedIn && !empty($noConnection)) {
+            $sysClass = ($pageName === 'systemPresentation') ? ' class="select"' : '';
+            echo "<a href='/$folder/base/systemPresentation.php'$sysClass>Le Système</a>";
             echo "<a href='/$folder/connection/loginForm.php' class='sidebar-btn'>Login</a>";
         } else {
             // Define main links

--- a/connection/loginForm.php
+++ b/connection/loginForm.php
@@ -43,9 +43,13 @@ if (!$gameReady) {
     echo "The game is not ready. Please check DB Configuration and Setup. <br />";
     exit();
 }else{
-    $_SESSION['DEBUG'] = getConfig($gameReady, 'DEBUG');
+    if (strtolower(getConfig($gameReady, 'DEBUG')) == 'true') {
+        $_SESSION['DEBUG'] = true;
+    }
+    $gameTitle = getConfig($gameReady, 'TITLE');
     if ($_SESSION['DEBUG'] == true){
         echo "The game is ready.<br />";
+        echo "The gameTitle is : '$gameTitle'.<br />";
     }
 }
 
@@ -123,8 +127,17 @@ if (
 </head>
 <body>
 <div class="header">
-    <h1>RPGConquestGame</h1>
+    <h1>RPGConquestGame : <?php echo $gameTitle ?> </h1>
 </div>
+<!-- Sidebar MENU -->
+<div id="sidebar" class="sidebar">
+    <a href="javascript:void(0)" class="closebtn" onclick="toggleSidebar()">&times;</a>
+    <?php $folder = $_SESSION['FOLDER'] ?? ''; ?>
+    <a href="/<?php echo htmlspecialchars($folder); ?>/base/systemPresentation.php">Le Système</a>
+    <a href="/<?php echo htmlspecialchars($folder); ?>/connection/loginForm.php" class="select">Login</a>
+</div>
+<span class="openbtn" onclick="toggleSidebar()"> ☰ </span>
+<?php require_once '../base/baseScript.php'; ?>
 <div class="content flex">
     <form action="loginForm.php" method="post">
         <h3> Please log in : </H3>


### PR DESCRIPTION
## Summary

  - Login screen (`connection/loginForm.php`) gains a sidebar with two links: **Le Système**
  (systemPresentation) and **Login** (self-link, highlighted). Toggle button + `toggleSidebar` JS via
  `baseScript.php`. Header now shows the game title.
  - `base/baseHTML.php` anonymous-`$noConnection` branch also emits the **Le Système** link, so any
  future `$noConnection` page (`docConfig`, `docCSV`, etc.) inherits the same menu structure.
  
  Closes #48.

  ## Manual Test plan
  - [ ] Anonymous visit to `/connection/loginForm.php` shows the sidebar toggle (☰); click reveals
  **Login** (highlighted) + **Le Système**.
  - [ ] **Le Système** link navigates to `/base/systemPresentation.php` while anonymous.
  - [ ] `systemPresentation.php` sidebar (anonymous) shows both links (**Le Système** highlighted).
  - [ ] Logged-in flow unchanged: full sidebar still rendered by `baseHTML.php`.
