### PR TITLE
chore : PR #77 follow-up cleanups (orphan config + missing bold)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,6 @@ Quand un enquêteur redécouvre un agent ou un lieu déjà connu de son contrôl
 - **`textesAgentUpgradeInfo`** (= `["Nous avons obtenu de nouvelles informations concernant %1$s :"]`) — en-tête visible quand l'enquête courante atteint un niveau `DIFF` supérieur à ce qui était déjà connu ; les slabs nouveaux apparaissent ensuite en clair, les anciens sont repliés.
 - **`textesAgentReminderLabel`** (= `Rappel des informations connues`) — étiquette du `<summary>` qui replie les slabs déjà connus dans la variante « upgrade ».
 - **`textesLocationStillHere`** (= `["Le lieu %1$s est toujours là."]`) — résumé pour un lieu déjà répertorié dans `controller_known_locations` sans nouvelle découverte. `%1$s` = nom du lieu.
-- **`textesLocationReminderLabel`** (= `Rappel des informations connues`) — étiquette du `<summary>` pour les lieux repliés.
 
 ### Combat entre agents
 

--- a/mechanics/locationSearchMechanic.php
+++ b/mechanics/locationSearchMechanic.php
@@ -185,7 +185,6 @@ function locationSearchMechanic($pdo, $mechanics) {
         'locationDescText'            => json_decode(getConfig($pdo, 'TEXT_LOCATION_DISCOVERED_DESCRIPTION'), true),
         'locationDestroyableText'     => json_decode(getConfig($pdo, 'TEXT_LOCATION_CAN_BE_DESTROYED'), true),
         'textesLocationStillHere'     => json_decode(getConfig($pdo, 'textesLocationStillHere'), true),
-        'textesLocationReminderLabel' => getConfig($pdo, 'textesLocationReminderLabel'),
     ];
 
     $textForZoneType = getConfig($pdo, 'textForZoneType');

--- a/ressources/view.php
+++ b/ressources/view.php
@@ -85,7 +85,7 @@ $timeValueLabel = ucfirst(getConfig($gameReady, 'timeValue') ?: 'Tour');
                 <h4 class="title is-6 mt-4"><?= htmlspecialchars($r['ressource_name']) ?></h4>
 <?php if (!$hasAny): ?>
                 <p class="has-text-grey">Aucune règle conditionnelle.</p>
-                <p>Gain de fin de tour fixe : +<?= (int)$r['end_turn_gain'] ?></p>
+                <p>Gain de fin de tour fixe : <strong>+<?= (int)$r['end_turn_gain'] ?></strong></p>
 <?php else: ?>
 <?php if (!empty($rules['before_claim'])): ?>
                 <h5 class="title is-6 has-text-weight-semibold mt-2">Avant la résolution des conquêtes</h5>
@@ -103,7 +103,7 @@ $timeValueLabel = ucfirst(getConfig($gameReady, 'timeValue') ?: 'Tour');
 <?php endforeach; ?>
                 </ul>
 <?php endif; ?>
-                <p class="mt-3">Gain de fin de tour fixe : +<?= (int)$r['end_turn_gain'] ?></p>
+                <p class="mt-3">Gain de fin de tour fixe : <strong>+<?= (int)$r['end_turn_gain'] ?></strong></p>
                 <p>Estimation totale du tour suivant : <strong>+<?= (int)($r['end_turn_gain'] + ($rules['total'] ?? 0)) ?></strong></p>
 <?php endif; ?>
 <?php endforeach; ?>

--- a/var/mysql/minimalData.sql
+++ b/var/mysql/minimalData.sql
@@ -115,7 +115,6 @@ VALUES
     ('textesAgentUpgradeInfo', '["Nous avons obtenu de nouvelles informations concernant %1$s :"]', 'Templates (JSON array) for the "new info on agent" report variant. %1$s = agent name.'),
     ('textesAgentReminderLabel', 'Rappel des informations connues', 'Label inside <details><summary> for folded previously-known agent info.'),
     ('textesLocationStillHere', '["Le lieu %1$s est toujours là."]', 'Templates (JSON array) for the "location still here" report variant. %1$s = location name.'),
-    ('textesLocationReminderLabel', 'Rappel des informations connues', 'Label inside <details><summary> for folded previously-known location info.'),
     -- Action End turn effects
     ('continuing_investigate_action', 1, 'Does the investigate action stay active' ),
     ('continuing_claimed_action', 1, 'Does the claim action stay active' ),

--- a/var/postgres/minimalData.sql
+++ b/var/postgres/minimalData.sql
@@ -104,7 +104,6 @@ VALUES
     ('textesAgentUpgradeInfo', '["Nous avons obtenu de nouvelles informations concernant %1$s :"]', 'Templates (JSON array) for the "new info on agent" report variant. %1$s = agent name.'),
     ('textesAgentReminderLabel', 'Rappel des informations connues', 'Label inside <details><summary> for folded previously-known agent info.'),
     ('textesLocationStillHere', '["Le lieu %1$s est toujours là."]', 'Templates (JSON array) for the "location still here" report variant. %1$s = location name.'),
-    ('textesLocationReminderLabel', 'Rappel des informations connues', 'Label inside <details><summary> for folded previously-known location info.'),
     ('continuing_investigate_action', '1', 'Does the investigate action stay active'),
     ('continuing_claimed_action', '1', 'Does the claim action stay active'),
     ('baseDiscoveryDiff', '3', 'Base discovery value for bases'),


### PR DESCRIPTION
## Summary

Two small cleanups surfaced by the PR #77 self-review pass.

- **Drop orphan `textesLocationReminderLabel` config key** — the key was loaded into the `txtBag` in `mechanics/locationSearchMechanic.php` but never read anywhere. Locations have no V4-upgrade variant by D16 design, so the reminder label is agent-only (`textesAgentReminderLabel` stays). Removed from both `minimalData.sql` seeds, the loader, and the `docs/configuration.md` bullet.
- **Bold the fixed end-turn gain value in `ressources/view.php`** — both `Gain de fin de tour fixe : +X` lines were missing the `<strong>` wrap around the `+value`, while sibling conditional-rule totals and the "Estimation totale" line use `<strong>`. Wrapped both for visual consistency.

## Test plan

- [x] No behaviour change expected — pure orphan removal + display markup tweak.
- [x] Visual check on `ressources/view.php`: both fixed-gain lines render `+N` in bold like the conditional totals.
- [x] Full pytest suite green (no test files touched).