### PR TITLE
fix : prevent self-target on gift forms (ressource, worker, information)

### DIFF
--- a/controllers/action.php
+++ b/controllers/action.php
@@ -119,6 +119,8 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
 
         if (empty($controller_id) || empty($target_controller_id) || empty($enemy_worker_id)) {
             echo '<div class="notification is-warning">Sélection incomplète : faction ou agent manquant.</div>';
+        } else if ((int)$controller_id === (int)$target_controller_id) {
+            echo '<div class="notification is-warning">Faction cible invalide : on ne peut pas se donner d\'information à soi-même.</div>';
         } else {
             $sql = "SELECT zone_id FROM {$prefix}controllers_known_enemies WHERE controller_id = ? AND discovered_worker_id = ?";
             $stmt = $gameReady->prepare($sql);
@@ -136,6 +138,8 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
 
         if (empty($target_controller_id) || empty($location_id) || empty($giver_id)) {
             echo '<div class="notification is-warning">Sélection incomplète : faction ou lieu manquant.</div>';
+        } else if ((int)$giver_id === (int)$target_controller_id) {
+            echo '<div class="notification is-warning">Faction cible invalide : on ne peut pas se donner d\'information à soi-même.</div>';
         } else {
             addLocationToCKL($gameReady, $target_controller_id, $location_id, $mechanics['turncounter'], false);
             logInformationGift($gameReady, $giver_id, $target_controller_id, 'location', $location_id, $mechanics['turncounter']);

--- a/controllers/functions.php
+++ b/controllers/functions.php
@@ -1,44 +1,49 @@
 <?php
 
 /**
- * get all information for Controllers 
+ * get all information for Controllers
  *  - optional by player
  *  - optional for a specific controller
- * 
+ *  - optional exclusion of one controller (e.g. session-active controller for "target" selects)
+ *
  * @param PDO $pdo : database connection
  * @param int|null $player_id
  * @param int|null $controller_id
  * @param bool $hide_secret_controllers default: true
- * 
- * @return array|null 
- * 
+ * @param int|null $exclude_controller_id : drops one controller from the result (used to forbid self-target on gift selects)
+ *
+ * @return array|null
+ *
  */
 // Function to get controllers and return as an array
-function getControllers($pdo, $player_id = NULL, $controller_id = NULL, $hide_secret_controllers = true) {
+function getControllers($pdo, $player_id = NULL, $controller_id = NULL, $hide_secret_controllers = true, $exclude_controller_id = NULL) {
     $controllersArray = array();
     $prefix = $_SESSION['GAME_PREFIX'];
 
     try{
         $sql = "SELECT c.*,
-            f.name AS faction_name, 
+            f.name AS faction_name,
             ff.name AS fake_faction_name
             FROM {$prefix}controllers c
             LEFT JOIN {$prefix}factions f ON c.faction_id = f.ID
             LEFT JOIN {$prefix}factions ff ON c.fake_faction_id = ff.ID";
+        $hasWhere = false;
         if ($player_id !== NULL){
             $sql .= "
                 INNER JOIN {$prefix}player_controller pc ON pc.controller_id = c.id
                 WHERE pc.player_id = '$player_id'";
+            $hasWhere = true;
         }
         if ($controller_id !== NULL){
-            $sql .= sprintf (
-                " %s c.id = '%s'",
-                $player_id !== NULL ? 'AND' : 'WHERE',
-                $controller_id
-            );
+            $sql .= sprintf(' %s c.id = \'%s\'', $hasWhere ? 'AND' : 'WHERE', $controller_id);
+            $hasWhere = true;
         } else if ($hide_secret_controllers == true){
-            $sql .=  ($player_id !== NULL) ? ' AND' : ' WHERE';
-            $sql .= " c.secret_controller IS NOT True";
+            $sql .= sprintf(' %s c.secret_controller IS NOT True', $hasWhere ? 'AND' : 'WHERE');
+            $hasWhere = true;
+        }
+        if ($exclude_controller_id !== NULL){
+            $sql .= sprintf(' %s c.id <> %d', $hasWhere ? 'AND' : 'WHERE', (int) $exclude_controller_id);
+            $hasWhere = true;
         }
         $sql .= ' ORDER BY c.id';
         $stmt = $pdo->prepare($sql);
@@ -1109,7 +1114,7 @@ function buildGiveKnowledgeHTML($pdo, $origin = 'controller', $controller_id = N
         $enemyWorkerOptions
     );
 
-    $controllers = getControllers($pdo, null, null, ($origin != 'admin'));
+    $controllers = getControllers($pdo, null, null, ($origin != 'admin'), ($origin != 'admin') ? $controller_id : NULL);
     $htmlGiftInformationAgent = sprintf('
         <form action="/%s/%s" method="GET">
         <h4 class="title is-5 mt-5">Sur les agents connus:</h4>

--- a/ressources/view.php
+++ b/ressources/view.php
@@ -26,10 +26,7 @@ foreach ($ressourcesList as $r) {
 }
 
 $gainEstimate = ressourceGainEstimateForController($gameReady, $controller_id);
-$visibleFactions = array_values(array_filter(
-    getControllers($gameReady, NULL, NULL, true) ?: [],
-    function ($c) use ($controller_id) { return (int)$c['id'] !== $controller_id; }
-));
+$visibleFactions = getControllers($gameReady, NULL, NULL, true, $controller_id) ?: [];
 $receivedGifts = getRessourceGiftsReceived($gameReady, $controller_id);
 $timeValueLabel = ucfirst(getConfig($gameReady, 'timeValue') ?: 'Tour');
 ?>

--- a/workers/action.php
+++ b/workers/action.php
@@ -145,6 +145,11 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
         activateWorker($gameReady, $worker_id, 'claim', $claim_controller_id);
     }
     if (isset($_GET['gift'])){
+        $session_controller_id = $_SESSION['controller']['id'] ?? null;
+        if (empty($_SESSION['is_privileged']) && $session_controller_id !== null && (int)$gift_controller_id === (int)$session_controller_id) {
+            http_response_code(403);
+            exit();
+        }
         activateWorker($gameReady, $worker_id, 'gift', $gift_controller_id);
         header(sprintf('Location: /%s/workers/viewAll.php', $_SESSION['FOLDER']));
     }

--- a/workers/view.php
+++ b/workers/view.php
@@ -199,7 +199,8 @@ if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {
                 if ($_SESSION['DEBUG'] == true) echo "showZoneSelect: ".var_export($showZoneSelect, true)."<br /><br />";
 
                 $controllers = getControllers($gameReady);
-                $showcontrollersSelect = showControllerSelect($controllers, $controller_id, 'gift_controller_id');
+                $giftControllers = getControllers($gameReady, NULL, NULL, true, $controller_id);
+                $showcontrollersSelect = showControllerSelect($giftControllers, $controller_id, 'gift_controller_id');
 
                 $claim_mode = getConfig($gameReady, 'claimMode');
                 $showListClaimTargetsSelect = '';


### PR DESCRIPTION
## Summary

Players could pick their own faction as the target of three gift forms, which was illogical and caused bugs (self-loop in `controllers_known_enemies` / `controller_known_locations`, no-op ressource transfer, etc.).

- **Worker gift** — `workers/view.php` `gift_controller_id` select listed every controller including self.
- **Information gift on agents / locations** — `controllers/functions.php buildGiveKnowledgeHTML` `target_controller_id` selects listed every controller including self.
- **Ressource gift** — already excluded self via an `array_filter` post-filter on the controller list.

## Approach

Generalised the existing `ressources/view.php` pattern into the helper:

1. **`getControllers`** gains a 5th optional param `$exclude_controller_id` (int|null, default `NULL`). When set, the SQL adds `AND c.id <> %d` to the WHERE clause.
2. **`ressources/view.php`** — `array_filter` block collapsed to `getControllers(..., $controller_id)`. Same behaviour, less code.
3. **`workers/view.php`** — added a separate `$giftControllers` list excluding self. The existing unfiltered `$controllers` stays for the **claim** select (claim-for-self is legitimate — that's just keeping the zone).
4. **`controllers/functions.php buildGiveKnowledgeHTML`** — passes `$controller_id` as the exclude when `$origin != 'admin'` (admin route gifts on behalf of an arbitrary controller, no self to exclude).

### Defence-in-depth (server-side)

Form-level exclusion alone can be bypassed via a crafted GET/POST. Server handlers now reject self-target too:

- **`workers/action.php`** — `gift` branch rejects with 403 if `gift_controller_id == session controller_id` (privileged users bypass).
- **`controllers/action.php`** — both `giftInformationAgent` and `giftInformationLocation` show a French warning notification when `controller_id == target_controller_id` and skip the side-effects.

The ressource gift handler (`ressources/functions.php::giftRessource`) already had the equivalent `$target_id === $giver_id` check.

## Test plan

- [x] Full pytest suite green (413/413 in 20:12).
- [x] Manual: open `ressources/view.php` gift form — own faction absent from "Faction cible" dropdown (already was).
- [x] Manual: open `workers/view.php` worker action panel — own faction absent from "Donner à" gift select, present in "Revendiquer au nom de" claim select.
- [x] Manual: open the give-information modal from controllers view — own faction absent from "Faction à informer" on both agent and location subforms.
- [x] Manual: craft a GET with `target_controller_id == your_controller_id` against `controllers/action.php?giftInformationAgent=1...` and verify the warning notification fires and no CKE/CKL row is written.