### PR TITLE
feat : extend mass actions with investigate / passive / hide (#65)

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -941,6 +941,49 @@ def ui_mass_move_click(page: Page, controller_lastname: str,
     page.wait_for_load_state("load")
 
 
+def _ui_mass_zoneless_action_click(page: Page, controller_lastname: str,
+                                   worker_lastnames: list, action: str,
+                                   base_url: str = None):
+    """Shared driver for the parameter-free mass actions (investigate, passive, hide).
+    Same pre-resolve-then-click pattern as ui_mass_move_click, minus the zone select."""
+    if action not in ('investigate', 'passive', 'hide'):
+        raise ValueError(f"unsupported mass action: {action}")
+    submit_name = f"mass_{action}"
+    url = base_url or PHP_BASE_URL
+    ensure_gm_login(page, url)
+    cid = ui_controller_id(page, controller_lastname, base_url=url)
+    worker_ids = [_cached_wid(page, ln, base_url) for ln in worker_lastnames]
+    safe_goto(page, f"{url}/base/accueil.php?controller_id={cid}&chosir=Choisir")
+    _wait_loaded(page, "div.header")
+    safe_goto(page, f"{url}/workers/viewAll.php")
+    _wait_loaded(page, f"input[name='{submit_name}']")
+    for wid in worker_ids:
+        page.locator(f"input[name='worker_ids[]'][value='{wid}']").check()
+    page.locator(f"input[name='{submit_name}']").click()
+    page.wait_for_load_state("load")
+
+
+def ui_mass_investigate_click(page: Page, controller_lastname: str,
+                              worker_lastnames: list, base_url: str = None):
+    """UI-button-click for the Mass Investigate form on workers/viewAll.php."""
+    _ui_mass_zoneless_action_click(page, controller_lastname, worker_lastnames,
+                                   'investigate', base_url)
+
+
+def ui_mass_passive_click(page: Page, controller_lastname: str,
+                          worker_lastnames: list, base_url: str = None):
+    """UI-button-click for the Mass Passive form on workers/viewAll.php."""
+    _ui_mass_zoneless_action_click(page, controller_lastname, worker_lastnames,
+                                   'passive', base_url)
+
+
+def ui_mass_hide_click(page: Page, controller_lastname: str,
+                       worker_lastnames: list, base_url: str = None):
+    """UI-button-click for the Mass Hide form on workers/viewAll.php."""
+    _ui_mass_zoneless_action_click(page, controller_lastname, worker_lastnames,
+                                   'hide', base_url)
+
+
 def ui_claim(page: Page, lastname: str, claim_controller_lastname: str,
              base_url: str = None):
     """Queue a claim action targeting `claim_controller_lastname`."""

--- a/tests/test_workers_mass_actions_e2e.py
+++ b/tests/test_workers_mass_actions_e2e.py
@@ -1,0 +1,199 @@
+"""Playwright E2E tests for the mass-action extension on /workers/massAction.php.
+
+Issue #65 — adds mass_investigate / mass_passive / mass_hide alongside the
+existing mass_move button on workers/viewAll.php. The dispatcher loops the
+checked worker_ids[] and calls activateWorker() per worker with the matching
+action_choice. Ownership guard is shared across all four mass actions.
+
+Subjects: Beta's three combat-row workers (Chain_B, Inv_Def_1, Keep_Def) are
+re-used across the happy-path classes — each class re-clicks the mass form
+with a different action and asserts the post-state action_choice. Order
+within the file is alphabetical (Hide → Investigate → Passive) so each class
+overwrites the previous class's setting; this is the same chained-state
+pattern the existing mass-move test relies on.
+
+UI-only / prod-DEMO-runnable.
+
+Run:
+    python3 -m pytest tests/test_workers_mass_actions_e2e.py -v
+"""
+import pytest
+from playwright.sync_api import Page
+
+from conftest import PHP_BASE_URL, ensure_gm_login
+from helpers import (
+    DB_AVAILABLE, load_minimal_data, load_scenario_via_admin, login_as, safe_goto,
+    register_php_error_listener, assert_no_collected_php_errors,
+    ui_worker_id, ui_all_workers,
+    ui_mass_hide_click, ui_mass_investigate_click, ui_mass_passive_click,
+)
+
+
+_MASS_WORKERS = ["Chain_B", "Inv_Def_1", "Keep_Def"]
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return PHP_BASE_URL
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_testconfig(browser):
+    """Load TestConfig once per module."""
+    if DB_AVAILABLE:
+        load_minimal_data()
+    load_scenario_via_admin(browser, PHP_BASE_URL, "TestConfig")
+    yield
+
+
+def _capture_action_choices(page):
+    return {w["lastname"]: w["action_choice"]
+            for w in ui_all_workers(page)
+            if w["lastname"] in _MASS_WORKERS}
+
+
+class TestMassHide:
+    """Mass-hide the 3 Beta combat workers in a single submit;
+    massAction.php loops worker_ids[] and calls activateWorker(_, 'hide')."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def mass_hide_state(self, browser):
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+
+        ui_mass_hide_click(page, "Beta", _MASS_WORKERS)
+
+        post = _capture_action_choices(page)
+
+        assert_no_collected_php_errors(page)
+        context.close()
+        type(self)._post = post
+        yield
+
+    def test_chain_b_action_is_hide(self):
+        assert self._post["Chain_B"] == "hide", (
+            f"Chain_B action_choice should be 'hide' after mass-hide; "
+            f"got {self._post['Chain_B']}"
+        )
+
+    def test_inv_def_1_action_is_hide(self):
+        assert self._post["Inv_Def_1"] == "hide", (
+            f"Inv_Def_1 action_choice should be 'hide' after mass-hide; "
+            f"got {self._post['Inv_Def_1']}"
+        )
+
+    def test_keep_def_action_is_hide(self):
+        assert self._post["Keep_Def"] == "hide", (
+            f"Keep_Def action_choice should be 'hide' after mass-hide; "
+            f"got {self._post['Keep_Def']}"
+        )
+
+
+class TestMassInvestigate:
+    """Mass-investigate the 3 Beta combat workers."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def mass_investigate_state(self, browser):
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+
+        ui_mass_investigate_click(page, "Beta", _MASS_WORKERS)
+
+        post = _capture_action_choices(page)
+
+        assert_no_collected_php_errors(page)
+        context.close()
+        type(self)._post = post
+        yield
+
+    def test_chain_b_action_is_investigate(self):
+        assert self._post["Chain_B"] == "investigate", (
+            f"Chain_B action_choice should be 'investigate' after mass-investigate; "
+            f"got {self._post['Chain_B']}"
+        )
+
+    def test_inv_def_1_action_is_investigate(self):
+        assert self._post["Inv_Def_1"] == "investigate", (
+            f"Inv_Def_1 action_choice should be 'investigate' after mass-investigate; "
+            f"got {self._post['Inv_Def_1']}"
+        )
+
+    def test_keep_def_action_is_investigate(self):
+        assert self._post["Keep_Def"] == "investigate", (
+            f"Keep_Def action_choice should be 'investigate' after mass-investigate; "
+            f"got {self._post['Keep_Def']}"
+        )
+
+
+class TestMassPassive:
+    """Mass-passive the 3 Beta combat workers."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def mass_passive_state(self, browser):
+        context = browser.new_context()
+        page = context.new_page()
+        register_php_error_listener(page)
+        ensure_gm_login(page, PHP_BASE_URL)
+
+        ui_mass_passive_click(page, "Beta", _MASS_WORKERS)
+
+        post = _capture_action_choices(page)
+
+        assert_no_collected_php_errors(page)
+        context.close()
+        type(self)._post = post
+        yield
+
+    def test_chain_b_action_is_passive(self):
+        assert self._post["Chain_B"] == "passive", (
+            f"Chain_B action_choice should be 'passive' after mass-passive; "
+            f"got {self._post['Chain_B']}"
+        )
+
+    def test_inv_def_1_action_is_passive(self):
+        assert self._post["Inv_Def_1"] == "passive", (
+            f"Inv_Def_1 action_choice should be 'passive' after mass-passive; "
+            f"got {self._post['Inv_Def_1']}"
+        )
+
+    def test_keep_def_action_is_passive(self):
+        assert self._post["Keep_Def"] == "passive", (
+            f"Keep_Def action_choice should be 'passive' after mass-passive; "
+            f"got {self._post['Keep_Def']}"
+        )
+
+
+def _resolve_worker_id(browser, base_url, lastname):
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    ensure_gm_login(page, base_url)
+    wid = ui_worker_id(page, lastname, base_url=base_url)
+    ctx.close()
+    return wid
+
+
+@pytest.mark.parametrize("mass_action", ["mass_investigate", "mass_passive", "mass_hide"])
+def test_mass_action_non_owner_returns_403(browser, base_url, mass_action):
+    """single_player owns Alpha; Bystander_1 belongs to Beta. massAction.php
+    must 403 before any activateWorker() call when a non-privileged controller
+    attempts to mass-act on workers they do not own."""
+    bystander_wid = _resolve_worker_id(browser, base_url, "Bystander_1")
+
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    login_as(page, base_url, "single_player", "test")
+    url = (
+        f"{base_url}/workers/massAction.php"
+        f"?{mass_action}=1&worker_ids%5B%5D={bystander_wid}"
+    )
+    response = page.goto(url)
+    assert response is not None
+    assert response.status == 403, (
+        f"Non-owner {mass_action} on a foreign worker must 403; "
+        f"got {response.status}"
+    )
+    ctx.close()

--- a/workers/massAction.php
+++ b/workers/massAction.php
@@ -10,6 +10,8 @@ if (
     exit();
 }
 
+$MASS_ACTIONS = ['mass_move', 'mass_investigate', 'mass_passive', 'mass_hide'];
+
 if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
     if ($_SESSION['DEBUG'] == true) echo "_GET:".var_export($_GET, true)." <br /> <br />";
 
@@ -20,12 +22,15 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
     if ( !empty($_GET['zone_id']) ) $zone_id = $_GET['zone_id'];
     if ( $_SESSION['DEBUG'] == true ) echo "zone_id: ".var_export($zone_id, true)."<br /><br />";
 
-    // Mass move workers to zone
-    if (isset($_GET['mass_move']) && !empty($zone_id) && !empty($worker_ids)){
+    $mass_action_requested = false;
+    foreach ($MASS_ACTIONS as $k) {
+        if (isset($_GET[$k])) { $mass_action_requested = true; break; }
+    }
+
+    if ($mass_action_requested && !empty($worker_ids)) {
         if (!is_array($worker_ids)) { http_response_code(403); exit(); }
         $worker_ids = array_map('intval', $worker_ids);
 
-        // Ownership check: every worker_id must belong to the session controller
         if (empty($_SESSION['is_privileged'])) {
             $session_controller_id = $_SESSION['controller']['id'] ?? null;
             if (empty($session_controller_id)) { http_response_code(403); exit(); }
@@ -47,8 +52,22 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
             }
         }
 
-        foreach ($worker_ids as $worker_id) {
-            moveWorker($gameReady, $worker_id, $zone_id);
+        if (isset($_GET['mass_move']) && !empty($zone_id)) {
+            foreach ($worker_ids as $worker_id) {
+                moveWorker($gameReady, $worker_id, $zone_id);
+            }
+        } else if (isset($_GET['mass_investigate'])) {
+            foreach ($worker_ids as $worker_id) {
+                activateWorker($gameReady, $worker_id, 'investigate');
+            }
+        } else if (isset($_GET['mass_passive'])) {
+            foreach ($worker_ids as $worker_id) {
+                activateWorker($gameReady, $worker_id, 'passive');
+            }
+        } else if (isset($_GET['mass_hide'])) {
+            foreach ($worker_ids as $worker_id) {
+                activateWorker($gameReady, $worker_id, 'hide');
+            }
         }
     }
 }

--- a/workers/viewAll.php
+++ b/workers/viewAll.php
@@ -127,14 +127,14 @@ if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {
                 foreach ($liveWorkerArray as $worker) {
                     echo $worker['view'];
                 }
-                // Mass worker action
-                // Mass move to zone
-                    // Zone select
-                    echo '<div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">';
-                    echo showZoneSelect($gameReady, getZonesArray($gameReady), null, false, false, true);
-                    echo " <div class='control'> <input type='submit' name='mass_move' value='Déplacer les agents sélectionnés' class='button is-warning mb-2 ml-2'></div>";
-                    echo "</div>";
-                    // Submit button
+                echo '<div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">';
+                echo '<div class="control"><label class="label is-small mb-0">Zone cible (pour déplacement uniquement) :</label></div>';
+                echo showZoneSelect($gameReady, getZonesArray($gameReady), null, false, false, true);
+                echo " <div class='control'> <input type='submit' name='mass_move' value='Déplacer les agents sélectionnés' class='button is-warning mb-2 ml-2'></div>";
+                echo " <div class='control'> <input type='submit' name='mass_investigate' value='Enquêter sur les agents sélectionnés' class='button is-info mb-2 ml-2'></div>";
+                echo " <div class='control'> <input type='submit' name='mass_passive' value='Mettre en passif les agents sélectionnés' class='button is-warning mb-2 ml-2'></div>";
+                echo " <div class='control'> <input type='submit' name='mass_hide' value='Cacher les agents sélectionnés' class='button is-danger mb-2 ml-2'></div>";
+                echo "</div>";
                 echo "</form>";
                 echo "</div>";
             }

--- a/workers/viewAll.php
+++ b/workers/viewAll.php
@@ -14,7 +14,13 @@ if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {
     if ( empty($controller_id) ) $controller_id = $_SESSION['controller']['id'];
     if ( $_SESSION['DEBUG'] == true ) echo "controller_id: ".var_export($controller_id, true)."<br /><br />";
 
-    $sort = in_array($_GET['sort'] ?? '', ['age','zone','investigate','attack']) ? $_GET['sort'] : 'age';
+    $validSorts = ['age','zone','investigate','attack'];
+    if (in_array($_GET['sort'] ?? '', $validSorts, true)) {
+        $sort = $_GET['sort'];
+        $_SESSION['workers_view_sort'] = $sort;
+    } else {
+        $sort = $_SESSION['workers_view_sort'] ?? 'age';
+    }
 
     echo "<div class='section workers'>";
         $recruitButton = "";

--- a/workers/viewAll.php
+++ b/workers/viewAll.php
@@ -127,16 +127,27 @@ if ( !empty($_SESSION['controller']) ||  !empty($controller_id) ) {
                 foreach ($liveWorkerArray as $worker) {
                     echo $worker['view'];
                 }
-                echo '<div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">';
-                echo '<div class="control"><label class="label is-small mb-0">Zone cible (pour déplacement uniquement) :</label></div>';
-                echo showZoneSelect($gameReady, getZonesArray($gameReady), null, false, false, true);
-                echo " <div class='control'> <input type='submit' name='mass_move' value='Déplacer les agents sélectionnés' class='button is-warning mb-2 ml-2'></div>";
-                echo " <div class='control'> <input type='submit' name='mass_investigate' value='Enquêter sur les agents sélectionnés' class='button is-info mb-2 ml-2'></div>";
-                echo " <div class='control'> <input type='submit' name='mass_passive' value='Mettre en passif les agents sélectionnés' class='button is-warning mb-2 ml-2'></div>";
-                echo " <div class='control'> <input type='submit' name='mass_hide' value='Cacher les agents sélectionnés' class='button is-danger mb-2 ml-2'></div>";
-                echo "</div>";
-                echo "</form>";
-                echo "</div>";
+                echo sprintf('
+                <div class="control"><strong>Zone cible (pour déplacement uniquement) :</strong></div>
+                <div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">
+                    %s
+                    <div class="control"> 
+                        <input type="submit" name="mass_move" value="Déplacer les agents sélectionnés" class="button is-warning">
+                    </div>
+                </div>
+                <div class="control"><strong>Mettre en place l\'action suivante sur les agents sélectionnés :</strong></div>
+                <div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">
+                    <div class="control"> 
+                        <input type="submit" name="mass_investigate" value="%3$s" class="button is-info">
+                        <input type="submit" name="mass_passive" value="%2$s" class="button is-warning">
+                        <input type="submit" name="mass_hide" value="%4$s" class="button is-danger">
+                </div></div>', 
+                showZoneSelect($gameReady, getZonesArray($gameReady), null, false, false, true), // %1$s
+                ucfirst(getConfig($gameReady, 'txt_inf_passive')), // %2$s
+                ucfirst(getConfig($gameReady, 'txt_inf_investigate')), // %3$s
+                ucfirst(getConfig($gameReady, 'txt_inf_hide')) // %4$s
+                );
+                echo "</form></div>";
             }
 
             if ( !empty($doubleAgentWorkerArray )) {


### PR DESCRIPTION
Closes #65.

## Summary

Players with many agents in one zone previously had to click each agent individually to toggle them all to `passive` / `hide` / `investigate`; only mass-move existed. This PR adds three more submit buttons to the existing form on `workers/viewAll.php`, sharing the same `worker_ids[]` checkbox set.

User-locked design decisions during planning (2026-06-18):
- **Single form, 4 buttons** — same checkboxes, four submits. Zone select stays visible with a clarifying label since it is only used by `mass_move`.
- **Trace/dead guard** — out of scope. `workers/massAction.php` already lacked this single-worker guard for mass-move; the pre-existing inconsistency is kept (not regressing, not opportunistically fixed).
- **Button labels** — French wording mirrors the existing `Déplacer les agents sélectionnés` template.

## Changes

| File | Change |
|---|---|
| `workers/massAction.php` | Hoist the ownership-check block above the dispatch; add 3 new branches (`mass_investigate`, `mass_passive`, `mass_hide`) each looping `worker_ids[]` through `activateWorker($pdo, $wid, $action)`. `mass_move` keeps its `zone_id` requirement. |
| `workers/viewAll.php` | Relabel the zone-select line `Zone cible (pour déplacement uniquement) :`; append 3 submit buttons with Bulma `is-info` / `is-warning` / `is-danger` (mirrors the colour mapping of the single-worker buttons in `workers/view.php:252-254`). |
| `tests/helpers.py` | One private shared driver `_ui_mass_zoneless_action_click` + 3 public helpers (`ui_mass_investigate_click` / `ui_mass_passive_click` / `ui_mass_hide_click`). Same pre-resolve-then-click pattern as `ui_mass_move_click` (Slice-15 navigation rule), minus the zone select. |
| `tests/test_workers_mass_actions_e2e.py` *(NEW)* | 3 happy-path classes (Hide / Investigate / Passive) × 3 assertions on Beta combat workers (Chain_B / Inv_Def_1 / Keep_Def), reading `action_choice` via `ui_all_workers` post-click. Parametrized 403 test covers each new action name (mirrors `test_mass_action_non_owner_returns_403`). |

## Test plan

- [x] Targeted run: `python3 -m pytest tests/test_workers_mass_actions_e2e.py -v` → 12 passed.
- [x] Full suite: `python3 -m pytest tests/ -v` → 425 passed in 22:26 (+12 from baseline 413).
- [x] Manual on demo: as a player, open `workers/viewAll.php`, check 2+ live workers, click each of the 4 buttons in turn. After each reload, the per-worker action label shown by `setWorkerCurrentAction` should reflect the new choice.
- [x] Manual 403 sanity: while logged in as `single_player`, craft `GET /workers/massAction.php?mass_investigate=1&worker_ids[]=<Beta-worker-id>` → expect HTTP 403.

## Out of scope (intentional)

- Mass `attack` / mass `claim` — these need extra params (target enemy, claim controller) so they cannot reuse the parameter-free dispatch pattern.
- A "select all" JS checkbox helper for `worker_ids[]` — useful UX but a separate item.
- Trace/dead guard on the mass dispatcher — pre-existing inconsistency, kept tight to the issue scope.