### PR TITLE
feat : end-turn attack collisions (ordering + cancel-on-move + dedupe + postgres seed parity)

### DIFF
--- a/base/version.php
+++ b/base/version.php
@@ -2,4 +2,4 @@
 // Application version — bumped per release in the same commit/PR that
 // introduces a user-visible change. Rendered in the page footer via
 // base/baseHTMLFooter.php.
-define('APP_VERSION', '0.6.0-beta-unstable');
+define('APP_VERSION', '0.6.1-beta-unstable');

--- a/controllers/functions.php
+++ b/controllers/functions.php
@@ -316,6 +316,26 @@ function moveBase($pdo, $base_id, $zone_id, $controller_id) {
     spendRessourcesToMoveBase($pdo, $controller_id);
 
     $prefix = $_SESSION['GAME_PREFIX'];
+
+    // Cancel any in-flight end-turn attacks targeting this base.
+    $mechanics = getMechanics($pdo);
+    $turn_number = isset($mechanics['turncounter']) ? (int)$mechanics['turncounter'] : 0;
+    try {
+        $sel = $pdo->prepare("SELECT id, location_id, location_name, attacker_controller_id
+            FROM {$prefix}controller_location_attacks
+            WHERE location_id = :base_id AND queued_turn = :turn AND success IS NULL");
+        $sel->bindParam(':base_id', $base_id, PDO::PARAM_INT);
+        $sel->bindParam(':turn', $turn_number, PDO::PARAM_INT);
+        $sel->execute();
+        $inFlight = $sel->fetchAll(PDO::FETCH_ASSOC);
+    } catch (PDOException $e) {
+        echo __FUNCTION__."(): SELECT in-flight attacks failed: " . $e->getMessage()."<br />";
+        $inFlight = [];
+    }
+    foreach ($inFlight as $row) {
+        failQueuedLocationAttack($pdo, $row, $turn_number, 'moved');
+    }
+
     // update locations set zone_id where controller_id = "%s";
     $sql = "UPDATE {$prefix}locations SET zone_id = :zone_id, setup_turn = (SELECT turncounter FROM {$prefix}mechanics LIMIT 1) WHERE id = :base_id";
     try{

--- a/controllers/functions.php
+++ b/controllers/functions.php
@@ -488,16 +488,29 @@ function attackLocation($pdo, $controller_id, $target_location_id) {
 
     if ($mode === 'endTurn') {
         try {
+            // INSERT WHERE NOT EXISTS: dedupe (attacker, location, turn) at the backend.
             $insertSql = "INSERT INTO {$prefix}controller_location_attacks
                 (location_id, location_name, attacker_controller_id, queued_turn, defence_val_snapshot)
-                VALUES (:location_id, :location_name, :attacker, :turn, :defence)";
+                SELECT :location_id, :location_name, :attacker, :turn, :defence
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM {$prefix}controller_location_attacks
+                    WHERE attacker_controller_id = :attacker_check
+                      AND location_id = :location_check
+                      AND queued_turn = :turn_check
+                )";
             $stmt = $pdo->prepare($insertSql);
             $stmt->bindParam(':location_id', $target_location_id, PDO::PARAM_INT);
+            $stmt->bindParam(':location_check', $target_location_id, PDO::PARAM_INT);
             $stmt->bindParam(':location_name', $location[0]['name'], PDO::PARAM_STR);
             $stmt->bindParam(':attacker', $controller_id, PDO::PARAM_INT);
+            $stmt->bindParam(':attacker_check', $controller_id, PDO::PARAM_INT);
             $stmt->bindParam(':turn', $turn_number, PDO::PARAM_INT);
+            $stmt->bindParam(':turn_check', $turn_number, PDO::PARAM_INT);
             $stmt->bindParam(':defence', $locationDefence, PDO::PARAM_INT);
             $stmt->execute();
+            if ($stmt->rowCount() === 0) {
+                return array('success' => false, 'queued' => false, 'message' => 'Attaque déjà planifiée ce tour.');
+            }
         } catch (PDOException $e) {
             echo __FUNCTION__."(): INSERT controller_location_attacks Failed: " . $e->getMessage()."<br />";
             return array('success' => false, 'message' => 'Error : Queue Failed');

--- a/mechanics/functions.php
+++ b/mechanics/functions.php
@@ -4,6 +4,7 @@ require_once '../mechanics/aiMechanic.php';
 require_once '../mechanics/attackMechanic.php';
 require_once '../mechanics/claimMechanic.php';
 require_once '../mechanics/investigateMechanic.php';
+require_once '../mechanics/locationAttackMechanic.php';
 require_once '../mechanics/locationSearchMechanic.php';
 
 /**

--- a/mechanics/locationAttackMechanic.php
+++ b/mechanics/locationAttackMechanic.php
@@ -16,7 +16,7 @@
 function failQueuedLocationAttack($pdo, array $queue_row, $turn_number, $reason) {
     $prefix = $_SESSION['GAME_PREFIX'];
     $textKey = $reason === 'moved' ? 'textLocationAttackMoved' : 'textLocationAttackDestroyed';
-    $attackerText = (string)getConfig($pdo, $textKey);
+    $attackerText = sprintf((string)getConfig($pdo, $textKey), $queue_row['location_name']);
 
     try {
         $u = $pdo->prepare("UPDATE {$prefix}controller_location_attacks

--- a/mechanics/locationAttackMechanic.php
+++ b/mechanics/locationAttackMechanic.php
@@ -1,10 +1,60 @@
 <?php
 
 /**
- * 
+ * Mark a queued end-turn location attack as failed and write an
+ * attacker-only log entry. Used by both the cascade-destroyed branch
+ * in locationAttackMechanic() and the cancel-on-move path in moveBase().
+ *
+ * @param PDO    $pdo
+ * @param array  $queue_row controller_location_attacks row (needs id,
+ *                          location_name, attacker_controller_id)
+ * @param int    $turn_number
+ * @param string $reason     'destroyed' | 'moved'
+ *
+ * @return bool
+ */
+function failQueuedLocationAttack($pdo, array $queue_row, $turn_number, $reason) {
+    $prefix = $_SESSION['GAME_PREFIX'];
+    $textKey = $reason === 'moved' ? 'textLocationAttackMoved' : 'textLocationAttackDestroyed';
+    $attackerText = (string)getConfig($pdo, $textKey);
+
+    try {
+        $u = $pdo->prepare("UPDATE {$prefix}controller_location_attacks
+            SET success = :success, resolved_turn = :turn
+            WHERE id = :id");
+        $false = false;
+        $u->bindParam(':success', $false, PDO::PARAM_BOOL);
+        $u->bindParam(':turn', $turn_number, PDO::PARAM_INT);
+        $u->bindParam(':id', $queue_row['id'], PDO::PARAM_INT);
+        $u->execute();
+    } catch (PDOException $e) {
+        echo __FUNCTION__."(): UPDATE controller_location_attacks Failed: " . $e->getMessage()."<br />";
+        return false;
+    }
+
+    try {
+        $log = $pdo->prepare("INSERT INTO {$prefix}location_attack_logs
+            (target_controller_id, location_name, attacker_id, attack_val, defence_val,
+             turn, success, target_result_text, attacker_result_text)
+            VALUES (NULL, :location_name, :attacker_id, 0, 0, :turn, 0, '', :attacker_text)");
+        $log->bindParam(':location_name', $queue_row['location_name'], PDO::PARAM_STR);
+        $log->bindParam(':attacker_id', $queue_row['attacker_controller_id'], PDO::PARAM_INT);
+        $log->bindParam(':turn', $turn_number, PDO::PARAM_INT);
+        $log->bindParam(':attacker_text', $attackerText, PDO::PARAM_STR);
+        $log->execute();
+    } catch (PDOException $e) {
+        echo __FUNCTION__."(): INSERT location_attack_logs Failed: " . $e->getMessage()."<br />";
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ *
  * @param PDO $pdo
  * @param int $turn_number
- * 
+ *
  * @return array $return
  */
 function locationAttackMechanic($pdo, $turn_number) {
@@ -18,9 +68,10 @@ function locationAttackMechanic($pdo, $turn_number) {
     }
 
     try {
-        $stmt = $pdo->prepare("SELECT id, location_id, attacker_controller_id
+        $stmt = $pdo->prepare("SELECT id, location_id, location_name, attacker_controller_id
             FROM {$prefix}controller_location_attacks
-            WHERE queued_turn = :turn AND success IS NULL");
+            WHERE queued_turn = :turn AND success IS NULL
+            ORDER BY id ASC");
         $stmt->bindParam(':turn', $turn_number, PDO::PARAM_INT);
         $stmt->execute();
         $queued = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -36,7 +87,10 @@ function locationAttackMechanic($pdo, $turn_number) {
             WHERE l.id = :id LIMIT 1");
         $locStmt->execute([':id' => $row['location_id']]);
         $location = $locStmt->fetch(PDO::FETCH_ASSOC);
-        if (!$location) continue;
+        if (!$location) {
+            failQueuedLocationAttack($pdo, $row, $turn_number, 'destroyed');
+            continue;
+        }
 
         $zone_id = $location['zone_id'];
         $resolvedAttack = calculatecontrollerAttack($pdo, $zone_id, $row['attacker_controller_id']);

--- a/tests/test_attack_location_baseline_e2e.py
+++ b/tests/test_attack_location_baseline_e2e.py
@@ -1167,3 +1167,101 @@ class TestEndTurnCascadeDestroyed:
             f"attacker_result_text should contain destroyed-text; "
             f"got {log['attacker_result_text']!r}"
         )
+
+
+class TestMoveBaseCancelsInFlightAttacks:
+    """When moveBase fires while in-flight queued end-turn attacks
+    target the base, those attacks must be cancelled via
+    failQueuedLocationAttack with reason='moved'. Defender-invisible
+    (target_controller_id=NULL); attacker_result_text uses
+    textLocationAttackMoved config text.
+
+    Uses a synthetic base + synthetic queue row + gm-privileged
+    /controllers/action.php?moveBase=… URL to isolate from other state."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def move_cancel_state(self, browser):
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+        _set_config_via_ui(page, "locationAttackMode", "endTurn")
+        foxtrot_id = _controller_id_via_management(page, "Foxtrot")
+        echo_id = _controller_id_via_management(page, "Echo")
+
+        conn = _db_conn()
+        cur = conn.cursor()
+        cur.execute(f"SELECT turncounter FROM `{GAME_PREFIX}mechanics` LIMIT 1")
+        turn = cur.fetchone()['turncounter']
+        cur.execute(f"SELECT id FROM `{GAME_PREFIX}zones` LIMIT 2")
+        zones = cur.fetchall()
+        zone_origin = zones[0]['id']
+        zone_target = zones[1]['id']
+        cur.execute(
+            f"INSERT INTO `{GAME_PREFIX}locations` "
+            f"(name, description, zone_id, controller_id, can_be_destroyed, is_base) "
+            f"VALUES ('SyntheticMovedBase', 'temp', %s, %s, 1, 1)",
+            (zone_origin, echo_id),
+        )
+        synthetic_id = cur.lastrowid
+        cur.execute(
+            f"INSERT INTO `{GAME_PREFIX}controller_location_attacks` "
+            f"(location_id, location_name, attacker_controller_id, queued_turn, defence_val_snapshot) "
+            f"VALUES (%s, 'SyntheticMovedBase', %s, %s, 0)",
+            (synthetic_id, foxtrot_id, turn),
+        )
+        queue_row_id = cur.lastrowid
+        conn.commit()
+        cur.close()
+        conn.close()
+
+        safe_goto(
+            page,
+            f"{PHP_BASE_URL}/controllers/action.php"
+            f"?moveBase=1&base_id={synthetic_id}&zone_id={zone_target}&controller_id={echo_id}",
+        )
+        page.wait_for_load_state("load")
+
+        _set_config_via_ui(page, "locationAttackMode", "immediate")
+        assert_no_collected_php_errors(page)
+        context.close()
+
+        conn = _db_conn()
+        cur = conn.cursor()
+        cur.execute(
+            f"SELECT * FROM `{GAME_PREFIX}controller_location_attacks` WHERE id = %s",
+            (queue_row_id,),
+        )
+        queue_row_post = cur.fetchone()
+        cur.execute(
+            f"SELECT * FROM `{GAME_PREFIX}location_attack_logs` "
+            f"WHERE location_name = 'SyntheticMovedBase' AND attacker_id = %s",
+            (foxtrot_id,),
+        )
+        log_rows = cur.fetchall()
+        cur.close()
+        conn.close()
+
+        type(self)._queue_row_post = queue_row_post
+        type(self)._log_rows = log_rows
+        yield
+
+    def test_move_cancels_in_flight_attack(self):
+        """Combined assertion: queue row resolved-failed; log entry
+        defender-invisible with textLocationAttackMoved message."""
+        assert self._queue_row_post['success'] == 0, (
+            f"Queue row should be success=0; got {self._queue_row_post['success']}"
+        )
+        assert self._queue_row_post['resolved_turn'] is not None
+        assert len(self._log_rows) == 1, (
+            f"Expected exactly one log row; got {len(self._log_rows)}"
+        )
+        log = self._log_rows[0]
+        assert log['target_controller_id'] is None, (
+            f"target_controller_id must be NULL (defender-invisible); "
+            f"got {log['target_controller_id']}"
+        )
+        assert 'déplacée' in (log['attacker_result_text'] or ''), (
+            f"attacker_result_text should contain moved-text; "
+            f"got {log['attacker_result_text']!r}"
+        )

--- a/tests/test_attack_location_baseline_e2e.py
+++ b/tests/test_attack_location_baseline_e2e.py
@@ -1163,8 +1163,12 @@ class TestEndTurnCascadeDestroyed:
             f"target_controller_id must be NULL (defender-invisible); "
             f"got {log['target_controller_id']}"
         )
-        assert 'détruite' in (log['attacker_result_text'] or ''), (
+        assert 'détruit' in (log['attacker_result_text'] or ''), (
             f"attacker_result_text should contain destroyed-text; "
+            f"got {log['attacker_result_text']!r}"
+        )
+        assert 'SyntheticCascadeTarget' in (log['attacker_result_text'] or ''), (
+            f"attacker_result_text should embed the location name; "
             f"got {log['attacker_result_text']!r}"
         )
 
@@ -1261,8 +1265,12 @@ class TestMoveBaseCancelsInFlightAttacks:
             f"target_controller_id must be NULL (defender-invisible); "
             f"got {log['target_controller_id']}"
         )
-        assert 'déplacée' in (log['attacker_result_text'] or ''), (
+        assert 'déplacé' in (log['attacker_result_text'] or ''), (
             f"attacker_result_text should contain moved-text; "
+            f"got {log['attacker_result_text']!r}"
+        )
+        assert 'SyntheticMovedBase' in (log['attacker_result_text'] or ''), (
+            f"attacker_result_text should embed the location name; "
             f"got {log['attacker_result_text']!r}"
         )
 

--- a/tests/test_attack_location_baseline_e2e.py
+++ b/tests/test_attack_location_baseline_e2e.py
@@ -1073,3 +1073,97 @@ class TestAttackModeDisabled:
         assert re.search(r"locationAttackMechanic : mode 'foobar'.*not supported, skipped", self._eot_html), (
             "EOT page should contain the locationAttackMechanic skip-warning"
         )
+
+
+class TestEndTurnCascadeDestroyed:
+    """When a queued end-turn attack's target no longer exists at
+    resolution time (cascade from prior successful attack — FK
+    ON DELETE SET NULL blanks the queue row's location_id), the row
+    must be marked success=0/resolved_turn AND an attacker-only log
+    entry must be written using the textLocationAttackDestroyed
+    config text. Defender-invisible: target_controller_id=NULL.
+
+    Uses a synthetic location + synthetic queue row to isolate from
+    the rest of the file's location-attack state."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def cascade_state(self, browser):
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+        _set_config_via_ui(page, "locationAttackMode", "endTurn")
+        foxtrot_id = _controller_id_via_management(page, "Foxtrot")
+
+        conn = _db_conn()
+        cur = conn.cursor()
+        cur.execute(f"SELECT turncounter FROM `{GAME_PREFIX}mechanics` LIMIT 1")
+        turn = cur.fetchone()['turncounter']
+        cur.execute(f"SELECT id FROM `{GAME_PREFIX}zones` LIMIT 1")
+        zone_id = cur.fetchone()['id']
+        cur.execute(
+            f"INSERT INTO `{GAME_PREFIX}locations` "
+            f"(name, description, zone_id, controller_id, can_be_destroyed, is_base) "
+            f"VALUES ('SyntheticCascadeTarget', 'temp', %s, %s, 1, 1)",
+            (zone_id, foxtrot_id),
+        )
+        synthetic_id = cur.lastrowid
+        cur.execute(
+            f"INSERT INTO `{GAME_PREFIX}controller_location_attacks` "
+            f"(location_id, location_name, attacker_controller_id, queued_turn, defence_val_snapshot) "
+            f"VALUES (%s, 'SyntheticCascadeTarget', %s, %s, 0)",
+            (synthetic_id, foxtrot_id, turn),
+        )
+        queue_row_id = cur.lastrowid
+        cur.execute(
+            f"DELETE FROM `{GAME_PREFIX}locations` WHERE id = %s",
+            (synthetic_id,),
+        )
+        conn.commit()
+        cur.close()
+        conn.close()
+
+        end_turn(page, PHP_BASE_URL)
+        _set_config_via_ui(page, "locationAttackMode", "immediate")
+        assert_no_collected_php_errors(page)
+        context.close()
+
+        conn = _db_conn()
+        cur = conn.cursor()
+        cur.execute(
+            f"SELECT * FROM `{GAME_PREFIX}controller_location_attacks` WHERE id = %s",
+            (queue_row_id,),
+        )
+        queue_row_post = cur.fetchone()
+        cur.execute(
+            f"SELECT * FROM `{GAME_PREFIX}location_attack_logs` "
+            f"WHERE location_name = 'SyntheticCascadeTarget' AND attacker_id = %s",
+            (foxtrot_id,),
+        )
+        log_rows = cur.fetchall()
+        cur.close()
+        conn.close()
+
+        type(self)._queue_row_post = queue_row_post
+        type(self)._log_rows = log_rows
+        yield
+
+    def test_cascade_destroyed_fails_and_logs(self):
+        """Combined assertion: queue row resolved-failed; log entry
+        defender-invisible with textLocationAttackDestroyed message."""
+        assert self._queue_row_post['success'] == 0, (
+            f"Queue row should be success=0; got {self._queue_row_post['success']}"
+        )
+        assert self._queue_row_post['resolved_turn'] is not None
+        assert len(self._log_rows) == 1, (
+            f"Expected exactly one log row; got {len(self._log_rows)}"
+        )
+        log = self._log_rows[0]
+        assert log['target_controller_id'] is None, (
+            f"target_controller_id must be NULL (defender-invisible); "
+            f"got {log['target_controller_id']}"
+        )
+        assert 'détruite' in (log['attacker_result_text'] or ''), (
+            f"attacker_result_text should contain destroyed-text; "
+            f"got {log['attacker_result_text']!r}"
+        )

--- a/tests/test_attack_location_baseline_e2e.py
+++ b/tests/test_attack_location_baseline_e2e.py
@@ -1265,3 +1265,72 @@ class TestMoveBaseCancelsInFlightAttacks:
             f"attacker_result_text should contain moved-text; "
             f"got {log['attacker_result_text']!r}"
         )
+
+
+class TestDuplicateQueueAttemptRejected:
+    """Backend INSERT WHERE NOT EXISTS guard at attackLocation() must
+    prevent duplicate (attacker, location, queued_turn) queue rows.
+    Two URL hits with identical params → exactly one queue row exists."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def duplicate_state(self, browser):
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+        _set_config_via_ui(page, "locationAttackMode", "endTurn")
+        foxtrot_id = _controller_id_via_management(page, "Foxtrot")
+        echo_id = _controller_id_via_management(page, "Echo")
+
+        conn = _db_conn()
+        cur = conn.cursor()
+        cur.execute(f"SELECT turncounter FROM `{GAME_PREFIX}mechanics` LIMIT 1")
+        turn = cur.fetchone()['turncounter']
+        cur.execute(f"SELECT id FROM `{GAME_PREFIX}zones` LIMIT 1")
+        zone_id = cur.fetchone()['id']
+        cur.execute(
+            f"INSERT INTO `{GAME_PREFIX}locations` "
+            f"(name, description, zone_id, controller_id, can_be_destroyed, is_base) "
+            f"VALUES ('SyntheticDupTarget', 'temp', %s, %s, 1, 1)",
+            (zone_id, echo_id),
+        )
+        synthetic_id = cur.lastrowid
+        conn.commit()
+        cur.close()
+        conn.close()
+
+        url = (
+            f"{PHP_BASE_URL}/controllers/action.php"
+            f"?attackLocation=1&controller_id={foxtrot_id}&target_location_id={synthetic_id}"
+        )
+        safe_goto(page, url)
+        page.wait_for_load_state("load")
+        safe_goto(page, url)
+        page.wait_for_load_state("load")
+
+        _set_config_via_ui(page, "locationAttackMode", "immediate")
+        assert_no_collected_php_errors(page)
+        context.close()
+
+        conn = _db_conn()
+        cur = conn.cursor()
+        cur.execute(
+            f"SELECT * FROM `{GAME_PREFIX}controller_location_attacks` "
+            f"WHERE attacker_controller_id = %s AND location_id = %s AND queued_turn = %s",
+            (foxtrot_id, synthetic_id, turn),
+        )
+        queue_rows = cur.fetchall()
+        cur.close()
+        conn.close()
+
+        type(self)._queue_rows = queue_rows
+        yield
+
+    def test_duplicate_url_attack_inserts_only_one_row(self):
+        """Two URL hits with same (attacker, location, turn) → exactly
+        one queue row (backend INSERT WHERE NOT EXISTS guard fires on
+        the second attempt)."""
+        assert len(self._queue_rows) == 1, (
+            f"Expected exactly one queue row after duplicate URL hit; "
+            f"got {len(self._queue_rows)}"
+        )

--- a/var/mysql/minimalData.sql
+++ b/var/mysql/minimalData.sql
@@ -138,6 +138,8 @@ VALUES
     ('textLocationAttackOutcomeWeak', 'Faibles chances.', 'Predicted-outcome band when current attack is within bandwidth of snapshot defence'),
     ('textLocationAttackOutcomeProbable', 'Réussite probable.', 'Predicted-outcome band when current attack is well above snapshot defence'),
     ('textLocationAttackResolved', 'Attaque sur %s en fin de tour %d : %s.', 'End-of-turn resolved-attack message. Placeholders. location name, resolved_turn, outcome text'),
+    ('textLocationAttackDestroyed', 'La cible a été détruite avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack arrives after a prior attack in the same turn destroyed the target.'),
+    ('textLocationAttackMoved', 'La base avait été déplacée avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack is cancelled because the target base moved before resolution.'),
     ('textOwnedArtefacts', 'Vos artefacts :', 'Text for location owned artefacts'),
     -- Ressource management
     ('ressource_management', 'TRUE', 'Ressource management configuration')

--- a/var/mysql/minimalData.sql
+++ b/var/mysql/minimalData.sql
@@ -138,8 +138,8 @@ VALUES
     ('textLocationAttackOutcomeWeak', 'Faibles chances.', 'Predicted-outcome band when current attack is within bandwidth of snapshot defence'),
     ('textLocationAttackOutcomeProbable', 'Réussite probable.', 'Predicted-outcome band when current attack is well above snapshot defence'),
     ('textLocationAttackResolved', 'Attaque sur %s en fin de tour %d : %s.', 'End-of-turn resolved-attack message. Placeholders. location name, resolved_turn, outcome text'),
-    ('textLocationAttackDestroyed', 'La cible a été détruite avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack arrives after a prior attack in the same turn destroyed the target.'),
-    ('textLocationAttackMoved', 'La base avait été déplacée avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack is cancelled because the target base moved before resolution.'),
+    ('textLocationAttackDestroyed', 'Le lieu %1$s a été détruit avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack arrives after a prior attack in the same turn destroyed the target. Placeholder: %1$s = location name.'),
+    ('textLocationAttackMoved', 'Le lieu %1$s avait été déplacé avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack is cancelled because the target base moved before resolution. Placeholder: %1$s = location name.'),
     ('textOwnedArtefacts', 'Vos artefacts :', 'Text for location owned artefacts'),
     -- Ressource management
     ('ressource_management', 'TRUE', 'Ressource management configuration')

--- a/var/mysql/setupBDD.sql
+++ b/var/mysql/setupBDD.sql
@@ -150,7 +150,8 @@ CREATE TABLE {prefix}controller_location_attacks (
     defence_val_resolved INT DEFAULT NULL,
     resolved_turn INT DEFAULT NULL,
     FOREIGN KEY (location_id) REFERENCES {prefix}locations (id) ON DELETE SET NULL,
-    FOREIGN KEY (attacker_controller_id) REFERENCES {prefix}controllers (id)
+    FOREIGN KEY (attacker_controller_id) REFERENCES {prefix}controllers (id),
+    UNIQUE (attacker_controller_id, location_id, queued_turn)
 );
 CREATE INDEX idx_controller_location_attacks_location_id ON {prefix}controller_location_attacks (location_id);
 CREATE INDEX idx_controller_location_attacks_attacker_controller_id ON {prefix}controller_location_attacks (attacker_controller_id);

--- a/var/postgres/minimalData.sql
+++ b/var/postgres/minimalData.sql
@@ -34,6 +34,7 @@ VALUES
     ('recrutement_transformation', '{"action": "check"}', 'Json string calibrating transformations allowed on recrutment'),
     ('age_discipline', '{"age": ["2"]}', 'If disciplines can be gained with AGE'),
     ('age_transformation', '{"action": "check"}', 'If transformation can be gained with AGE'),
+    ('owner_knows_own_base_secret', 'TRUE', 'On base creation / scenario load, seed controller_known_locations with found_secret=TRUE so owners auto-know their own base secrets. Set FALSE for fog-of-war setups where the owner must learn their own base secret separately.'),
     ('MINROLL', '1', 'Minimum Roll for an active worker'),
     ('MAXROLL', '6', 'Maximum Roll for a an active worker'),
     ('PASSIVEVAL', '3', 'Value for passive actions'),

--- a/var/postgres/minimalData.sql
+++ b/var/postgres/minimalData.sql
@@ -126,6 +126,8 @@ VALUES
     ('textLocationAttackOutcomeWeak', 'Faibles chances.', 'Predicted-outcome band when current attack is within bandwidth of snapshot defence'),
     ('textLocationAttackOutcomeProbable', 'Réussite probable.', 'Predicted-outcome band when current attack is well above snapshot defence'),
     ('textLocationAttackResolved', 'Attaque sur %s en fin de tour %d : %s.', 'End-of-turn resolved-attack message. Placeholders. location name, resolved_turn, outcome text'),
+    ('textLocationAttackDestroyed', 'La cible a été détruite avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack arrives after a prior attack in the same turn destroyed the target.'),
+    ('textLocationAttackMoved', 'La base avait été déplacée avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack is cancelled because the target base moved before resolution.'),
     ('textOwnedArtefacts', 'Vos artefacts :', 'Text for location owned artefacts'),
     ('ressource_management', 'TRUE', 'Ressource management configuration')
 ON CONFLICT (name) DO NOTHING;

--- a/var/postgres/minimalData.sql
+++ b/var/postgres/minimalData.sql
@@ -126,8 +126,8 @@ VALUES
     ('textLocationAttackOutcomeWeak', 'Faibles chances.', 'Predicted-outcome band when current attack is within bandwidth of snapshot defence'),
     ('textLocationAttackOutcomeProbable', 'Réussite probable.', 'Predicted-outcome band when current attack is well above snapshot defence'),
     ('textLocationAttackResolved', 'Attaque sur %s en fin de tour %d : %s.', 'End-of-turn resolved-attack message. Placeholders. location name, resolved_turn, outcome text'),
-    ('textLocationAttackDestroyed', 'La cible a été détruite avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack arrives after a prior attack in the same turn destroyed the target.'),
-    ('textLocationAttackMoved', 'La base avait été déplacée avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack is cancelled because the target base moved before resolution.'),
+    ('textLocationAttackDestroyed', 'Le lieu %1$s a été détruit avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack arrives after a prior attack in the same turn destroyed the target. Placeholder: %1$s = location name.'),
+    ('textLocationAttackMoved', 'Le lieu %1$s avait été déplacé avant notre arrivée.', 'Attacker-only log line when an end-turn queued attack is cancelled because the target base moved before resolution. Placeholder: %1$s = location name.'),
     ('textOwnedArtefacts', 'Vos artefacts :', 'Text for location owned artefacts'),
     ('ressource_management', 'TRUE', 'Ressource management configuration')
 ON CONFLICT (name) DO NOTHING;

--- a/var/postgres/setupBDD.sql
+++ b/var/postgres/setupBDD.sql
@@ -148,7 +148,8 @@ CREATE TABLE {prefix}controller_location_attacks (
     defence_val_resolved INT DEFAULT NULL,
     resolved_turn INT DEFAULT NULL,
     FOREIGN KEY (location_id) REFERENCES {prefix}locations (id) ON DELETE SET NULL,
-    FOREIGN KEY (attacker_controller_id) REFERENCES {prefix}controllers (id)
+    FOREIGN KEY (attacker_controller_id) REFERENCES {prefix}controllers (id),
+    UNIQUE (attacker_controller_id, location_id, queued_turn)
 );
 CREATE INDEX idx_controller_location_attacks_location_id ON {prefix}controller_location_attacks (location_id);
 CREATE INDEX idx_controller_location_attacks_attacker_controller_id ON {prefix}controller_location_attacks (attacker_controller_id);


### PR DESCRIPTION
## Summary

Implements all 5 sections of #55 in 4 commits.

- **Postgres seed parity** (`dc67c25`) — adds missing `owner_knows_own_base_secret` config row to `var/postgres/minimalData.sql` so Postgres deployments behave consistently with MySQL.
- **Deterministic end-turn resolution** (`ec148b1`) — `ORDER BY id ASC` in the queue SELECT (chronological order matters for cascade), plus new shared helper `failQueuedLocationAttack` in `mechanics/locationAttackMechanic.php` for the destroyed-cascade case. New config keys `textLocationAttackDestroyed` / `textLocationAttackMoved`.
- **moveBase cancel-on-move** (`760c5d6`) — when a base is moved while in-flight end-turn attacks target it, those attacks are cancelled via `failQueuedLocationAttack(reason='moved')`. Active intent, zero false positives. (Replaces the proposed `setup_turn > queued_turn` mechanism which is mathematically broken — see #55 design pivot note.)
- **Duplicate-queue guard** (`38ee9b0`) — `INSERT WHERE NOT EXISTS` in `attackLocation()` blocks direct-URL duplicate queue rows; `UNIQUE (attacker_controller_id, location_id, queued_turn)` on `controller_location_attacks` adds DB-level defence-in-depth for new games.

## Defender-invisible failures

Cancel-on-move and cascade-destroyed log entries are written to `location_attack_logs` with `target_controller_id=NULL` so they only appear in the attacker's outgoing-attacks tab on `controllers/view.php`. No view.php changes needed — existing render handles them.

## Tests

Three negative E2E tests added to `tests/test_attack_location_baseline_e2e.py`:
- `TestEndTurnCascadeDestroyed` — cascade-destroyed row marked resolved-failed + attacker-only log entry.
- `TestMoveBaseCancelsInFlightAttacks` — moveBase cancels in-flight queue rows + attacker-only log entry.
- `TestDuplicateQueueAttemptRejected` — two URL hits with same (attacker, location, turn) → exactly one queue row.

## Test plan

- [x] Local code review in Codium
- [x] GitHub Actions CI green
- [x] Manual: queue attack, owner moves base mid-turn, attacker reload → sees moved-message in outgoing panel
- [x] Manual: two attackers queue against same base, EOT → first destroys, second sees destroyed-message
- [x] Manual: direct URL `attackLocation` twice → second hit returns "Attaque déjà planifiée"

Closes #55