### PR TITLE
fix : guard workers/massAction.php with login + ownership checks

### DIFF
--- a/tests/test_workers_action_auth_e2e.py
+++ b/tests/test_workers_action_auth_e2e.py
@@ -262,3 +262,34 @@ class TestInactiveStateBlock:
             f"resurrect carve-out); got 403"
         )
         ctx_xform.close()
+
+
+# ---------------------------------------------------------------------------
+# /workers/massAction.php ownership guard
+#
+# Sibling endpoint to /workers/action.php. The gm-driven happy path
+# (TestMassMoveBetaCombatWorkers in test_workers_special_e2e.py) uses
+# is_privileged=1 and bypasses the ownership check entirely; this single
+# negative test exercises the new non-privileged codepath.
+# ---------------------------------------------------------------------------
+
+def test_mass_action_non_owner_returns_403(browser, base_url):
+    """single_player owns Alpha; Bystander_1 belongs to Beta. massAction.php
+    must 403 before any moveWorker() call when a non-privileged controller
+    attempts to mass-move workers they do not own."""
+    bystander_wid = _resolve_worker_id(browser, base_url, "Bystander_1")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    login_as(page, base_url, "single_player", "test")
+    url = (
+        f"{base_url}/workers/massAction.php"
+        f"?mass_move=1&zone_id=1&worker_ids%5B%5D={bystander_wid}"
+    )
+    response = page.goto(url)
+    assert response is not None
+    assert response.status == 403, (
+        f"Non-owner mass-move on a foreign worker must 403; "
+        f"got {response.status}"
+    )
+    ctx.close()

--- a/workers/massAction.php
+++ b/workers/massAction.php
@@ -2,6 +2,14 @@
 
 require_once '../base/basePHP.php';
 
+// Check if the user is logged in
+if (
+    (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true)
+) {
+    header(sprintf('Location: /%s/connection/loginForm.php', $_SESSION['FOLDER']));
+    exit();
+}
+
 if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
     if ($_SESSION['DEBUG'] == true) echo "_GET:".var_export($_GET, true)." <br /> <br />";
 
@@ -14,6 +22,31 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
 
     // Mass move workers to zone
     if (isset($_GET['mass_move']) && !empty($zone_id) && !empty($worker_ids)){
+        if (!is_array($worker_ids)) { http_response_code(403); exit(); }
+        $worker_ids = array_map('intval', $worker_ids);
+
+        // Ownership check: every worker_id must belong to the session controller
+        if (empty($_SESSION['is_privileged'])) {
+            $session_controller_id = $_SESSION['controller']['id'] ?? null;
+            if (empty($session_controller_id)) { http_response_code(403); exit(); }
+
+            try {
+                $prefix = $_SESSION['GAME_PREFIX'];
+                $placeholders = implode(',', array_fill(0, count($worker_ids), '?'));
+                $stmt = $gameReady->prepare(
+                    "SELECT COUNT(*) FROM {$prefix}controller_worker
+                     WHERE controller_id = ? AND worker_id IN ($placeholders)"
+                );
+                $stmt->execute(array_merge([$session_controller_id], $worker_ids));
+                if ((int)$stmt->fetchColumn() !== count($worker_ids)) {
+                    http_response_code(403); exit();
+                }
+            } catch (PDOException $e) {
+                echo __FUNCTION__."(): SELECT controller_worker Failed: " . $e->getMessage()."<br />";
+                http_response_code(403); exit();
+            }
+        }
+
         foreach ($worker_ids as $worker_id) {
             moveWorker($gameReady, $worker_id, $zone_id);
         }


### PR DESCRIPTION
## Summary

- Adds login gate at top of `workers/massAction.php` (mirrors `workers/action.php:7-13`).
- Adds batched ownership check inside the `mass_move` branch — every `worker_id` must belong to the session controller; 403 with no partial mutation if any do not.
- Privileged users (`$_SESSION['is_privileged']`) retain the bypass.
- Layer 3 (defence-in-depth filter inside `moveWorker()` itself) deferred — tracked in #56.

## Test plan

- [x] Single negative E2E test added (cross-owner non-privileged → 403) covering the new ownership-check codepath that the gm-driven happy path (TestMassMoveBetaCombatWorkers) bypasses.
- [x] GitHub Actions CI green.
- [x] Manual: unauth GET `/workers/massAction.php?mass_move=1&zone_id=X&worker_ids[]=Y` → login redirect.
- [x] Manual: logged-in non-privileged controller attempting to move another controller's workers → 403, no DB change.

Closes #56