### PR TITLE
refactor : reuse showWorkerShort in zones/showZoneAgents (#93)

### DIFF
--- a/workers/functions.php
+++ b/workers/functions.php
@@ -387,7 +387,7 @@ function showWorkerShort($pdo, $worker, $mechanics, $showCheckBox = false) {
             data-worker-status="%11$s"
         >
             %8$s
-            <a href="/%7$s/workers/action.php?worker_id=%1$s" class="has-text-weight-semibold is-size-5" role="button" style="text-decoration:none;">
+            <a href="/%7$s/workers/action.php?worker_id=%1$s" class="has-text-weight-semibold" role="button" style="text-decoration:none;">
                 %2$s %3$s
             </a>
             <span>%6$s %5$s %4$s.</span>

--- a/zones/functions.php
+++ b/zones/functions.php
@@ -609,12 +609,13 @@ function calculatecontrollerAttack($pdo, $zone_id, $controller_id = null) {
  * @param PDO $pdo
  * @param int $controller_id          logged-in controller (self perspective)
  * @param int $zone_id
- * @param int $turn_number            current turn (used for ACTIVE_ACTIONS lookup)
+ * @param array $mechanics : must contain key 'turncounter'
  * @param array $controllerWorkers    pre-fetched getWorkersByController result; caller coalesces NULL to []
  *
  * @return string HTML — '' when both sections empty
  */
-function showZoneAgents(PDO $pdo, int $controller_id, int $zone_id, int $turn_number, array $controllerWorkers): string {
+function showZoneAgents(PDO $pdo, int $controller_id, int $zone_id, array $mechanics, array $controllerWorkers): string {
+    $turn_number = (int)$mechanics['turncounter'];
     $friendlies = [];
     $doubles = [];
     foreach ($controllerWorkers as $w) {
@@ -629,27 +630,18 @@ function showZoneAgents(PDO $pdo, int $controller_id, int $zone_id, int $turn_nu
         }
     }
 
-    $folder = $_SESSION['FOLDER'];
     $out = '';
     if (!empty($friendlies)) {
         $out .= '<p><strong>Nos Agents présents :</strong></p><ul>';
         foreach ($friendlies as $w) {
-            $out .= sprintf(
-                '<li><a href="/%s/workers/action.php?worker_id=%d" class="has-text-weight-semibold" role="button" style="text-decoration:none;">%s %s</a> <i>(<strong>%d</strong>, <strong>%d</strong>/<strong>%d</strong>)</i></li>',
-                $folder, $w['id'], $w['firstname'], $w['lastname'],
-                $w['total_enquete'], $w['total_attack'], $w['total_defence']
-            );
+            $out .= '<li>' . showWorkerShort($pdo, $w, $mechanics, false) . '</li>';
         }
         $out .= '</ul>';
     }
     if (!empty($doubles)) {
         $out .= '<details><summary>Nos Agents doubles</summary><ul>';
         foreach ($doubles as $w) {
-            $out .= sprintf(
-                '<li><a href="/%s/workers/action.php?worker_id=%d" class="has-text-weight-semibold" role="button" style="text-decoration:none;">%s %s</a> <i>(<strong>%d</strong>, <strong>%d</strong>/<strong>%d</strong>)</i></li>',
-                $folder, $w['id'], $w['firstname'], $w['lastname'],
-                $w['total_enquete'], $w['total_attack'], $w['total_defence']
-            );
+            $out .= '<li>' . showWorkerShort($pdo, $w, $mechanics, false) . '</li>';
         }
         $out .= '</ul></details>';
     }

--- a/zones/view.php
+++ b/zones/view.php
@@ -55,7 +55,7 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
                 ? showcontrollerKnownSecrets($gameReady, $_SESSION['controller']['id'], $zone['zone_id'])
                 : '';
             $agentLists = !empty($_SESSION['controller']['id'])
-                ? showZoneAgents($gameReady, $_SESSION['controller']['id'], $zone['zone_id'], $mechanics['turncounter'], $controllerWorkers)
+                ? showZoneAgents($gameReady, $_SESSION['controller']['id'], $zone['zone_id'], $mechanics, $controllerWorkers)
                 : '';
             $ourControl = (!empty($_SESSION['controller']['id']) && $zone['holder_controller_id'] == $_SESSION['controller']['id'])
                 ? '<span class="tag is-danger ml-2">Sous notre contrôle</span><br>'


### PR DESCRIPTION
Ferme #93.

## Contexte

`showZoneAgents` (`zones/functions.php`) rendait inline chaque worker ami + double-agent d'une zone via un `sprintf('<li><a ...>')` qui dupliquait la structure de `showWorkerShort` sans l'action courante du worker. Le ticket demandait de réutiliser `showWorkerShort` pour uniformiser le rendering et exposer l'action inline dans la vue zone.

## Changements

### `refactor : reuse showWorkerShort in showZoneAgents (#93)`

- Signature de `showZoneAgents` change : `int $turn_number` → `array $mechanics` (showWorkerShort attend `$mechanics` complet).
- Remplacement des 2 blocs `sprintf('<li><a ...>')` par `'<li>' . showWorkerShort($pdo, $w, $mechanics, false) . '</li>'`.
- `$folder = $_SESSION['FOLDER']` supprimé (plus utilisé après le remplacement).
- Un seul caller (`zones/view.php:58`) adapté.
- Section "Agents ennemis repérés" inchangée : les données d'ennemis n'ont pas les stats/action requis par showWorkerShort.

Gains fonctionnels :
- L'action courante du worker apparaît dans la vue zone (objectif principal du ticket).
- Cohérence visuelle avec `allworkers.php` (mêmes divs `worker-short`, mêmes data-attributes exploitables par JS).

Net : -8 LOC, 1 fonction refactorée, 1 caller adapté.

### `style : drop is-size-5 on showWorkerShort link`

Test rendering dans les zones a montré que le link taille 5 était trop imposant en mode liste dense. Ajustement global (allworkers.php et tout autre appelant de showWorkerShort) — la taille normale + weight semibold reste lisible.

## Test plan

- [ ] Full pytest local (525+ tests) avant merge.
- [ ] Vérifier CI GitHub Actions.
- [ ] Sanity manuelle : vue zone affiche bien firstname/lastname + action courante + stats pour agents amis + doubles ; allworkers.php inchangé.