### PR TITLE
Route PHP errors to game_error_log + admin log viewer

### DIFF
--- a/BDD/db_connector.php
+++ b/BDD/db_connector.php
@@ -345,6 +345,7 @@ function loadCSVFile(PDO $pdo, string $csvFile, string $tableName, array $column
     $prefixedTable = $prefix . $tableName;
 
     if (!file_exists($csvFile)) {
+        game_error_log(__FUNCTION__, 'CSV file not found : ' . $csvFile, ['csvFile' => $csvFile, 'tableName' => $tableName], 'error');
         echo "CSV file $csvFile not found.<br />";
         return false;
     }
@@ -352,6 +353,7 @@ function loadCSVFile(PDO $pdo, string $csvFile, string $tableName, array $column
     try {
         $handle = fopen($csvFile, 'r');
         if ($handle === false) {
+            game_error_log(__FUNCTION__, 'fopen failed on CSV : ' . $csvFile, ['csvFile' => $csvFile, 'tableName' => $tableName], 'error');
             echo "Failed to open CSV file $csvFile.<br />";
             return false;
         }
@@ -622,6 +624,7 @@ function loadWorkersCSV(PDO $pdo, string $csvFile): bool {
     $prefix = $_SESSION['GAME_PREFIX'];
 
     if (!file_exists($csvFile)) {
+        game_error_log(__FUNCTION__, 'Workers CSV file not found : ' . $csvFile, ['csvFile' => $csvFile], 'error');
         echo "Workers CSV file $csvFile not found.<br />";
         return false;
     }
@@ -629,6 +632,7 @@ function loadWorkersCSV(PDO $pdo, string $csvFile): bool {
     try {
         $handle = fopen($csvFile, 'r');
         if ($handle === false) {
+            game_error_log(__FUNCTION__, 'fopen failed on workers CSV : ' . $csvFile, ['csvFile' => $csvFile], 'error');
             echo "Failed to open workers CSV $csvFile.<br />";
             return false;
         }

--- a/BDD/db_connector.php
+++ b/BDD/db_connector.php
@@ -1,7 +1,14 @@
 <?php
 
 
-function getPath ($file) {
+/**
+ * Resolves the directory containing a given config filename.
+ *
+ * @param string $file : config filename with leading slash (e.g. "/var/config.ini")
+ *
+ * @return string|null : matching directory or null when no candidate contains the file
+ */
+function getPath(string $file): string|null {
 
     $path = null;
     $paths = array( __DIR__ ,"..", ".", "/var/www/RPGConquestGame");
@@ -19,12 +26,14 @@ function getPath ($file) {
 }
 
 /**
- * Loads DB config from file or defaults
- * @param string $path
- * @param string $configFile
- * @return array
+ * Loads DB config from file, falling back to defaults for missing keys.
+ *
+ * @param string|null $path : directory containing the config file (nullable when getPath found nothing)
+ * @param string $configFile : config filename with leading slash
+ *
+ * @return array : normalised config array with host/dbname/username/password/db_type/folder/game_prefix
  */
-function loadDBConfig($path, $configFile) {
+function loadDBConfig(string|null $path, string $configFile): array {
     // Default values
     $config = [
         'host' => 'localhost',
@@ -70,11 +79,17 @@ function loadDBConfig($path, $configFile) {
 }
 
 /**
- * Get and Check connection to the database
+ * Opens a PDO connection to the configured database (MySQL or PostgreSQL).
  *
- * @return PDO $pdo
+ * @param string|null $path : directory containing the config file (nullable when getPath found nothing)
+ * @param string $configFile : config filename with leading slash
+ *
+ * @return PDO|null : live PDO handle, or null when the connection failed
  */
-function getDBConnection ($path, $configFile) {
+function getDBConnection(string|null $path, string $configFile): PDO|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with configFile : ' . $configFile, ['path' => $path], 'debug');
+
     $debug = strtolower($_SESSION['DEBUG']) === 'true';
 
     $config = loadDBConfig($path, $configFile);
@@ -97,7 +112,7 @@ function getDBConnection ($path, $configFile) {
             return $pdo;
 
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): Connection failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'Connection failed : ' . $e->getMessage(), ['dbname' => $config['dbname'], 'db_type' => $config['db_type']], 'error');
             return NULL;
         }
     }else{
@@ -114,22 +129,24 @@ function getDBConnection ($path, $configFile) {
             return $pdo;
 
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): Connection failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'Connection failed : ' . $e->getMessage(), ['dbname' => $config['dbname'], 'db_type' => $config['db_type']], 'error');
             return NULL;
         }
     }
 }
 
 /**
- * Checks that the database table does exist
+ * Checks that the database table does exist.
  *
- * @param PDO $pdo
- * @param string $tableName
+ * @param PDO $pdo : database connection
+ * @param string $tableName : bare table name (prefix appended internally)
  *
- * @return bool
- *
+ * @return bool|null : true/false when the query ran, null when it threw
  */
-function tableExists($pdo, $tableName) {
+function tableExists(PDO $pdo, string $tableName): bool|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with tableName : ' . $tableName, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $prefixedTableName = $prefix . $tableName;
     try{
@@ -155,20 +172,23 @@ function tableExists($pdo, $tableName) {
             $stmt->execute([':tableName' => $prefixedTableName]);
         }
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): $prefixedTableName failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, $prefixedTableName . ' failed : ' . $e->getMessage(), ['prefixedTableName' => $prefixedTableName], 'error');
         return NULL;
     }
     return $stmt->fetchColumn();
 }
 
 /**
- * Searches and destroys all tables in database
+ * Searches and destroys all tables in the current database schema.
  *
- * @param PDO $pdo
+ * @param PDO $pdo : database connection
  *
- * @return bool
+ * @return bool : true on success, false when a PDO exception was caught
  */
-function destroyAllTables($pdo) {
+function destroyAllTables(PDO $pdo): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['prefix' => $_SESSION['GAME_PREFIX'] ?? null], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     try {
@@ -245,7 +265,7 @@ function destroyAllTables($pdo) {
         // Success message
         echo "All tables in database have been destroyed successfully.<br />";
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Error: " . $e->getMessage();
+        game_error_log(__FUNCTION__, 'Error : ' . $e->getMessage(), ['prefix' => $prefix, 'dbtype' => $_SESSION['DBTYPE'] ?? null], 'error');
         return false;
     }
     return true;
@@ -267,12 +287,15 @@ function destroyAllTables($pdo) {
  * time. This walks the controllers CSV after zones are loaded and
  * UPDATEs each row's origin_zone_id based on the zone name in the CSV.
  *
- * @param PDO    $pdo
- * @param string $controllersCsvPath
+ * @param PDO $pdo : database connection
+ * @param string $controllersCsvPath : absolute path to the controllers CSV
  *
- * @return int  count of rows updated
+ * @return int : count of rows updated
  */
-function resolveControllerOriginZones($pdo, $controllersCsvPath) {
+function resolveControllerOriginZones(PDO $pdo, string $controllersCsvPath): int {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controllersCsvPath : ' . $controllersCsvPath, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $fh = fopen($controllersCsvPath, 'r');
     if (!$fh) return 0;
@@ -295,7 +318,7 @@ function resolveControllerOriginZones($pdo, $controllersCsvPath) {
             $upd->execute([':z' => $zoneId, ':n' => $lastname]);
             if ($upd->rowCount() > 0) $count++;
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): {$lastname} → {$zoneName} failed: ".$e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, $lastname . ' -> ' . $zoneName . ' failed : ' . $e->getMessage(), ['lastname' => $lastname, 'zoneName' => $zoneName], 'warning');
         }
     }
     fclose($fh);
@@ -303,7 +326,21 @@ function resolveControllerOriginZones($pdo, $controllersCsvPath) {
     return $count;
 }
 
-function loadCSVFile($pdo, $csvFile, $tableName, $columns) {
+/**
+ * Loads a CSV file into the named table, resolving inline FK lookups
+ * (`table__col->targetCol`) and linkTable_ junction inserts.
+ *
+ * @param PDO $pdo : database connection
+ * @param string $csvFile : absolute path to CSV file
+ * @param string $tableName : target table name (without prefix)
+ * @param array $columns : column headers as declared in the CSV; may include lookup and linkTable_ specs
+ *
+ * @return bool : true on success, false when the file is missing or a fatal PDO exception was caught
+ */
+function loadCSVFile(PDO $pdo, string $csvFile, string $tableName, array $columns): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with tableName : ' . $tableName, ['csvFile' => $csvFile, 'columns' => $columns], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $prefixedTable = $prefix . $tableName;
 
@@ -387,7 +424,7 @@ function loadCSVFile($pdo, $csvFile, $tableName, $columns) {
                         $lookupCaches[$targetCol][$row[$lookupNameCol]] = $row['id'];
                     }
                 } catch (PDOException $e) {
-                    echo "Warning: Could not build compound lookup cache for {$targetCol}: " . $e->getMessage() . "<br />";
+                    game_error_log(__FUNCTION__, 'Could not build compound lookup cache for ' . $targetCol . ' : ' . $e->getMessage(), ['targetCol' => $targetCol, 'lookupTable' => $lookupTable, 'junctionTable' => $jt], 'warning');
                 }
             } else {
                 // Simple lookup
@@ -398,7 +435,7 @@ function loadCSVFile($pdo, $csvFile, $tableName, $columns) {
                         $lookupCaches[$targetCol][$row[$lookupNameCol]] = $row['id'];
                     }
                 } catch (PDOException $e) {
-                    echo "Warning: Could not build lookup cache for {$targetCol}: " . $e->getMessage() . "<br />";
+                    game_error_log(__FUNCTION__, 'Could not build lookup cache for ' . $targetCol . ' : ' . $e->getMessage(), ['targetCol' => $targetCol, 'lookupTable' => $lookupTable], 'warning');
                 }
             }
         }
@@ -415,7 +452,7 @@ function loadCSVFile($pdo, $csvFile, $tableName, $columns) {
                     $linkTableCaches[$def['csvHeader']][$row[$ltCol]] = $row['id'];
                 }
             } catch (PDOException $e) {
-                echo "Warning: Could not build linkTable cache for {$def['csvHeader']}: " . $e->getMessage() . "<br />";
+                game_error_log(__FUNCTION__, 'Could not build linkTable cache for ' . $def['csvHeader'] . ' : ' . $e->getMessage(), ['csvHeader' => $def['csvHeader'], 'lookupTable' => $ltTable], 'warning');
             }
         }
 
@@ -435,7 +472,7 @@ function loadCSVFile($pdo, $csvFile, $tableName, $columns) {
                     }
                 }
             } catch (PDOException $e) {
-                echo "Warning: Could not detect back-ref column for {$def['junctionTable']}: " . $e->getMessage() . "<br />";
+                game_error_log(__FUNCTION__, 'Could not detect back-ref column for ' . $def['junctionTable'] . ' : ' . $e->getMessage(), ['junctionTable' => $def['junctionTable']], 'warning');
             }
         }
         unset($def);
@@ -455,6 +492,7 @@ function loadCSVFile($pdo, $csvFile, $tableName, $columns) {
             }
         } catch (PDOException $e) {
             // proceed without column info — fallback to old behavior
+            game_error_log(__FUNCTION__, 'Could not detect column info for ' . $prefixedTable . ' : ' . $e->getMessage(), ['prefixedTable' => $prefixedTable], 'warning');
         }
 
         // Prepare main insert statement
@@ -555,7 +593,7 @@ function loadCSVFile($pdo, $csvFile, $tableName, $columns) {
         echo "CSV file $csvFile loaded successfully ($rowCount rows).<br />";
         return true;
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Error loading CSV $csvFile: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'Error loading CSV ' . $csvFile . ' : ' . $e->getMessage(), ['csvFile' => $csvFile, 'tableName' => $tableName], 'error');
         return false;
     }
 }
@@ -572,11 +610,15 @@ function loadCSVFile($pdo, $csvFile, $tableName, $columns) {
  *   action_choice, action_params,
  *   powers (pipe-separated list of power names)
  *
- * @param PDO $pdo Database connection
- * @param string $csvFile Path to CSV file
- * @return bool Success status
+ * @param PDO $pdo : database connection
+ * @param string $csvFile : absolute path to advanced-workers CSV
+ *
+ * @return bool : true on success, false when the file is missing or a PDO exception was caught
  */
-function loadWorkersCSV($pdo, $csvFile) {
+function loadWorkersCSV(PDO $pdo, string $csvFile): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with csvFile : ' . $csvFile, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     if (!file_exists($csvFile)) {
@@ -689,20 +731,23 @@ function loadWorkersCSV($pdo, $csvFile) {
         echo "Workers CSV $csvFile loaded successfully ($rowCount rows).<br />";
         return true;
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Error loading workers CSV $csvFile: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'Error loading workers CSV ' . $csvFile . ' : ' . $e->getMessage(), ['csvFile' => $csvFile], 'error');
         return false;
     }
 }
 
 /**
  * Check that the game is ready:
- *  - databse is accessible
+ *  - database is accessible
  *  - tables are loaded
- *  - load tables if $_POST['config_name'] is set
+ *  - load tables if $_POST['config_name'] is set.
  *
- * @return PDO $pdo
+ * @return PDO|null : live PDO handle when the game is ready, null on failure
  */
-function gameReady() {
+function gameReady(): PDO|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['config_name' => $_POST['config_name'] ?? null], 'debug');
+
     $debug = false;
 
     // Path to the config.ini file
@@ -838,7 +883,7 @@ function gameReady() {
                         $pdo->exec($sql);
                         echo "Auto-assigned all controllers to privileged players.<br />";
                     } catch (PDOException $e) {
-                        echo "Warning: auto-assign privileged players failed: " . $e->getMessage() . "<br />";
+                        game_error_log(__FUNCTION__, 'auto-assign privileged players failed : ' . $e->getMessage(), ['prefix' => $prefix], 'warning');
                     }
 
                     // Load powers from CSV or SQL files for each power type.
@@ -887,7 +932,7 @@ function gameReady() {
                                 $stmt = $pdo->prepare($sql);
                                 $stmt->execute();
                             } catch (PDOException $e) {
-                                echo __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+                                game_error_log(__FUNCTION__, $sql . ' failed : ' . $e->getMessage(), ['sql' => $sql, 'powerTypeName' => $powerTypeName], 'error');
                                 return NULL;
                             }
                             $powerTypes = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -898,7 +943,7 @@ function gameReady() {
                                     $stmt = $pdo->prepare($sql);
                                     $stmt->execute();
                                 } catch (PDOException $e) {
-                                    echo __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+                                    game_error_log(__FUNCTION__, $sql . ' failed : ' . $e->getMessage(), ['sql' => $sql, 'powerTypeName' => $powerTypeName], 'error');
                                     return NULL;
                                 }
                                 $powers = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -913,7 +958,7 @@ function gameReady() {
                                         $stmt = $pdo->prepare($sql);
                                         $stmt->execute();
                                     } catch (PDOException $e) {
-                                        echo __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+                                        game_error_log(__FUNCTION__, $sql . ' failed : ' . $e->getMessage(), ['sql' => $sql, 'powerTypeName' => $powerTypeName], 'error');
                                         return NULL;
                                     }
                                 }
@@ -1024,14 +1069,13 @@ function gameReady() {
                         $synthStmt->rowCount()
                     );
                 } catch (PDOException $e) {
-                    echo __FUNCTION__."(): Post-load CKL synthesis failed: "
-                        . $e->getMessage() . "<br />";
+                    game_error_log(__FUNCTION__, 'Post-load CKL synthesis failed : ' . $e->getMessage(), ['prefix' => $prefix, 'synthTurn' => $synthTurn ?? null], 'warning');
                 }
 
                 echo 'END <br />';
             }
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): Check Database failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'Check Database failed : ' . $e->getMessage(), ['dbtype' => $_SESSION['DBTYPE'] ?? null], 'error');
             return null;
         }
     } else {
@@ -1041,7 +1085,12 @@ function gameReady() {
     return $pdo;
 }
 
-function exportBDD() {
+/**
+ * Dumps the current database to a downloadable SQL file via mysqldump / pg_dump.
+ *
+ * @return void : streams the dump to the browser and calls exit on success
+ */
+function exportBDD(): void {
 
     $config = loadDBConfig($_SESSION['PATH'], $_SESSION['configFile']);
 
@@ -1089,12 +1138,14 @@ function exportBDD() {
 }
 
 /**
- * Import BDD from file.sql
- * @param PDO $pdo
- * @param string $file
- * @return bool
+ * Import BDD from an uploaded SQL file (destroys existing tables first).
+ *
+ * @param PDO $pdo : database connection
+ * @param array $file : $_FILES entry describing the uploaded .sql file
+ *
+ * @return bool : true when the import command ran, false on upload/type errors
  */
-function importBDD($pdo, $file){
+function importBDD(PDO $pdo, array $file): bool {
 
     if ($file['error'] === UPLOAD_ERR_OK) {
         $tmpFilePath = $file['tmp_name'];

--- a/README
+++ b/README
@@ -24,6 +24,10 @@ Installation (Docker — recommended):
  - Start the application:
      cd RPGConquestGame
      docker compose up -d
+ - Grant write access to the log directory for the PHP container user:
+     chmod 777 var/logs/
+   (needed once; the container runs PHP as www-data while checked-out
+   files are owned by your host user)
  - First start builds the PHP image and initializes the database (may take 1-2 minutes).
  - The application is available at: http://localhost:8080/RPGConquestGame/
  - MySQL is accessible at localhost:3307 (user: rpg_user / rpg_pass, database: rpgconquestgame).
@@ -79,12 +83,18 @@ Troubleshooting:
  - Tests fail with "No local MySQL available": pytest connects to
    127.0.0.1:3307 with rpg_user/rpg_pass. Verify the mysql container
    is healthy: `docker compose ps` should show "(healthy)".
+ - "Recent errors" widget on admin.php stays empty despite errors:
+   var/logs/ or var/logs/game_errors.log is not writable by PHP.
+   Fix locally: chmod 777 var/logs/ && chmod 666 var/logs/game_errors.log
+   On shared hosting (OVH etc.), the account user runs PHP so this
+   usually just works — check ownership if it doesn't.
  - Windows-specific setup: see README_setup_windows.md.
 
 Installation (manual):
  - Create a folder called RPGConquestGame and pull the sources to it.
  - Create a config.ini file in the VAR folder and add the parent folder name to it.
  - Setup a database, and add the connection info to the ./var/config.ini file and execute the ./var/setupBDD.sql file.
+ - Ensure var/logs/ is writable by the PHP process user.
  - The base game is set up with a user: gm; pwd: orga.
 
 Preparing a game :

--- a/base/admin.php
+++ b/base/admin.php
@@ -8,6 +8,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     if ( isset($_POST['resetBDD']) ) {
         // empty controller SESSION
         $_SESSION['controller'] = NULL;
+        // Purge the game error log as part of the full reset (mirrors DB wipe)
+        if (is_writable($GLOBALS['LOG_PATH'])) @file_put_contents($GLOBALS['LOG_PATH'], '');
         destroyAllTables($gameReady);
         $gameReady = gameReady();
     }

--- a/base/admin.php
+++ b/base/admin.php
@@ -29,6 +29,11 @@ require_once '../base/baseHTML.php';
 ?>
 
 <div class="content">
+    <?php
+    $adminRecentErrors = game_error_log_tail(2, $_SESSION['GAME_PREFIX'] ?? null, 'error');
+    $adminBorderColor = empty($adminRecentErrors) ? '#27ae60' : '#c0392b';
+    ?>
+    <!-- Ligne 1 : Mechanics | Recent errors | BDD management -->
     <div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">
         <div class="mechanics">
             <h1>Mechanics</h1>
@@ -49,6 +54,43 @@ require_once '../base/baseHTML.php';
                 ?>
             </table>
         </div>
+        <div class="config" style="border-left: 5px solid <?= $adminBorderColor ?>; padding-left: 0.75em;">
+            <h1>Recent errors</h1>
+            <p>prefix <code>[<?= htmlspecialchars($_SESSION['GAME_PREFIX'] ?? '') ?>]</code></p>
+            <?php if (empty($adminRecentErrors)): ?>
+                <p style="color: #27ae60;">Aucune erreur recente</p>
+            <?php else: ?>
+                <ul style="font-family: monospace; font-size: 12px; margin: 0.5em 0 0 0;">
+                    <?php foreach ($adminRecentErrors as $line): ?>
+                        <li style="color: #c0392b;"><?= htmlspecialchars($line) ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+            <p style="margin-top: 0.5em;"><a href="/<?= htmlspecialchars($_SESSION['FOLDER']) ?>/base/admin_logs.php">&rarr; Game errors log</a></p>
+        </div>
+        <div class="config">
+                <h1>BDD management : </h1>
+                <?php
+                    // Add button to extract BDD to file.sql or .sql
+                    echo sprintf('<p> <form action="/%s/base/admin.php" method="post">
+                        <input type="hidden" name="exportBDD" />
+                        <input type="submit" name="submitButton" value="Export BDD to file.sql" />
+                    </form> </p>',
+                    $_SESSION['FOLDER']
+                    );
+                    // Import BDD from file.sql
+                    echo sprintf('<p> <form action="/%s/base/admin.php" method="post" enctype="multipart/form-data">
+                        <input type="hidden" name="importBDD" />
+                        <input type="file" name="bddFile" id="bddFile" />
+                        <input type="submit" name="submitButton" value="Import BDD from file.sql" />
+                    </form> </p>',
+                    $_SESSION['FOLDER']
+                    );
+                ?>
+        </div>
+    </div>
+    <!-- Ligne 2 : Config Management | Management | List (avec Worker list) -->
+    <div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">
         <div class="config">
             <h1>Config Management</h1>
             <?php echo sprintf( '<p> <a href="/%1$s/base/configuration.php">Configuration</a> </p>',
@@ -81,45 +123,19 @@ require_once '../base/baseHTML.php';
                 $_SESSION['FOLDER']
                 ); ?>
         </div>
-    </div>
-    <div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">
         <div class="config">
                 <h1>List</h1>
                 <?php echo sprintf( '
                 <p> <a href="/%1$s/zones/management_zones.php">Zone control list</a> </p>
                 <p> <a href="/%1$s/zones/management_locations.php">Discovered location list</a> </p>
-                <p> <a href="/%1$s/zones/management_bases.php">Attack on player base list</a> </p>',
+                <p> <a href="/%1$s/zones/management_bases.php">Attack on player base list</a> </p>
+                <p> <a href="/%1$s/workers/management_workers.php">Worker list</a> </p>',
                 $_SESSION['FOLDER']
                 ); ?>
-        </div>
-        <div class="config">
-                <h1>BDD management : </h1>
-                <?php
-                    // Add button to extract BDD to file.sql or .sql
-                    echo sprintf('<p> <form action="/%s/base/admin.php" method="post">
-                        <input type="hidden" name="exportBDD" />
-                        <input type="submit" name="submitButton" value="Export BDD to file.sql" />
-                    </form> </p>',
-                    $_SESSION['FOLDER']
-                    );
-                    // Import BDD from file.sql
-                    echo sprintf('<p> <form action="/%s/base/admin.php" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="importBDD" />
-                        <input type="file" name="bddFile" id="bddFile" />
-                        <input type="submit" name="submitButton" value="Import BDD from file.sql" />
-                    </form> </p>',
-                    $_SESSION['FOLDER']
-                    );
-                ?>
         </div>
     </div>
+    <!-- Ligne 3 : Admin - Create Perfect Agent (pleine largeur) -->
     <div class="field is-grouped is-grouped-multiline is-flex-wrap-wrap">
-        <div class="config">
-            <h1>Workers</h1>
-            <?php echo sprintf( '<p> <a href="/%1$s/workers/management_workers.php">Worker list</a> </p>',
-                $_SESSION['FOLDER']
-                ); ?>
-        </div>
         <?php
             // Allow for admin creation of a perfect agent
             require_once '../workers/newPerfectWorker.php';

--- a/base/admin_logs.php
+++ b/base/admin_logs.php
@@ -1,0 +1,140 @@
+<?php
+require_once '../base/basePHP.php';
+
+// Admin-only page: require privileged session
+if (empty($_SESSION['is_privileged'])) {
+    header('Location: /' . $_SESSION['FOLDER'] . '/connection/loginForm.php');
+    exit();
+}
+
+$pageName = 'admin_logs';
+
+// Boutons pour écrire des lignes test aux 3 niveaux
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['test_error'])) {
+        game_error_log('test', 'clicked at ' . date('c'), ['user_id' => $_SESSION['user_id'] ?? null], 'error');
+    }
+    if (isset($_POST['test_warning'])) {
+        game_error_log('test', 'clicked at ' . date('c'), ['user_id' => $_SESSION['user_id'] ?? null], 'warning');
+    }
+    if (isset($_POST['test_debug'])) {
+        game_error_log('test', 'clicked at ' . date('c'), ['user_id' => $_SESSION['user_id'] ?? null], 'debug');
+    }
+    header('Location: admin_logs.php' . (empty($_GET) ? '' : '?' . http_build_query($_GET)));
+    exit();
+}
+
+$logPath = __DIR__ . '/../var/logs/game_errors.log';
+
+$lines = [];
+if (is_readable($logPath)) {
+    $raw = @file($logPath, FILE_IGNORE_NEW_LINES);
+    if ($raw !== false) {
+        $lines = array_slice($raw, -500);
+        $lines = array_reverse($lines);
+    }
+}
+
+$filterPrefix = trim($_GET['prefix'] ?? '');
+if ($filterPrefix !== '') {
+    $needle = "[{$filterPrefix}]";
+    $lines = array_values(array_filter($lines, fn($l) => str_contains($l, $needle)));
+}
+
+$filterLevel = strtoupper(trim($_GET['level'] ?? ''));
+if (in_array($filterLevel, ['ERROR', 'WARNING', 'DEBUG'], true)) {
+    $needle = "[{$filterLevel}]";
+    $lines = array_values(array_filter($lines, fn($l) => str_contains($l, $needle)));
+} else {
+    $filterLevel = '';
+}
+
+$LEVEL_COLORS = [
+    'ERROR'   => '#c0392b',
+    'WARNING' => '#e67e22',
+    'DEBUG'   => '#7f8c8d',
+];
+
+function classify_log_line(string $line, array $colors): string {
+    foreach ($colors as $lvl => $color) {
+        if (str_contains($line, "[{$lvl}]")) {
+            return $color;
+        }
+    }
+    return '#333';
+}
+
+$currentPrefix = $_SESSION['GAME_PREFIX'] ?? '';
+$fileExists = file_exists($logPath);
+$fileReadable = is_readable($logPath);
+$fileSize = $fileExists ? filesize($logPath) : 0;
+$iniErrorLog = ini_get('error_log');
+
+require_once '../base/baseHTML.php';
+?>
+<div class="content">
+    <h1>Game Errors Log </h1>
+
+    <div class="box">
+        <p><strong>Log path :</strong> <code><?= htmlspecialchars($logPath) ?></code></p>
+        <p><strong>ini_get('error_log') :</strong> <code><?= htmlspecialchars($iniErrorLog ?: '(empty)') ?></code>
+            <?php if ($iniErrorLog !== $logPath): ?>
+                <span style="color:orange">&nbsp;— &ne; path attendu, <code>ini_set</code> peut avoir echoue</span>
+            <?php else: ?>
+                <span style="color:green">&nbsp;— OK</span>
+            <?php endif; ?>
+        </p>
+        <p><strong>Status :</strong>
+            <?php if (!$fileExists): ?>
+                <span style="color:orange">Fichier inexistant. Cliquer le bouton ci-dessous pour ecrire la premiere ligne.</span>
+            <?php elseif (!$fileReadable): ?>
+                <span style="color:red">Non lisible (permissions).</span>
+            <?php else: ?>
+                <span style="color:green"><?= number_format($fileSize) ?> octets</span>
+            <?php endif; ?>
+        </p>
+    </div>
+
+    <form method="get" style="margin-bottom:1em;">
+        <label>Filter prefix :
+            <input type="text" name="prefix" value="<?= htmlspecialchars($filterPrefix) ?>"
+                placeholder="ex. <?= htmlspecialchars($currentPrefix) ?>" size="30">
+        </label>
+        &nbsp;&nbsp;
+        <label>Filter level :
+            <select name="level">
+                <option value="">All</option>
+                <?php foreach (array_keys($LEVEL_COLORS) as $lvl): ?>
+                    <option value="<?= $lvl ?>" <?= $filterLevel === $lvl ? 'selected' : '' ?> style="color:<?= $LEVEL_COLORS[$lvl] ?>">
+                        <?= $lvl ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </label>
+        <button type="submit">Filtrer</button>
+        <a href="admin_logs.php">Reset</a>
+    </form>
+
+    <form method="post" style="margin-bottom:1em;">
+        <button type="submit" name="test_error" class="button" style="background:<?= $LEVEL_COLORS['ERROR'] ?>;color:white;">
+            Ecrire ERROR test
+        </button>
+        <button type="submit" name="test_warning" class="button" style="background:<?= $LEVEL_COLORS['WARNING'] ?>;color:white;">
+            Ecrire WARNING test
+        </button>
+        <button type="submit" name="test_debug" class="button" style="background:<?= $LEVEL_COLORS['DEBUG'] ?>;color:white;">
+            Ecrire DEBUG test
+        </button>
+    </form>
+
+    <h2><?= count($lines) ?> derniere(s) ligne(s) <small>(plus recente d'abord)</small></h2>
+    <pre style="background:#f5f5f5;padding:1em;overflow:auto;max-height:600px;font-size:12px;line-height:1.4;">
+<?php foreach ($lines as $line): ?>
+<span style="color:<?= classify_log_line($line, $LEVEL_COLORS) ?>;"><?= htmlspecialchars($line) ?></span>
+
+<?php endforeach; ?>
+<?php if (empty($lines)): ?>
+<em>(rien a afficher)</em>
+<?php endif; ?>
+    </pre>
+</div>

--- a/base/admin_logs.php
+++ b/base/admin_logs.php
@@ -8,8 +8,24 @@ if (empty($_SESSION['is_privileged'])) {
 }
 
 $pageName = 'admin_logs';
+$logPath = $GLOBALS['LOG_PATH'];
 
-// Boutons pour écrire des lignes test aux 3 niveaux
+// Download RAW log file (all prefixes / all levels, unfiltered)
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && ($_GET['action'] ?? '') === 'download') {
+    if (!is_readable($logPath)) {
+        http_response_code(404);
+        echo 'Log file not readable';
+        exit();
+    }
+    $filename = 'game_errors_' . date('Y-m-d_His') . '.log';
+    header('Content-Type: text/plain; charset=utf-8');
+    header('Content-Disposition: attachment; filename="' . $filename . '"');
+    header('Content-Length: ' . filesize($logPath));
+    readfile($logPath);
+    exit();
+}
+
+// Boutons pour écrire des lignes test aux 3 niveaux + purge
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['test_error'])) {
         game_error_log('test', 'clicked at ' . date('c'), ['user_id' => $_SESSION['user_id'] ?? null], 'error');
@@ -20,17 +36,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['test_debug'])) {
         game_error_log('test', 'clicked at ' . date('c'), ['user_id' => $_SESSION['user_id'] ?? null], 'debug');
     }
+    if (isset($_POST['purge_log'])) {
+        @file_put_contents($logPath, '');
+    }
     header('Location: admin_logs.php' . (empty($_GET) ? '' : '?' . http_build_query($_GET)));
     exit();
 }
-
-$logPath = __DIR__ . '/../var/logs/game_errors.log';
 
 $lines = [];
 if (is_readable($logPath)) {
     $raw = @file($logPath, FILE_IGNORE_NEW_LINES);
     if ($raw !== false) {
-        $lines = array_slice($raw, -500);
+        $lines = array_slice($raw, -1000);
         $lines = array_reverse($lines);
     }
 }
@@ -127,6 +144,14 @@ require_once '../base/baseHTML.php';
         </button>
     </form>
 
+    <div style="margin-bottom:1em;">
+        <a href="admin_logs.php?action=download" class="button">Telecharger le log (RAW)</a>
+        <form id="purgeLogForm" method="post" style="display:inline;">
+            <input type="hidden" name="purge_log" value="1" />
+            <button type="submit" class="button is-danger">Vider le log</button>
+        </form>
+    </div>
+
     <h2><?= count($lines) ?> derniere(s) ligne(s) <small>(plus recente d'abord)</small></h2>
     <pre style="background:#f5f5f5;padding:1em;overflow:auto;max-height:600px;font-size:12px;line-height:1.4;">
 <?php foreach ($lines as $line): ?>
@@ -138,3 +163,42 @@ require_once '../base/baseHTML.php';
 <?php endif; ?>
     </pre>
 </div>
+
+<div id="confirmPurgeModal" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+        <header class="modal-card-head">
+            <p class="modal-card-title">Confirm log purge</p>
+        </header>
+        <section class="modal-card-body">
+            <p>Vider le fichier de log ? <strong>Cette action est irreversible.</strong></p>
+            <p>Le fichier est conserve (inode + permissions), seul son contenu est efface.</p>
+        </section>
+        <footer class="modal-card-foot">
+            <button id="confirmPurgeYes" class="button is-danger">Oui, vider</button>
+            <button id="confirmPurgeNo" class="button">Annuler</button>
+        </footer>
+    </div>
+</div>
+
+<script>
+    function openPurgeModal() {
+        document.getElementById('confirmPurgeModal').classList.add('is-active');
+    }
+    function closePurgeModal() {
+        document.getElementById('confirmPurgeModal').classList.remove('is-active');
+    }
+    function submitPurgeForm() {
+        closePurgeModal();
+        document.getElementById('purgeLogForm').submit();
+    }
+    document.addEventListener('DOMContentLoaded', function () {
+        document.getElementById('purgeLogForm').addEventListener('submit', function (event) {
+            event.preventDefault();
+            openPurgeModal();
+        });
+        document.getElementById('confirmPurgeNo').addEventListener('click', closePurgeModal);
+        document.getElementById('confirmPurgeYes').addEventListener('click', submitPurgeForm);
+        document.querySelector('#confirmPurgeModal .modal-background').addEventListener('click', closePurgeModal);
+    });
+</script>

--- a/base/basePHP.php
+++ b/base/basePHP.php
@@ -9,6 +9,9 @@ if ($_SESSION['DEBUG'] == true ){
     echo sprintf("_SESSION %s <br />", var_export($_SESSION, true));
 }
 
+// Set BEFORE errorLog.php require so its ini_set('error_log', ...) picks it up.
+$GLOBALS['LOG_PATH'] = __DIR__ . '/../var/logs/game_errors.log';
+
 require_once '../base/version.php';
 require_once '../base/errorLog.php';
 require_once '../BDD/db_connector.php';

--- a/base/basePHP.php
+++ b/base/basePHP.php
@@ -23,14 +23,17 @@ require_once '../workers/functions.php';
 require_once '../zones/functions.php';
 
 /**
- *  Extract configuration value from the database by key
+ * Extract configuration value from the database by key.
  *
  * @param PDO $pdo : database connection
  * @param string $configName : configuration key
- * 
- * @return string|null $value 
+ *
+ * @return string|null : stored value or NULL on error / missing key
  */
-function getConfig($pdo, $configName) {
+function getConfig(PDO $pdo, string $configName): string|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with configName : ' . $configName, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try{
         $stmt = $pdo->prepare("SELECT value
@@ -38,33 +41,33 @@ function getConfig($pdo, $configName) {
             WHERE name = :configName
         ");
         $stmt->execute([':configName' => $configName]);
-        return $stmt->fetchColumn();
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : NULL;
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $configName failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'PDO error : ' . $e->getMessage(), ['configName' => $configName], 'error');
         return NULL;
     }
 }
 
 /**
- *  Extract elements of mechanics from database
+ * Extract elements of mechanics from database.
  *
  * @param PDO $pdo : database connection
  *
- * @return array|null : $mechanics
+ * @return array|null : first mechanics row (assoc) or NULL on error / empty
  */
-function getMechanics($pdo) {
+function getMechanics(PDO $pdo): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try{
         $stmt = $pdo->query("SELECT * FROM {$prefix}mechanics");
         $mechanics = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        if ($_SESSION['DEBUG'] == true){
-            echo "mechanics :  <br />";
-            print_r ($mechanics);
-            echo "<br />";
-        }
+        game_error_log(__FUNCTION__, 'DONE', ['mechanics' => $mechanics], 'debug');
         return $mechanics[0] ?? NULL;
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'PDO error : ' . $e->getMessage(), [], 'error');
         return NULL;
     }
 }

--- a/base/basePHP.php
+++ b/base/basePHP.php
@@ -10,6 +10,7 @@ if ($_SESSION['DEBUG'] == true ){
 }
 
 require_once '../base/version.php';
+require_once '../base/errorLog.php';
 require_once '../BDD/db_connector.php';
 require_once '../controllers/functions.php';
 require_once '../mechanics/functions.php';

--- a/base/configuration.php
+++ b/base/configuration.php
@@ -3,6 +3,8 @@ $pageName = 'Configuration';
 
 require_once '../base/basePHP.php';
 
+// $GLOBALS['DEBUG_LOG_SECTIONS'][] = 'configuration_page';  // uncomment to log DEBUG events from this page
+
 $prefix = $_SESSION['GAME_PREFIX'];
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
@@ -18,15 +20,13 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $stmt->bindParam(':value', $value);
             $stmt->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): INSERT config Failed: " . $e->getMessage()."<br />";
+            game_error_log('configuration_page', 'INSERT config failed', ['error' => $e->getMessage()]);
         }
     }
 
     // Check if action is to delete a config value
     if (isset($_POST['delete_config'])) {
-        if ($_SESSION['DEBUG'] == true){
-            echo "delete_config => id: ".$_POST['id'].".<br />";
-        }
+        game_error_log('configuration_page', 'delete_config request', ['id' => $_POST['id']], 'debug');
         try{
             $id = $_POST['id'];
 
@@ -35,15 +35,13 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $stmt->bindParam(':id', $id);
             $stmt->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): DELETE config Failed: " . $e->getMessage()."<br />";
+            game_error_log('configuration_page', 'DELETE config failed', ['error' => $e->getMessage()]);
         }
     }
 
     // Check if action is to update a config value
     if (isset($_POST['update_config'])) {
-        if ($_SESSION['DEBUG'] == true){
-            echo "update_config => id: ".$_POST['id']." and value ".$_POST['value'].".<br />";
-        }
+        game_error_log('configuration_page', 'update_config request', ['id' => $_POST['id'], 'value' => $_POST['value']], 'debug');
         try{
             $id = $_POST['id'];
             $value = $_POST['value'];
@@ -54,7 +52,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $stmt->bindParam(':value', $value);
             $stmt->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): UPDATE config Failed: " . $e->getMessage()."<br />";
+            game_error_log('configuration_page', 'UPDATE config failed', ['error' => $e->getMessage()]);
         }
     }
 }
@@ -64,7 +62,7 @@ try{
     $stmt = $gameReady->query("SELECT * FROM {$prefix}config ORDER BY ID ASC");
     $config_values = $stmt->fetchAll(PDO::FETCH_ASSOC);
 } catch (PDOException $e) {
-    echo __FUNCTION__."(): GET config Failed: " . $e->getMessage()."<br />";
+    game_error_log('configuration_page', 'SELECT config failed', ['error' => $e->getMessage()]);
 }
 
 require_once '../base/baseHTML.php';

--- a/base/errorLog.php
+++ b/base/errorLog.php
@@ -2,9 +2,7 @@
 // Route les erreurs vers var/logs/game_errors.log. Le dossier doit exister
 // (cree par l'ops au deploiement). Acces public bloque par var/.htaccess.
 
-$gameLogPath = __DIR__ . '/../var/logs/game_errors.log';
-@ini_set('error_log', $gameLogPath);
-
+@ini_set('error_log', $GLOBALS['LOG_PATH']);
 
 /**
  * Retourne les N dernieres lignes du log, plus recentes en premier.
@@ -16,7 +14,7 @@ $gameLogPath = __DIR__ . '/../var/logs/game_errors.log';
  * @return array
  */
 function game_error_log_tail(int $lines = 2, ?string $prefixFilter = null, ?string $levelFilter = null): array {
-    $logPath = __DIR__ . '/../var/logs/game_errors.log';
+    $logPath = $GLOBALS['LOG_PATH'];
     if (!is_readable($logPath)) return [];
     $raw = @file($logPath, FILE_IGNORE_NEW_LINES);
     if ($raw === false) return [];

--- a/base/errorLog.php
+++ b/base/errorLog.php
@@ -1,0 +1,66 @@
+<?php
+// Route les erreurs vers var/logs/game_errors.log. Le dossier doit exister
+// (cree par l'ops au deploiement). Acces public bloque par var/.htaccess.
+
+$gameLogPath = __DIR__ . '/../var/logs/game_errors.log';
+@ini_set('error_log', $gameLogPath);
+
+
+/**
+ * Retourne les N dernieres lignes du log, plus recentes en premier.
+ * Filtres optionnels par prefix et par level (case-insensitive pour level).
+ *
+ * @param int         $lines
+ * @param string|null $prefixFilter   ex. $_SESSION['GAME_PREFIX']
+ * @param string|null $levelFilter    'error' | 'warning' | 'debug'
+ * @return array
+ */
+function game_error_log_tail(int $lines = 2, ?string $prefixFilter = null, ?string $levelFilter = null): array {
+    $logPath = __DIR__ . '/../var/logs/game_errors.log';
+    if (!is_readable($logPath)) return [];
+    $raw = @file($logPath, FILE_IGNORE_NEW_LINES);
+    if ($raw === false) return [];
+
+    if ($prefixFilter !== null && $prefixFilter !== '') {
+        $needle = "[{$prefixFilter}]";
+        $raw = array_filter($raw, fn($l) => str_contains($l, $needle));
+    }
+    if ($levelFilter !== null && $levelFilter !== '') {
+        $needle = "[" . strtoupper($levelFilter) . "]";
+        $raw = array_filter($raw, fn($l) => str_contains($l, $needle));
+    }
+
+    return array_reverse(array_slice(array_values($raw), -$lines));
+}
+
+/**
+ * Ecrit une ligne d'erreur formatee dans le fichier de log.
+ *
+ * Format : [prefix] [LEVEL] function: message | ctx={json}
+ *
+ * Toutes les lignes sont ecrites au fichier, quel que soit le niveau.
+ * Le passthrough echo sur la page reste conditionne a $_SESSION['DEBUG'].
+ *
+ * @param string $function  short id (typiquement __FUNCTION__)
+ * @param string $message   free text
+ * @param array  $context   optional key/value bag serialise en JSON
+ * @param string $level     'error' (default) | 'warning' | 'debug'
+ */
+function game_error_log(string $function, string $message, array $context = [], string $level = 'error'): void {
+    $prefix = $_SESSION['GAME_PREFIX'] ?? 'no-prefix';
+    $lvl = strtoupper($level);
+    if (!in_array($lvl, ['ERROR', 'WARNING', 'DEBUG'], true)) {
+        $lvl = 'ERROR';
+    }
+    // Anti log-injection : neutralise les \r\n dans message + context strings
+    $message = strtr($message, ["\r" => ' ', "\n" => ' ']);
+    foreach ($context as $k => $v) {
+        if (is_string($v)) $context[$k] = strtr($v, ["\r" => ' ', "\n" => ' ']);
+    }
+    $ctx = $context ? ' | ctx=' . json_encode($context, JSON_UNESCAPED_UNICODE) : '';
+    error_log("[{$prefix}] [{$lvl}] {$function}: {$message}{$ctx}");
+
+    if (!empty($_SESSION['DEBUG'])) {
+        echo htmlspecialchars("[{$lvl}] {$function}: {$message}", ENT_QUOTES) . "<br />";
+    }
+}

--- a/base/errorLog.php
+++ b/base/errorLog.php
@@ -38,7 +38,10 @@ function game_error_log_tail(int $lines = 2, ?string $prefixFilter = null, ?stri
  *
  * Format : [prefix] [LEVEL] function: message | ctx={json}
  *
- * Toutes les lignes sont ecrites au fichier, quel que soit le niveau.
+ * ERROR + WARNING : toujours ecrits au fichier.
+ * DEBUG : ecrit uniquement si $_SESSION['DEBUG']=true (unlock global admin)
+ *         OU section listee dans $GLOBALS['DEBUG_LOG_SECTIONS'] (opt-in
+ *         par fichier via une ligne commentee en tete).
  * Le passthrough echo sur la page reste conditionne a $_SESSION['DEBUG'].
  *
  * @param string $function  short id (typiquement __FUNCTION__)
@@ -52,6 +55,14 @@ function game_error_log(string $function, string $message, array $context = [], 
     if (!in_array($lvl, ['ERROR', 'WARNING', 'DEBUG'], true)) {
         $lvl = 'ERROR';
     }
+    // DEBUG write gate : ecriture skipe si global DEBUG off ET section non opt-in
+    // via $GLOBALS['DEBUG_LOG_SECTIONS']. ERROR + WARNING ecrivent toujours.
+    if ($lvl === 'DEBUG'
+        && empty($_SESSION['DEBUG'])
+        && !in_array($function, $GLOBALS['DEBUG_LOG_SECTIONS'] ?? [], true)
+    ) {
+        return;
+    }
     // Anti log-injection : neutralise les \r\n dans message + context strings
     $message = strtr($message, ["\r" => ' ', "\n" => ' ']);
     foreach ($context as $k => $v) {
@@ -61,6 +72,6 @@ function game_error_log(string $function, string $message, array $context = [], 
     error_log("[{$prefix}] [{$lvl}] {$function}: {$message}{$ctx}");
 
     if (!empty($_SESSION['DEBUG'])) {
-        echo htmlspecialchars("[{$lvl}] {$function}: {$message}", ENT_QUOTES) . "<br />";
+        echo htmlspecialchars("[{$lvl}] {$function}: {$message}{$ctx}", ENT_QUOTES) . "<br />";
     }
 }

--- a/connection/loginForm.php
+++ b/connection/loginForm.php
@@ -11,17 +11,22 @@ require_once '../base/errorLog.php';
 require_once '../BDD/db_connector.php';
 require_once '../controllers/functions.php';
 
+// $GLOBALS['DEBUG_LOG_SECTIONS'][] = 'login_form_page';  // uncomment to log DEBUG events from this page
 
 /**
- *  Extract configuration value from the database by key
- * copy of getConfig function from basePHP.php because the function is unavailable here
+ * Extract configuration value from the database by key.
+ * Copy of getConfig from basePHP.php because that file is not loaded here
+ * (login page bootstraps before the full session is wired).
  *
  * @param PDO $pdo : database connection
  * @param string $configName : configuration key
- * 
- * @return string|null value
+ *
+ * @return string|null : stored value, or NULL on missing key / PDO error
  */
-function getConfig($pdo, $configName) {
+function getConfig(PDO $pdo, string $configName): string|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with configName : ' . $configName, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try{
         $stmt = $pdo->prepare("SELECT value
@@ -29,9 +34,10 @@ function getConfig($pdo, $configName) {
             WHERE name = :configName
         ");
         $stmt->execute([':configName' => $configName]);
-        return $stmt->fetchColumn();
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : NULL;
     } catch (PDOException $e) {
-        game_error_log(__FUNCTION__, 'SELECT config failed', ['configName' => $configName, 'error' => $e->getMessage()]);
+        game_error_log(__FUNCTION__, 'SELECT value failed : ' . $e->getMessage(), ['configName' => $configName], 'error');
         return NULL;
     }
 }
@@ -41,6 +47,7 @@ function getConfig($pdo, $configName) {
 $gameReady = gameReady();
 // Use the return value
 if (!$gameReady) {
+    game_error_log('login_form_page', 'gameReady() returned falsy — DB configuration missing or unreachable', [], 'warning');
     echo "The game is not ready. Please check DB Configuration and Setup. <br />";
     exit();
 }else{
@@ -107,11 +114,12 @@ if (
             exit();
         } else {
             $_SESSION['logged_in'] = false;
+            game_error_log('login_form_page', 'login rejected : no matching player row for submitted credentials', ['username' => $_SESSION['username']], 'warning');
             echo "Login impossible for the player. <br/>";
             echo "No matching record found.";
         }
     } catch (PDOException $e) {
-        game_error_log(__FUNCTION__, 'SELECT player failed', ['error' => $e->getMessage()]);
+        game_error_log('login_form_page', 'SELECT player failed : ' . $e->getMessage(), ['username' => $_SESSION['username']], 'error');
         exit();
     }
 }

--- a/connection/loginForm.php
+++ b/connection/loginForm.php
@@ -7,6 +7,7 @@ if ( !isset($_SESSION['DEBUG']) ){
 }
 
 require_once '../base/version.php';
+require_once '../base/errorLog.php';
 require_once '../BDD/db_connector.php';
 require_once '../controllers/functions.php';
 
@@ -30,7 +31,7 @@ function getConfig($pdo, $configName) {
         $stmt->execute([':configName' => $configName]);
         return $stmt->fetchColumn();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): $configName failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT config failed', ['configName' => $configName, 'error' => $e->getMessage()]);
         return NULL;
     }
 }
@@ -110,7 +111,7 @@ if (
             echo "No matching record found.";
         }
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Get player failed: " . $e->getMessage()."<br/>";
+        game_error_log(__FUNCTION__, 'SELECT player failed', ['error' => $e->getMessage()]);
         exit();
     }
 }

--- a/controllers/action.php
+++ b/controllers/action.php
@@ -1,6 +1,9 @@
 <?php
 
 require_once '../base/basePHP.php';
+
+// $GLOBALS['DEBUG_LOG_SECTIONS'][] = 'controllers_action_page';  // uncomment to log DEBUG events from this page
+
 $pageName = 'controllers_action';
 $debug = strtolower($_SESSION['DEBUG']) === 'true';
 
@@ -95,12 +98,13 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
             $stmt->bindParam(':cid', $controller_id, PDO::PARAM_INT);
             $stmt->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): DELETE controller_location_attacks Failed: " . $e->getMessage()."<br />";
+            game_error_log('controllers_action_page', 'DELETE controller_location_attacks failed : ' . $e->getMessage(), ['queue_row_id' => $queue_row_id, 'controller_id' => $controller_id], 'error');
         }
     }
     if (isset($_GET['repairLocation'])){
         if ($debug) echo sprintf('start <br> controller_id: %s, <br />target_location_id: %s<br /><br />', var_export($controller_id, true), var_export($target_location_id, true));
         if (!spendRessourcesToRepairLocation($gameReady, $controller_id)) {
+            game_error_log('controllers_action_page', 'repairLocation aborted : spendRessourcesToRepairLocation returned false', ['controller_id' => $controller_id, 'target_location_id' => $target_location_id], 'warning');
             echo "Stock insuffisant ou modifié.<br />";
         } else {
             $stmt = $gameReady->prepare("SELECT * FROM {$prefix}locations WHERE id = ?");
@@ -121,8 +125,10 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
         $enemy_worker_id = $_GET['enemy_worker_id'] ?? '';
 
         if (empty($controller_id) || empty($target_controller_id) || empty($enemy_worker_id)) {
+            game_error_log('controllers_action_page', 'giftInformationAgent aborted : missing controller_id / target_controller_id / enemy_worker_id', ['controller_id' => $controller_id, 'target_controller_id' => $target_controller_id, 'enemy_worker_id' => $enemy_worker_id], 'warning');
             echo '<div class="notification is-warning">Sélection incomplète : faction ou agent manquant.</div>';
         } else if ((int)$controller_id === (int)$target_controller_id) {
+            game_error_log('controllers_action_page', 'giftInformationAgent aborted : self-gift attempt', ['controller_id' => $controller_id, 'target_controller_id' => $target_controller_id, 'enemy_worker_id' => $enemy_worker_id], 'warning');
             echo '<div class="notification is-warning">Faction cible invalide : on ne peut pas se donner d\'information à soi-même.</div>';
         } else {
             $sql = "SELECT zone_id FROM {$prefix}controllers_known_enemies WHERE controller_id = ? AND discovered_worker_id = ?";
@@ -142,8 +148,10 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
         $giver_id = $_GET['controller_id'] ?? ($_SESSION['controller']['id'] ?? '');
 
         if (empty($target_controller_id) || empty($location_id) || empty($giver_id)) {
+            game_error_log('controllers_action_page', 'giftInformationLocation aborted : missing target_controller_id / location_id / giver_id', ['target_controller_id' => $target_controller_id, 'location_id' => $location_id, 'giver_id' => $giver_id], 'warning');
             echo '<div class="notification is-warning">Sélection incomplète : faction ou lieu manquant.</div>';
         } else if ((int)$giver_id === (int)$target_controller_id) {
+            game_error_log('controllers_action_page', 'giftInformationLocation aborted : self-gift attempt', ['giver_id' => $giver_id, 'target_controller_id' => $target_controller_id, 'location_id' => $location_id], 'warning');
             echo '<div class="notification is-warning">Faction cible invalide : on ne peut pas se donner d\'information à soi-même.</div>';
         } else {
             addLocationToCKL($gameReady, $target_controller_id, $location_id, $mechanics['turncounter'], false);

--- a/controllers/functions.php
+++ b/controllers/functions.php
@@ -7,16 +7,16 @@
  *  - optional exclusion of one controller (e.g. session-active controller for "target" selects)
  *
  * @param PDO $pdo : database connection
- * @param int|null $player_id
- * @param int|null $controller_id
- * @param bool $hide_secret_controllers default: true
+ * @param int|string|null $player_id : player id filter, NULL for none
+ * @param int|null $controller_id : controller id filter, NULL for none
+ * @param bool $hide_secret_controllers : hide secret controllers except the active session one, default: true
  * @param int|null $exclude_controller_id : drops one controller from the result (used to forbid self-target on gift selects)
- *
- * @return array|null
- *
+ * @return array|null : array of controller rows or NULL on error
  */
-// Function to get controllers and return as an array
-function getControllers($pdo, $player_id = NULL, $controller_id = NULL, $hide_secret_controllers = true, $exclude_controller_id = NULL) {
+function getControllers(PDO $pdo, int|string|null $player_id = NULL, int|null $controller_id = NULL, bool $hide_secret_controllers = true, int|null $exclude_controller_id = NULL): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['player_id' => $player_id, 'controller_id' => $controller_id, 'hide_secret_controllers' => $hide_secret_controllers, 'exclude_controller_id' => $exclude_controller_id], 'debug');
+
     $controllersArray = array();
     $prefix = $_SESSION['GAME_PREFIX'];
 
@@ -54,7 +54,7 @@ function getControllers($pdo, $player_id = NULL, $controller_id = NULL, $hide_se
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $player_id failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT controllers failed : ' . $e->getMessage(), ['player_id' => $player_id, 'controller_id' => $controller_id], 'error');
         return NULL;
     }
 
@@ -71,37 +71,40 @@ function getControllers($pdo, $player_id = NULL, $controller_id = NULL, $hide_se
 
 /**
  * Get the name of a controller
- * 
- * @param PDO $pdo
- * @param int $controller_id
- * 
- * @return string
+ *
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : controller id
+ * @return string|null : "firstname lastname" or NULL on error
  */
-function getControllerName($pdo, $controller_id) {
+function getControllerName(PDO $pdo, int $controller_id): string|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
-    try{ 
+    try{
         $sql = "SELECT  CONCAT(c.firstname, ' ', c.lastname) AS controller_name FROM {$prefix}controllers c WHERE c.id = :controller_id";
         $stmt = $pdo->prepare($sql);
         $stmt->execute([':controller_id' => $controller_id]);
         $controller = $stmt->fetch(PDO::FETCH_ASSOC);
         return $controller['controller_name'];
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT controllers Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT controllers failed : ' . $e->getMessage(), ['controller_id' => $controller_id], 'error');
         return NULL;
     }
 }
 
 /**
- * Show list of controller options for à controller select field.
- * 
- * @param array $controllers : array of controllers ('id', 'firstname', 'lastname')
+ * Show list of controller options for a controller select field.
+ *
+ * @param array|null $controllers : array of controllers ('id', 'firstname', 'lastname')
  * @param int|null $selectedID : ID of the selected controller (optional)
  * @param string $field_name : name of the select field (default: 'controller_id')
  * @param bool $addEmptySpace : add an empty option at the top of the list (default: false)
- * 
  * @return string : HTML select field
  */
-function showControllerSelect($controllers, $selectedID = null ,$field_name = 'controller_id', $addEmptySpace = false ) {
+function showControllerSelect(array|null $controllers, int|null $selectedID = null, string $field_name = 'controller_id', bool $addEmptySpace = false): string {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with field_name : ' . $field_name, ['selectedID' => $selectedID, 'addEmptySpace' => $addEmptySpace, 'controllers_count' => is_array($controllers) ? count($controllers) : 0], 'debug');
 
     if (empty($controllers)) return '';
     $controllerOptions = '';
@@ -128,13 +131,21 @@ function showControllerSelect($controllers, $selectedID = null ,$field_name = 'c
         $field_name,
         $controllerOptions
     );
-    if (!empty($_SESSION['DEBUG']) && $_SESSION['DEBUG'] == true) echo __FUNCTION__."(): showControllerSelect: ".var_export($showControllerSelect, true)."<br /><br />";
+    game_error_log(__FUNCTION__, 'DONE', ['showControllerSelect' => $showControllerSelect], 'debug');
 
     return $showControllerSelect;
 }
 
-/** This function resets the turn_recruited_workers and turn_firstcome_workers to 0 for every controller */
-function  restartTurnRecrutementCount($pdo){
+/**
+ * Reset turn_recruited_workers and turn_firstcome_workers to 0 for every controller.
+ *
+ * @param PDO $pdo : database connection
+ * @return bool|null : true on success, NULL on error
+ */
+function restartTurnRecrutementCount(PDO $pdo): bool|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $sql = "UPDATE {$prefix}controllers SET turn_firstcome_workers=0, turn_recruited_workers=0 WHERE True";
     try{
@@ -143,22 +154,23 @@ function  restartTurnRecrutementCount($pdo){
         $stmt->execute();
         return true;
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT locations Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'UPDATE controllers failed : ' . $e->getMessage(), [], 'error');
         return NULL;
     }
 }
 
 /**
+ * Check whether a controller may start a first-come worker draft this turn.
  *
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : controller id
+ * @return bool : true if turn_firstcome_workers < config threshold
  */
-function canStartFirstCome($pdo, $controller_id) {
+function canStartFirstCome(PDO $pdo, int $controller_id): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
 
     $controllerValues = getControllers($pdo, NULL, $controller_id);
-    if ( $_SESSION['DEBUG'] == true )
-    echo '<p>'
-        .'; turn_firstcome_workers: '. getConfig($pdo, 'turn_firstcome_workers')
-        .'; turn_firstcome_workers :'. $controllerValues[0]['turn_firstcome_workers']
-    .'</p>';
     if (
         (INT)$controllerValues[0]['turn_firstcome_workers'] < (INT)getConfig($pdo, 'turn_firstcome_workers')
     )  return true;
@@ -166,20 +178,20 @@ function canStartFirstCome($pdo, $controller_id) {
 }
 
 /**
+ * Check whether a controller may start a recruitment action this turn.
  *
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : controller id
+ * @param int $turnNumber : current turn number
+ * @return bool : true if the controller has a base and remains under the recruit cap
  */
-function canStartRecrutement($pdo, $controller_id, $turnNumber){
+function canStartRecrutement(PDO $pdo, int $controller_id, int $turnNumber): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['turnNumber' => $turnNumber], 'debug');
 
     $controllerValues = getControllers($pdo, NULL, $controller_id);
-    if ( $_SESSION['DEBUG'] == true )
-    echo '<p>hasBase: '. var_export(hasBase($pdo, $controller_id), true)
-        .';turncounter: '. $turnNumber
-        .'; turn_recrutable_workers: '. getConfig($pdo, 'turn_recrutable_workers')
-        .'; start_workers :'. $controllerValues[0]['start_workers']
-        .'; turn_recruited_workers :'. $controllerValues[0]['turn_recruited_workers']
-    .'</p>';
 
-    if (    
+    if (
         count(hasBase($pdo, $controller_id)) > 0
         &&
         ((
@@ -194,14 +206,16 @@ function canStartRecrutement($pdo, $controller_id, $turnNumber){
 }
 
 /**
- * This function returns an array of all bases a controller has or a NULL
+ * Return an array of all bases a controller has, or NULL on error.
  *
  * @param PDO $pdo : database connection
- * @param string : $controller_id 
- *
- * @return array|null : $bases
+ * @param int $controller_id : controller id
+ * @return array|null : base rows joined with zone info, NULL on error
  */
-function hasBase($pdo, $controller_id) {
+function hasBase(PDO $pdo, int $controller_id): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     $sql = "SELECT l.*, z.id AS zone_id, z.name AS zone_name FROM {$prefix}locations l
@@ -215,23 +229,23 @@ function hasBase($pdo, $controller_id) {
         $bases = $stmt->fetchALL(PDO::FETCH_ASSOC);
         return $bases;
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT locations Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT locations failed : ' . $e->getMessage(), ['controller_id' => $controller_id], 'error');
     }
     return NULL;
 }
 
 /**
- * Create the base for the controler in zone and return if success
+ * Create the base for the controller in zone and return true on success.
  *
  * @param PDO $pdo : database connection
- * @param int : $controller_id 
- * @param int : $zone_id 
- * 
- * @return bool
- * 
-*/
-function createBase($pdo, $controller_id, $zone_id) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+ * @param int|null $controller_id : controller id (NULL when the caller received no _GET param)
+ * @param int|null $zone_id : target zone id (NULL when the caller received no _GET param)
+ * @return bool : true on success, false on any guard/insert failure
+ */
+function createBase(PDO $pdo, int|null $controller_id, int|null $zone_id): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['zone_id' => $zone_id], 'debug');
 
     $prefix = $_SESSION['GAME_PREFIX'];
 
@@ -254,12 +268,12 @@ function createBase($pdo, $controller_id, $zone_id) {
 
     $controllers = getControllers($pdo, NULL, $controller_id);
     $controller_name = $controllers[0]['firstname']. ' '. $controllers[0]['lastname'];
-    if ($debug) echo sprintf("controller_name : %s </br>", $controller_name);
+    game_error_log(__FUNCTION__, 'controller_name : ' . $controller_name, [], 'debug');
 
     $discovery_diff = calculateSecretLocationDiscoveryDiff($pdo, $zone_id, null, $controller_id );
 
     $timeValue = getConfig($pdo, 'timeValue');
-    if ($debug) echo sprintf("timeValue : %s </br>", var_export($timeValue, true));
+    game_error_log(__FUNCTION__, 'timeValue : ' . var_export($timeValue, true), [], 'debug');
 
     $baseName = sprintf(
         getConfig($pdo, 'texteNameBase'),
@@ -291,11 +305,11 @@ function createBase($pdo, $controller_id, $zone_id) {
     ]);
 
         if ($checkStmt->fetchColumn() > 0) {
-            if ($debug) echo "Base already exists for this controller in this zone.<br />";
+            game_error_log(__FUNCTION__, 'Base already exists for this controller in this zone', ['controller_id' => $controller_id, 'zone_id' => $zone_id], 'debug');
             return false;
         }
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT locations Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT locations failed : ' . $e->getMessage(), ['controller_id' => $controller_id, 'zone_id' => $zone_id], 'warning');
     }
 
     $sql = "INSERT INTO {$prefix}locations (zone_id, name, description, hidden_description, controller_id, discovery_diff, can_be_destroyed, is_base, location_types) VALUES
@@ -313,7 +327,7 @@ function createBase($pdo, $controller_id, $zone_id) {
         $stmt->execute();
         $base_id = (int)$pdo->lastInsertId();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): INSERT locations Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'INSERT locations failed : ' . $e->getMessage(), ['controller_id' => $controller_id, 'zone_id' => $zone_id], 'error');
         return false;
     }
 
@@ -327,16 +341,17 @@ function createBase($pdo, $controller_id, $zone_id) {
 }
 
 /**
- * Changes the base to the new zone
- * 
+ * Move the controller base to the new zone.
+ *
  * @param PDO $pdo : database connection
- * @param int : $base_id 
- * @param int : $zone_id 
- * 
- * @return bool
- * 
+ * @param int|null $base_id : base (location) id (NULL when the caller received no _GET param)
+ * @param int|null $zone_id : target zone id (NULL when the caller received no _GET param)
+ * @param int|null $controller_id : owning controller id (NULL when the caller received no _GET param)
+ * @return bool : true on success, false on cost/update failure
  */
-function moveBase($pdo, $base_id, $zone_id, $controller_id) {
+function moveBase(PDO $pdo, int|null $base_id, int|null $zone_id, int|null $controller_id): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with base_id : ' . $base_id, ['zone_id' => $zone_id, 'controller_id' => $controller_id], 'debug');
 
     if (!spendRessourcesToMoveBase($pdo, $controller_id)) {
         echo "Stock insuffisant ou modifié.<br />";
@@ -357,23 +372,23 @@ function moveBase($pdo, $base_id, $zone_id, $controller_id) {
         $sel->execute();
         $inFlight = $sel->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT in-flight attacks failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT in-flight attacks failed : ' . $e->getMessage(), ['base_id' => $base_id, 'turn_number' => $turn_number], 'warning');
         $inFlight = [];
     }
     foreach ($inFlight as $row) {
         failQueuedLocationAttack($pdo, $row, $turn_number, 'moved');
     }
 
-    // Defensive: ensure any pre-existing base lacking the fortress tag gets it.              
-    try {                                                                                     
+    // Defensive: ensure any pre-existing base lacking the fortress tag gets it.
+    try {
         $stmt = $pdo->prepare("UPDATE {$prefix}locations SET location_types = '[\"fortress\"]'
-            WHERE id = :base_id AND location_types IS NULL");                                            
-        $stmt->bindParam(':base_id', $base_id, PDO::PARAM_INT);                               
-            $stmt->execute();                                                                     
-        } catch (PDOException $e) {                                                               
-            echo __FUNCTION__."(): UPDATE location_types failed: " . $e->getMessage()."<br />";   
+            WHERE id = :base_id AND location_types IS NULL");
+        $stmt->bindParam(':base_id', $base_id, PDO::PARAM_INT);
+            $stmt->execute();
+        } catch (PDOException $e) {
+            game_error_log(__FUNCTION__, 'UPDATE location_types failed : ' . $e->getMessage(), ['base_id' => $base_id], 'warning');
     }
-  
+
     // update locations set zone_id where controller_id = "%s";
     $sql = "UPDATE {$prefix}locations SET zone_id = :zone_id, setup_turn = (SELECT turncounter FROM {$prefix}mechanics LIMIT 1) WHERE id = :base_id";
     try{
@@ -390,7 +405,7 @@ function moveBase($pdo, $base_id, $zone_id, $controller_id) {
         $deleteStmt->bindParam(':base_id', $base_id, PDO::PARAM_INT);
         $deleteStmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): UPDATE locations SET zone_id: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'UPDATE locations SET zone_id failed : ' . $e->getMessage(), ['base_id' => $base_id, 'zone_id' => $zone_id], 'error');
         return false;
     }
 
@@ -404,15 +419,16 @@ function moveBase($pdo, $base_id, $zone_id, $controller_id) {
 }
 
 /**
- * Affiche les options de sélection pour les bases connues et attaquables par un contrôleur
- * 
- * @param PDO $pdo
- * @param int $controller_id
- * 
- * @return string returnText
- * 
+ * Render the select options for bases known and attackable by a controller.
+ *
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : attacking controller id
+ * @return string|null : HTML select field or NULL if no attackable location
  */
-function showAttackableControllerKnownLocations($pdo, $controller_id) {
+function showAttackableControllerKnownLocations(PDO $pdo, int $controller_id): string|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
+
     // Exclude own — controller cannot attack own base.
     $excludePending = in_array(getConfig($pdo, 'locationAttackMode'), ['endTurn'], true);
     $locations = listControllerKnownLocations($pdo, $controller_id, true, false, true, $excludePending);
@@ -443,15 +459,16 @@ function showAttackableControllerKnownLocations($pdo, $controller_id) {
 }
 
 /**
- * Affiche les options de sélection pour les bases connues et réparables par un contrôleur
- * 
- * @param PDO $pdo
- * @param int $controller_id
- * 
- * @return string returnText
- * 
+ * Render the select options for bases known and repairable by a controller.
+ *
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : owning controller id
+ * @return string|null : HTML select field or NULL if no repairable location
  */
-function showRepairableControllerKnownLocations($pdo, $controller_id) {
+function showRepairableControllerKnownLocations(PDO $pdo, int $controller_id): string|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
+
     $locations = listControllerKnownLocations($pdo, $controller_id, false, true);
     if (empty($locations)) return NULL;
 
@@ -480,17 +497,18 @@ function showRepairableControllerKnownLocations($pdo, $controller_id) {
 }
 
 /**
- * 
- * 
- * @param PDO $pdo
- * @param int $controller_id
- * @param int $target_location_id
- * 
- * @return array $return
- * 
+ * Attack a target location (immediate or queued at end of turn).
+ *
+ * @param PDO $pdo : database connection
+ * @param int|null $controller_id : attacking controller id (NULL when the caller received no _GET param)
+ * @param int|null $target_location_id : target location id (NULL when the caller received no _GET param)
+ * @return array|null : outcome ['success', 'message', ...], or NULL on SELECT failure
  */
-function attackLocation($pdo, $controller_id, $target_location_id) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function attackLocation(PDO $pdo, int|null $controller_id, int|null $target_location_id): array|null {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['target_location_id' => $target_location_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     $mode = getConfig($pdo, 'locationAttackMode');
@@ -510,7 +528,7 @@ function attackLocation($pdo, $controller_id, $target_location_id) {
         $stmt->execute([':id' => $target_location_id]);
         $location = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT location failed : ' . $e->getMessage(), ['target_location_id' => $target_location_id], 'error');
         return NULL;
     }
     if (empty($location)) {
@@ -518,11 +536,11 @@ function attackLocation($pdo, $controller_id, $target_location_id) {
     }
 
     $zone_id = $location[0]['zone_id'];
-    if ($debug) echo sprintf("%s() SELECT * FROM locations : %s <br>",__FUNCTION__, var_export($location, true));
+    game_error_log(__FUNCTION__, 'SELECT * FROM locations', ['location' => $location], 'debug');
     $controllerAttack = calculatecontrollerAttack($pdo, $zone_id, $controller_id);
-    if ($debug) echo sprintf("%s() controllerAttack : %s <br>",__FUNCTION__, var_export($controllerAttack, true));
+    game_error_log(__FUNCTION__, 'controllerAttack : ' . var_export($controllerAttack, true), [], 'debug');
     $locationDefence = calculateSecretLocationDefence($pdo, $zone_id, $target_location_id, $location[0]['controller_id']);
-    if ($debug) echo sprintf("%s() locationDefence : %s <br>",__FUNCTION__, var_export($locationDefence, true));
+    game_error_log(__FUNCTION__, 'locationDefence : ' . var_export($locationDefence, true), [], 'debug');
 
     if ($mode === 'endTurn') {
         try {
@@ -550,7 +568,7 @@ function attackLocation($pdo, $controller_id, $target_location_id) {
                 return array('success' => false, 'queued' => false, 'message' => 'Attaque déjà planifiée ce tour.');
             }
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): INSERT controller_location_attacks Failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'INSERT controller_location_attacks failed : ' . $e->getMessage(), ['target_location_id' => $target_location_id, 'controller_id' => $controller_id, 'turn_number' => $turn_number], 'error');
             return array('success' => false, 'message' => 'Error : Queue Failed');
         }
         return array(
@@ -563,8 +581,22 @@ function attackLocation($pdo, $controller_id, $target_location_id) {
     return resolveLocationAttackEffects($pdo, $location[0], $controller_id, $turn_number, $controllerAttack, $locationDefence);
 }
 
-function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_number, $controllerAttack, $locationDefence) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+/**
+ * Resolve the effects of a location attack (destruction, capture, logs, agent reports).
+ *
+ * @param PDO $pdo : database connection
+ * @param array $location : target location row (must include 'id', 'zone_id', 'controller_id', 'name', 'activate_json', 'zone_name')
+ * @param int $controller_id : attacking controller id
+ * @param int $turn_number : current turn
+ * @param int $controllerAttack : resolved attack value
+ * @param int $locationDefence : resolved defence value
+ * @return array|null : ['success', 'message'], or NULL on DELETE failure
+ */
+function resolveLocationAttackEffects(PDO $pdo, array $location, int $controller_id, int $turn_number, int $controllerAttack, int $locationDefence): array|null {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with target_location_id : ' . ($location['id'] ?? ''), ['controller_id' => $controller_id, 'turn_number' => $turn_number, 'controllerAttack' => $controllerAttack, 'locationDefence' => $locationDefence, 'location' => $location], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $return = array('success' => false, 'message' => '');
     $targetResultText = '';
@@ -572,7 +604,7 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
     $zone_id = $location['zone_id'];
     $target_location_id = $location['id'];
     $attackLocationDiff = getConfig($pdo, 'attackLocationDiff');
-    if ($debug) echo sprintf("%s() attackLocationDiff : %s <br>",__FUNCTION__, var_export($attackLocationDiff, true));
+    game_error_log(__FUNCTION__, 'attackLocationDiff : ' . var_export($attackLocationDiff, true), [], 'debug');
 
     if (($controllerAttack - $locationDefence) >= $attackLocationDiff){
         $return['success'] = true;
@@ -581,7 +613,7 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
         // Notre %s a été attaqué.e, par des agents du réseau %s. Ils ont franchi les portes avec succès.
         $locationAttackSuccessTextsArray = json_decode(getConfig($pdo,'TEXT_LOCATION_ATTACK_SUCCESS'), true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            echo __FUNCTION__."(): JSON decoding error: " . json_last_error_msg() . "<br />";
+            game_error_log(__FUNCTION__, 'JSON decoding error : ' . json_last_error_msg(), ['config_key' => 'TEXT_LOCATION_ATTACK_SUCCESS'], 'warning');
             $locationAttackSuccessTextsArray = array("Notre %s a été attaqué.e, par des agents du réseau %s. Ils ont franchi les portes avec succès.");
         }
         $targetResultText .= sprintf(
@@ -593,7 +625,7 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
         if (!empty($location['activate_json'])) {
             $activate_json = json_decode($location['activate_json'], true);
             if (json_last_error() !== JSON_ERROR_NONE) {
-                echo __FUNCTION__."(): JSON decoding error: " . json_last_error_msg() . "<br />";
+                game_error_log(__FUNCTION__, 'JSON decoding error : ' . json_last_error_msg(), ['location_id' => $target_location_id, 'activate_json' => $location['activate_json']], 'warning');
                 $activate_json = array();
             }
             $textSuccess = getConfig($pdo, 'textLocationDestroyed');
@@ -635,7 +667,7 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
                 $stmt = $pdo->prepare($sql);
                 $stmt->execute([':id' => $target_location_id]);
             } catch (PDOException $e) {
-                echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+                game_error_log(__FUNCTION__, 'DELETE location failed : ' . $e->getMessage(), ['target_location_id' => $target_location_id], 'error');
                 return NULL;
             }
             $targetResultText .= ' Tout a été détruit.';
@@ -643,7 +675,7 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
     } else {
         $locationAttackFailTextsArray = json_decode(getConfig($pdo,'TEXT_LOCATION_ATTACK_FAIL'), true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            echo __FUNCTION__."(): JSON decoding error: " . json_last_error_msg() . "<br />";
+            game_error_log(__FUNCTION__, 'JSON decoding error : ' . json_last_error_msg(), ['config_key' => 'TEXT_LOCATION_ATTACK_FAIL'], 'warning');
             $locationAttackFailTextsArray = array("Notre %s a été attaqué.e, par des agents du réseau %s.  Heureusement, ils ne semblent pas avoir atteint leur objectif.");
         }
         $targetResultText .= sprintf(
@@ -694,7 +726,7 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
         $logStmt->bindParam(':turn_number', $turn_number, PDO::PARAM_INT);
         $logStmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): INSERT location_attack_logs Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'INSERT location_attack_logs failed : ' . $e->getMessage(), ['target_location_id' => $target_location_id, 'controller_id' => $controller_id, 'turn_number' => $turn_number], 'error');
         return array('success' => false, 'message' => 'Error : Resultat Save Failed');
     }
 
@@ -710,7 +742,7 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
     }
     $locationAttackAgentReportArray = json_decode($locationAttackAgentReportJson, true);
     if (json_last_error() !== JSON_ERROR_NONE) {
-        echo __FUNCTION__."(): JSON decoding error: " . json_last_error_msg() . "<br />";
+        game_error_log(__FUNCTION__, 'JSON decoding error : ' . json_last_error_msg(), ['config_key' => 'TEXT_LOCATION_ATTACK_AGENT_REPORT_*'], 'warning');
         $locationAttackAgentReportArray = array("Attaque du lieu %s dans %s %s.<br/>");
     }
 
@@ -747,7 +779,7 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
         }
         $locationDefenceAgentReportArray = json_decode($locationDefenceAgentReportJson, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            echo __FUNCTION__."(): JSON decoding error: " . json_last_error_msg() . "<br />";
+            game_error_log(__FUNCTION__, 'JSON decoding error : ' . json_last_error_msg(), ['config_key' => 'TEXT_LOCATION_DEFENCE_AGENT_REPORT_*'], 'warning');
             $locationDefenceAgentReportArray = array('Défense du lieu %s dans %s contre les agent du réseau %s.<br/>');
         }
 
@@ -770,15 +802,17 @@ function resolveLocationAttackEffects($pdo, $location, $controller_id, $turn_num
 }
 
 /**
- * Changes all Artefacts in the location to the new controllers base.
- * 
- * @param PDO $pdo
- * @param int $controller_id
- * @param int $target_location_id
- * 
- * @return string message
+ * Move all artefacts from a captured location to the capturing controller's base.
+ *
+ * @param PDO $pdo : database connection
+ * @param int $location_id : source (captured) location id
+ * @param int $controller_id : capturing controller id
+ * @return array : ['success' => bool, 'message' => string]
  */
-function captureLocationsArtefacts($pdo, $location_id, $controller_id) {
+function captureLocationsArtefacts(PDO $pdo, int $location_id, int $controller_id): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with location_id : ' . $location_id, ['controller_id' => $controller_id], 'debug');
+
     $return = array('success' => true, 'message' => '');
     $prefix = $_SESSION['GAME_PREFIX'];
 
@@ -810,13 +844,15 @@ function captureLocationsArtefacts($pdo, $location_id, $controller_id) {
 /**
  * Read a single CKE row for (controller, worker). Caller compares prior state (zone_id + level flags) before calling addWorkerToCKE.
  *
- * @param PDO $pdo
- * @param int $controller_id
- * @param int $worker_id
- *
- * @return array|null  associative row, or NULL if no CKE entry exists
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : observing controller id
+ * @param int $worker_id : discovered worker id
+ * @return array|null : associative row, or NULL if no CKE entry exists / on error
  */
-function getCKEEntry($pdo, $controller_id, $worker_id) {
+function getCKEEntry(PDO $pdo, int $controller_id, int $worker_id): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['worker_id' => $worker_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
         $sql = "SELECT * FROM {$prefix}controllers_known_enemies
@@ -829,42 +865,44 @@ function getCKEEntry($pdo, $controller_id, $worker_id) {
         ]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Error SELECT FROM {$prefix}controllers_known_enemies Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT controllers_known_enemies failed : ' . $e->getMessage(), ['controller_id' => $controller_id, 'worker_id' => $worker_id], 'error');
         return NULL;
     }
     return $row ?: NULL;
 }
 
 /**
+ * Upsert a CKE row for (searcher, worker). Only fills discovered_* columns when the caller passes them truthy.
  *
- * @param PDO $pdo
- * @param int $searcher_controller_id
- * @param int $found_id
- * @param int $turn_number
- * @param int $zone_id
- * @param int|null $discovered_controller_id   monotonic — only persisted if truthy
- * @param string|null $discovered_controller_name   monotonic — only persisted if truthy
- * @param bool $discovered_powers   monotonic — DIFF1 flag (disciplines/transformations/hobby revealed); only persisted if truthy
- *
- * @return int $cke_existing_record_id
- *
+ * @param PDO $pdo : database connection
+ * @param int $searcher_controller_id : observing controller id
+ * @param int $found_worker_id : discovered worker id
+ * @param int $turn_number : turn of discovery
+ * @param int $zone_id : zone id of the sighting
+ * @param int|null $discovered_controller_id : monotonic — only persisted if truthy
+ * @param string|null $discovered_controller_name : monotonic — only persisted if truthy
+ * @param bool $discovered_powers : monotonic — DIFF1 flag (disciplines/transformations/hobby revealed); only persisted if truthy
+ * @return int|string|null : existing/inserted row id (string from lastInsertId), or NULL when the worker is already controlled or on hard-fail
  */
 function addWorkerToCKE(
-        $pdo,
-        $searcher_controller_id,
-        $found_worker_id,
-        $turn_number,
-        $zone_id,
-        $discovered_controller_id = NULL,
-        $discovered_controller_name = NULL,
-        $discovered_powers = false
-    ) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+        PDO $pdo,
+        int $searcher_controller_id,
+        int $found_worker_id,
+        int $turn_number,
+        int $zone_id,
+        int|null $discovered_controller_id = NULL,
+        string|null $discovered_controller_name = NULL,
+        bool $discovered_powers = false
+    ): int|string|null {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with searcher_controller_id : ' . $searcher_controller_id, ['found_worker_id' => $found_worker_id, 'turn_number' => $turn_number, 'zone_id' => $zone_id, 'discovered_controller_id' => $discovered_controller_id, 'discovered_controller_name' => $discovered_controller_name, 'discovered_powers' => $discovered_powers], 'debug');
 
     $cke_existing_record_id = NULL;
+    $count = 0;
 
     $prefix = $_SESSION['GAME_PREFIX'];
-    
+
     try{
         // Only add information to controllers_known_enemies if the worker is not controlled by the target controller
         $sql = "SELECT COUNT(*) AS count FROM {$prefix}controller_worker WHERE controller_id = :searcher_controller_id AND worker_id = :found_worker_id";
@@ -875,10 +913,10 @@ function addWorkerToCKE(
         ]);
         $count = $stmt->fetch(PDO::FETCH_ASSOC)['count'];
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Error COUNT(*) FROM {$prefix}controller_worker Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'COUNT(*) FROM controller_worker failed : ' . $e->getMessage(), ['searcher_controller_id' => $searcher_controller_id, 'found_worker_id' => $found_worker_id], 'warning');
     }
     if ($count == 1) {
-        if ($debug) echo __FUNCTION__."(): COUNT(*) FROM {$prefix}controller_worker; Worker is already controlled by the target controller<br />";
+        game_error_log(__FUNCTION__, 'Worker is already controlled by the target controller', ['searcher_controller_id' => $searcher_controller_id, 'found_worker_id' => $found_worker_id], 'debug');
         return NULL;
     }
 
@@ -893,9 +931,9 @@ function addWorkerToCKE(
             ':found_worker_id' => $found_worker_id
         ]);
         $existingRecord = $stmt->fetch(PDO::FETCH_ASSOC);
-        if ($debug) echo sprintf(" existingRecord: %s<br/> ", var_export($existingRecord,true));
+        game_error_log(__FUNCTION__, 'existingRecord lookup', ['existingRecord' => $existingRecord], 'debug');
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Error SELECT id FROM {$prefix}controllers_known_enemies Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT id FROM controllers_known_enemies failed : ' . $e->getMessage(), ['searcher_controller_id' => $searcher_controller_id, 'found_worker_id' => $found_worker_id], 'error');
         return NULL;
     }
 
@@ -911,7 +949,7 @@ function addWorkerToCKE(
                 $discovered_controller_name ? ", discovered_controller_name = :discovered_controller_name" : "",
                 $discovered_powers ? ", discovered_powers = :discovered_powers" : ""
             );
-            if ($debug) echo sprintf(" existingRecord: %s<br/> ", var_export($existingRecord,true));
+            game_error_log(__FUNCTION__, 'UPDATE existingRecord', ['existingRecord' => $existingRecord, 'sql' => $sql], 'debug');
             $stmt = $pdo->prepare($sql);
             $stmt->bindParam(':turn_number', $turn_number, PDO::PARAM_INT);
             $stmt->bindParam(':zone_id', $zone_id, PDO::PARAM_INT);
@@ -927,7 +965,7 @@ function addWorkerToCKE(
             }
             $stmt->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): Error UPDATE {$prefix}controllers_known_enemies Failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'UPDATE controllers_known_enemies failed : ' . $e->getMessage(), ['id' => $existingRecord['id'] ?? null, 'searcher_controller_id' => $searcher_controller_id, 'found_worker_id' => $found_worker_id], 'warning');
         }
     } else {
         try{
@@ -935,7 +973,7 @@ function addWorkerToCKE(
             $sql = "INSERT INTO {$prefix}controllers_known_enemies
                 (controller_id, discovered_worker_id, first_discovery_turn, last_discovery_turn, zone_id, discovered_controller_id, discovered_controller_name, discovered_powers)
                 VALUES (:searcher_controller_id, :found_worker_id, :turn_number, :turn_number, :zone_id, :discovered_controller_id, :discovered_controller_name, :discovered_powers)";
-            if ($debug) echo "sql :".var_export($sql, true)." <br>";
+            game_error_log(__FUNCTION__, 'INSERT sql', ['sql' => $sql], 'debug');
             $stmt = $pdo->prepare($sql);
             $stmt->bindParam(':searcher_controller_id', $searcher_controller_id, PDO::PARAM_INT);
             $stmt->bindParam(':found_worker_id', $found_worker_id, PDO::PARAM_INT);
@@ -947,7 +985,7 @@ function addWorkerToCKE(
             $stmt->execute();
             $cke_existing_record_id = $pdo->lastInsertId();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): Error INSERT INTO {$prefix}controllers_known_enemies Failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'INSERT INTO controllers_known_enemies failed : ' . $e->getMessage(), ['searcher_controller_id' => $searcher_controller_id, 'found_worker_id' => $found_worker_id, 'turn_number' => $turn_number, 'zone_id' => $zone_id], 'warning');
         }
     }
     return $cke_existing_record_id;
@@ -956,13 +994,15 @@ function addWorkerToCKE(
 /**
  * Read a single CKL row for (controller, location). Caller compares prior state (found_secret) before calling addLocationToCKL.
  *
- * @param PDO $pdo
- * @param int $controller_id
- * @param int $location_id
- *
- * @return array|null  associative row, or NULL if no CKL entry exists
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : observing controller id
+ * @param int $location_id : known location id
+ * @return array|null : associative row, or NULL if no CKL entry exists / on error
  */
-function getCKLEntry($pdo, $controller_id, $location_id) {
+function getCKLEntry(PDO $pdo, int $controller_id, int $location_id): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['location_id' => $location_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
         $sql = "SELECT * FROM {$prefix}controller_known_locations
@@ -975,24 +1015,27 @@ function getCKLEntry($pdo, $controller_id, $location_id) {
         ]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Error SELECT FROM {$prefix}controller_known_locations Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT controller_known_locations failed : ' . $e->getMessage(), ['controller_id' => $controller_id, 'location_id' => $location_id], 'error');
         return NULL;
     }
     return $row ?: NULL;
 }
 
 /**
+ * Upsert a CKL row for (controller, location). Only fills found_secret when the caller passes it truthy.
  *
- * @param PDO $pdo
- * @param int $controller_id
- * @param int $location_id
- * @param int $turn_number
- *
- * @return int $ckl_existing_record_id
- *
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : observing controller id
+ * @param int $location_id : known location id
+ * @param int $turn_number : turn of discovery
+ * @param bool $found_secret : monotonic flag — only persisted if truthy
+ * @return int|string|null : existing/inserted row id (string from lastInsertId), or NULL on hard-fail
  */
-function addLocationToCKL($pdo, $controller_id, $location_id, $turn_number, $found_secret) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function addLocationToCKL(PDO $pdo, int $controller_id, int $location_id, int $turn_number, bool $found_secret): int|string|null {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['location_id' => $location_id, 'turn_number' => $turn_number, 'found_secret' => $found_secret], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     $ckl_existing_record_id = NULL;
@@ -1007,7 +1050,7 @@ function addLocationToCKL($pdo, $controller_id, $location_id, $turn_number, $fou
         ':location_id' => $location_id
     ]);
     $existingRecord = $stmt->fetch(PDO::FETCH_ASSOC);
-    if ($debug) echo sprintf(" existingRecord: %s<br/> ", var_export($existingRecord,true));
+    game_error_log(__FUNCTION__, 'existingRecord lookup', ['existingRecord' => $existingRecord], 'debug');
 
     if (!empty($existingRecord)) {
         try{
@@ -1027,7 +1070,7 @@ function addLocationToCKL($pdo, $controller_id, $location_id, $turn_number, $fou
             $stmt->bindParam(':id', $existingRecord['id'], PDO::PARAM_INT);
             $stmt->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): Error UPDATE {$prefix}controller_known_locations Failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'UPDATE controller_known_locations failed : ' . $e->getMessage(), ['id' => $existingRecord['id'] ?? null, 'controller_id' => $controller_id, 'location_id' => $location_id], 'warning');
         }
     } else {
         try{
@@ -1046,21 +1089,23 @@ function addLocationToCKL($pdo, $controller_id, $location_id, $turn_number, $fou
             $insertStmt->execute();
             $ckl_existing_record_id = $pdo->lastInsertId();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): Error INSERT INTO {$prefix}controller_known_locations Failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'INSERT INTO controller_known_locations failed : ' . $e->getMessage(), ['controller_id' => $controller_id, 'location_id' => $location_id, 'turn_number' => $turn_number], 'warning');
         }
     }
     return $ckl_existing_record_id;
 }
 
 /**
- * Show the owned artefacts of a controller
- * 
- * @param PDO $pdo
- * @param int $controller_id
- * 
- * @return string
+ * Show the owned artefacts of a controller.
+ *
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : owning controller id
+ * @return string : HTML fragment listing artefacts
  */
-function showOwnedArtefacts($pdo, $controller_id) {
+function showOwnedArtefacts(PDO $pdo, int $controller_id): string {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
+
     $html = '';
     $prefix = $_SESSION['GAME_PREFIX'];
     $sql ="SELECT artefacts.name, artefacts.description, artefacts.full_description
@@ -1078,15 +1123,18 @@ function showOwnedArtefacts($pdo, $controller_id) {
     return $html;
 }
 
-/** Build HTML to give knowleadge of a worker to a controller
- * 
+/**
+ * Build HTML to give knowledge (agent or location) from one controller to another.
+ *
  * @param PDO $pdo : database connection
- * @param int $controller_id
- * @param int $turn_number
- * 
- * @return string
+ * @param string $origin : 'controller' (player view) or 'admin' (management view)
+ * @param int|null $controller_id : giver controller id, NULL for admin origin
+ * @return string : HTML block with the two gift forms
  */
-function buildGiveKnowledgeHTML($pdo, $origin = 'controller', $controller_id = NULL) {
+function buildGiveKnowledgeHTML(PDO $pdo, string $origin = 'controller', int|null $controller_id = NULL): string {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with origin : ' . $origin, ['controller_id' => $controller_id], 'debug');
+
     $html = '';
 
     $returnLink = '/controllers/action.php';
@@ -1229,21 +1277,22 @@ function buildGiveKnowledgeHTML($pdo, $origin = 'controller', $controller_id = N
 }
 
 /**
- * Append a row to information_gift_logs. Silent on error; the caller's
- * actual gift-information action has already succeeded (CKE/CKL row
- * written) and we don't want the log failure to surface as a user-facing
- * error.
+ * Append a row to information_gift_logs. Silent on error; the caller's actual
+ * gift-information action has already succeeded (CKE/CKL row written) and we
+ * don't want the log failure to surface as a user-facing error.
  *
- * @param PDO    $pdo
- * @param int    $giver_id
- * @param int    $recipient_id
- * @param string $target_type 'agent' | 'location'
- * @param int    $target_id   worker_id or location_id
- * @param int    $turn
- *
+ * @param PDO $pdo : database connection
+ * @param int $giver_id : giver controller id
+ * @param int $recipient_id : recipient controller id
+ * @param string $target_type : 'agent' | 'location'
+ * @param int $target_id : worker_id or location_id
+ * @param int $turn : current turn number
  * @return void
  */
-function logInformationGift($pdo, $giver_id, $recipient_id, $target_type, $target_id, $turn) {
+function logInformationGift(PDO $pdo, int $giver_id, int $recipient_id, string $target_type, int $target_id, int $turn): void {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with giver_id : ' . $giver_id, ['recipient_id' => $recipient_id, 'target_type' => $target_type, 'target_id' => $target_id, 'turn' => $turn], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
         $stmt = $pdo->prepare("INSERT INTO {$prefix}information_gift_logs
@@ -1257,22 +1306,24 @@ function logInformationGift($pdo, $giver_id, $recipient_id, $target_type, $targe
             ':turn'      => (int)$turn,
         ]);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): INSERT information_gift_logs failed: ".$e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'INSERT information_gift_logs failed : ' . $e->getMessage(), ['giver_id' => $giver_id, 'recipient_id' => $recipient_id, 'target_type' => $target_type, 'target_id' => $target_id, 'turn' => $turn], 'warning');
     }
 }
 
 /**
  * Fetch information gifts received by a controller, newest first.
  * Each row resolves `target_label` via the appropriate table:
- *   target_type='agent'    → worker firstname + lastname
- *   target_type='location' → location name
+ *   target_type='agent'    -> worker firstname + lastname
+ *   target_type='location' -> location name
  *
- * @param PDO $pdo
- * @param int $controller_id
- *
- * @return array each row: ['turn', 'giver', 'target_type', 'target_label']
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : recipient controller id
+ * @return array : rows ['turn', 'giver', 'target_type', 'target_id', 'target_label']
  */
-function getInformationGiftsReceived($pdo, $controller_id) {
+function getInformationGiftsReceived(PDO $pdo, int $controller_id): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
         $sql = "SELECT
@@ -1288,7 +1339,7 @@ function getInformationGiftsReceived($pdo, $controller_id) {
         $stmt->execute([':recipient' => (int)$controller_id]);
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT information_gift_logs failed: ".$e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT information_gift_logs failed : ' . $e->getMessage(), ['controller_id' => $controller_id], 'error');
         return [];
     }
 

--- a/controllers/view.php
+++ b/controllers/view.php
@@ -5,6 +5,8 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
     exit();
 }
 
+// $GLOBALS['DEBUG_LOG_SECTIONS'][] = 'controllers_view_page';  // uncomment to log DEBUG events from this page
+
     // Get zones information
     $zonesArray = getZonesArray($gameReady);
 
@@ -22,7 +24,7 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
             $stmtPlayers = $gameReady->prepare($sqlPlayers);
             $stmtPlayers->execute();
         } catch (PDOException $e) {
-            echo sprintf("%s(): %s failed:  %s <br />",  __FUNCTION__, $e->getMessage(), $_SESSION['user_id']);
+            game_error_log('controllers_view_page', 'SELECT player failed : ' . $e->getMessage(), ['user_id' => $_SESSION['user_id']], 'error');
         }
         // Fetch the results
         $players = $stmtPlayers->fetchAll(PDO::FETCH_ASSOC);
@@ -144,11 +146,12 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
                     </div>
                 </div>';
 
-                if (!hasEnoughRessourcesToMoveBase($gameReady, $controllers['id']))
+                if (!hasEnoughRessourcesToMoveBase($gameReady, $controllers['id'])) {
                     $baseMoveHTML = sprintf(
-                        '<div class="notification is-danger">Vous n\'avez pas les ressources nécessaires pour déménager une base %s.</div>', 
+                        '<div class="notification is-danger">Vous n\'avez pas les ressources nécessaires pour déménager une base %s.</div>',
                         moveBaseCostHTML($gameReady, $controllers['id'])
                     );
+                }
 
                 $htmlBase .= '<p>';
                 foreach ($bases as $base ){

--- a/index.php
+++ b/index.php
@@ -7,17 +7,24 @@ if ( !isset($_SESSION['DEBUG']) ){
 
 $pageName = 'index';
 
+// Set BEFORE errorLog.php require so its ini_set('error_log', ...) picks it up.
+$GLOBALS['LOG_PATH'] = __DIR__ . '/var/logs/game_errors.log';
+
+require_once './base/errorLog.php';
 require_once './BDD/db_connector.php';
 
 /**
  * get value from Config by name
- * 
+ *
  * @param PDO $pdo : database connection
- * @param string $configName
- * 
- * @return string|null : value
+ * @param string $configName : config key to look up
+ *
+ * @return string|null : value, or NULL on missing key / PDO error
  */
-function getConfig($pdo, $configName) {
+function getConfig(PDO $pdo, string $configName): string|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with configName : ' . $configName, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try{
         $stmt = $pdo->prepare("SELECT value
@@ -25,9 +32,10 @@ function getConfig($pdo, $configName) {
             WHERE name = :configName
         ");
         $stmt->execute([':configName' => $configName]);
-        return $stmt->fetchColumn();
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : NULL;
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $configName failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT value failed : ' . $e->getMessage(), ['configName' => $configName], 'error');
         return NULL;
     }
 }

--- a/mechanics/attackMechanic.php
+++ b/mechanics/attackMechanic.php
@@ -7,17 +7,19 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
 
 /**
  * Search database for all workers in attack mode and return their targets and combat power differences.
- * 
+ *
  * @param PDO $pdo : database connection
- * @param string|null $turn_number
- * @param int|null $attacker_id
- * 
- * @return array $final_attacks_aggregate
- * 
+ * @param int|null $turn_number : turn number (falls back to current turn from mechanics when empty)
+ * @param int|null $attacker_id : optional attacker id filter
+ *
+ * @return array : final_attacks_aggregate — map attacker_id => list of defender comparison rows
  */
-function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) {
-    $debug = false;
-    if (strtolower(getConfig($pdo, 'DEBUG_ATTACK')) == 'true') $debug = true;
+function getAttackerComparisons(PDO $pdo, int|null $turn_number = NULL, int|null $attacker_id = NULL): array {
+    if (strtolower(getConfig($pdo, 'DEBUG_ATTACK')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . ($turn_number ?? 'NULL'), ['attacker_id' => $attacker_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     // Check turn number is selected
@@ -25,7 +27,7 @@ function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) 
         $mechanics = getMechanics($pdo);
         $turn_number = $mechanics['turncounter'];
     }
-    if ($debug) echo "turn_number : $turn_number <br>";
+    game_error_log(__FUNCTION__, 'turn_number : ' . $turn_number, [], 'debug');
 
     try{
         // Define the SQL query to get all attackers for the turn
@@ -51,12 +53,11 @@ function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) 
         $stmt->bindParam(':turn_number', $turn_number);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Failed to SELECT list of attackers: " . $e->getMessage() . "<br />";
+        game_error_log(__FUNCTION__, 'SELECT list of attackers failed', ['error' => $e->getMessage()]);
     }
 
     $attackersActionArray = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    if ($debug)
-        echo sprintf("attackersActionArray : %s <br/>", var_export($attackersActionArray, true));
+    game_error_log(__FUNCTION__, 'attackersActionArray fetched', ['attackersActionArray' => $attackersActionArray], 'debug');
 
     $attackArray = array();
     // For each attacker we get the targets of the action
@@ -65,7 +66,7 @@ function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) 
             $attackArray[$attackAction['attacker_id']]=array();
             $attackParams = json_decode($attackAction['params'], true);
             if (json_last_error() !== JSON_ERROR_NONE) {
-                echo __FUNCTION__."(): JSON decoding error: " . json_last_error_msg() . "<br />";
+                game_error_log(__FUNCTION__, 'JSON decode error', ['error' => json_last_error_msg(), 'attacker_id' => $attackAction['attacker_id']]);
                 $attackParams = array();
             }
             foreach($attackParams AS $param){
@@ -80,11 +81,10 @@ function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) 
                         $stmtNetworkSearch->bindParam(':controller_id', $attackAction['controller_id'], PDO::PARAM_INT);
                         $stmtNetworkSearch->execute();
                     } catch (PDOException $e) {
-                        echo __FUNCTION__."(): Failed to SELECT list of attackers for network : " . $e->getMessage() . "<br />";
+                        game_error_log(__FUNCTION__, 'SELECT list of attackers for network failed', ['error' => $e->getMessage(), 'network_id' => $param['attackID']]);
                     }
                     $networkWorkersList = $stmtNetworkSearch->fetchAll(PDO::FETCH_COLUMN);
-                    if ($debug)
-                        echo sprintf("networkWorkersList : %s <br/>", var_export($networkWorkersList, true));
+                    game_error_log(__FUNCTION__, 'networkWorkersList fetched', ['networkWorkersList' => $networkWorkersList], 'debug');
                     foreach($networkWorkersList AS $worker_id){
                         if (!in_array($worker_id, $attackArray[$attackAction['attacker_id']]) ) {
                             $attackArray[$attackAction['attacker_id']][] = $worker_id;
@@ -100,8 +100,7 @@ function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) 
         }
     }
 
-    if ($debug)
-        echo sprintf("attackArray : %s <br/>", var_export($attackArray, true));
+    game_error_log(__FUNCTION__, 'attackArray built', ['attackArray' => $attackArray], 'debug');
 
     // Build SQL to compare attacker value to target value
     $sqlValCompare = "
@@ -224,8 +223,7 @@ function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) 
 
     foreach ($attackArray AS $compared_attacker_id => $defender_ids ) {
         try {
-            if ($debug)
-                echo sprintf("compared_attacker_id : %s => defender_ids : %s <br/>", $compared_attacker_id, var_export($defender_ids, true));
+            game_error_log(__FUNCTION__, 'compared_attacker_id : ' . $compared_attacker_id, ['defender_ids' => $defender_ids], 'debug');
 
             $stmtValCompare = $pdo->prepare(
                 sprintf(
@@ -239,12 +237,11 @@ function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) 
             $stmtValCompare->bindParam(':attacker_id', $compared_attacker_id, PDO::PARAM_INT);
             $stmtValCompare->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__."():Failed to SELECT compare attackers to defenders : " . $e->getMessage() . "<br />";
+            game_error_log(__FUNCTION__, 'SELECT compare attackers to defenders failed', ['error' => $e->getMessage(), 'attacker_id' => $compared_attacker_id]);
         }
         if ($stmtValCompare->rowCount() == 0) continue;
         $final_attacks_aggregate[$compared_attacker_id] = $stmtValCompare->fetchAll(PDO::FETCH_ASSOC);
-        if ($debug)
-            echo sprintf("final_attacks_aggregate : %s <br/>", var_export($final_attacks_aggregate[$compared_attacker_id], true));
+        game_error_log(__FUNCTION__, 'final_attacks_aggregate row for attacker : ' . $compared_attacker_id, ['row' => $final_attacks_aggregate[$compared_attacker_id]], 'debug');
     }
     return $final_attacks_aggregate;
 
@@ -252,33 +249,40 @@ function getAttackerComparisons($pdo, $turn_number = NULL, $attacker_id = NULL) 
 
 /**
  * Main function to calculate attack results.
- * 
+ *
  * @param PDO $pdo : database connection
- * @param array $mechanics : mechanics array
- * 
+ * @param array $mechanics : mechanics array (uses turncounter)
+ *
  * @return bool : success
-*/
-function attackMechanic($pdo, $mechanics){
+ */
+function attackMechanic(PDO $pdo, array $mechanics): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG_ATTACK')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+
+    game_error_log(__FUNCTION__, 'START with turncounter : ' . ($mechanics['turncounter'] ?? 'NULL'), [], 'debug');
+
     echo '<div> <h3>  attackMechanic : </h3> ';
     $prefix = $_SESSION['GAME_PREFIX'];
 
-    $debug = strtolower(getConfig($pdo, 'DEBUG_ATTACK')) === 'true';
     $ATTACKDIFF0 = getConfig($pdo, 'ATTACKDIFF0');
     $ATTACKDIFF1 = getConfig($pdo, 'ATTACKDIFF1');
     $RIPOSTDIFF = getConfig($pdo, 'RIPOSTDIFF');
     $RIPOSTACTIVE = getConfig($pdo, 'RIPOSTACTIVE');
 
-    if ($debug) {
-        echo "ATTACKDIFF0 : $ATTACKDIFF0 <br/>";
-        echo "ATTACKDIFF1 : $ATTACKDIFF1 <br/>";
-        echo "RIPOSTDIFF : $RIPOSTDIFF <br/>";
-        echo "RIPOSTACTIVE : $RIPOSTACTIVE <br/>";
-    }
+    game_error_log(__FUNCTION__, 'config thresholds', [
+        'ATTACKDIFF0' => $ATTACKDIFF0,
+        'ATTACKDIFF1' => $ATTACKDIFF1,
+        'RIPOSTDIFF' => $RIPOSTDIFF,
+        'RIPOSTACTIVE' => $RIPOSTACTIVE,
+    ], 'debug');
 
     $attacksArray = getAttackerComparisons($pdo, $mechanics['turncounter'], NULL);
-    if ($debug)
-        echo sprintf("attacksArray : %s <br/>", var_export($attacksArray, true));
-    if (empty($attacksArray)) { echo 'All is calm </div>'; return true;}
+    game_error_log(__FUNCTION__, 'attacksArray fetched', ['attacksArray' => $attacksArray], 'debug');
+    if (empty($attacksArray)) {
+        echo 'All is calm </div>';
+        game_error_log(__FUNCTION__, 'DONE with return : true (all is calm)', [], 'debug');
+        return true;
+    }
 
     $workerDisappearanceTexts = json_decode(getConfig($pdo,'workerDisappearanceTexts'), true);
     $workerCapturedTexts = json_decode(getConfig($pdo,'workerCapturedTexts'), true);
@@ -292,8 +296,7 @@ function attackMechanic($pdo, $mechanics){
 
     foreach ($attacksArray as $attacker_id => $defenders) {
         // Build report :
-        if ($debug)
-            echo sprintf("attacker_id: %s =>row %s <br/>", $attacker_id, var_export($defenders, true));
+        game_error_log(__FUNCTION__, 'attacker_id : ' . $attacker_id, ['defenders' => $defenders], 'debug');
         if (!is_array($defenders[0])) continue;
 
         echo sprintf("attacker_name: %s <br/>", $defenders[0]['attacker_name']);
@@ -366,7 +369,7 @@ function attackMechanic($pdo, $mechanics){
                                 $tmpDoubleAgentReport = sprintf("<br/> J'était un <strong>agent double %s %s.</strong>", getConfig($pdo,'controllerNameDenominatorOf'), $doubleAgentControllerResult['double_agent_contoller_name']);
                             }
                         } catch (PDOException $e) {
-                            echo __FUNCTION__." (): Error fetching double agent: " . $e->getMessage();
+                            game_error_log(__FUNCTION__, 'SELECT double agent controller failed', ['error' => $e->getMessage()]);
                         }
 
                         $defenderReport['life_report'] = sprintf(
@@ -394,11 +397,11 @@ function attackMechanic($pdo, $mechanics){
                             $stmt->bindParam(':worker_id', $defender['defender_id'], PDO::PARAM_INT);
                             $stmt->execute();
                         } catch (PDOException $e) {
-                            echo __FUNCTION__." (): Error updating controller_worker: " . $e->getMessage();
+                            game_error_log(__FUNCTION__, 'UPDATE controller_worker on capture failed', ['error' => $e->getMessage(), 'defender_id' => $defender['defender_id']]);
                         }
                         // Check for existing trace
                         if (destroyTraceWorker($pdo, $defender['defender_id'], $defender['attacker_controller_id']) === false)
-                            echo __FUNCTION__." (): Failed to destroy trace worker ! <br />";
+                            game_error_log(__FUNCTION__, 'destroyTraceWorker failed', ['defender_id' => $defender['defender_id']], 'warning');
                     }
                 } else {
                     echo $defender['defender_name']. ' Escaped !<br />';
@@ -430,12 +433,11 @@ function attackMechanic($pdo, $mechanics){
                             addWorkerToCKE($pdo, $defender['defender_controller_id'], $defender['attacker_id'], $defender['turn_number'], $defender['zone_id']);
                         }
                     } catch (PDOException $e) {
-                        echo __FUNCTION__." (): Error fetching/inserting enemy workers: " . $e->getMessage();
+                        game_error_log(__FUNCTION__, 'SELECT/INSERT controllers_known_enemies failed', ['error' => $e->getMessage()]);
                     }
                     $defenderReport['life_report'] = sprintf($escapeTextes[array_rand($escapeTextes)], sprintf("%s(%s)%s",$defender['attacker_name'], $defender['attacker_id'], $knownEnemycontroller));
                 }
-                if ($debug)
-                    echo sprintf("(survived  : %s <br/>", ($survived ));
+                game_error_log(__FUNCTION__, 'survived : ' . ($survived ? 'true' : 'false'), [], 'debug');
                 if ( $RIPOSTACTIVE!= '0' && $survived  && $defender['riposte_difference'] >= (INT)$RIPOSTDIFF ){
                     $attacker_status = 'dead';
                     echo $defender['defender_name']. ' RIPOSTE ! <br />';
@@ -457,5 +459,6 @@ function attackMechanic($pdo, $mechanics){
     }
 
     echo '<p> attackMechanic: DONE ! </p> </div>';
+    game_error_log(__FUNCTION__, 'DONE with return : true', [], 'debug');
     return true;
 }

--- a/mechanics/claimMechanic.php
+++ b/mechanics/claimMechanic.php
@@ -11,7 +11,7 @@ require_once '../controllers/functions.php';
  * @param PDO $pdo : database connection
  * 
  */
-function _claimResolveOnBehalfName($pdo, array $params, int $selfControllerId): string {
+function _claimResolveOnBehalfName(PDO $pdo, array $params, int $selfControllerId): string {
     $claimControllerId = $params['claim_controller_id'] ?? null;
     if ($claimControllerId === 'null') return 'Personne (Sans bannière)';
     if (empty($claimControllerId)) return (string) getControllerName($pdo, $selfControllerId);
@@ -27,7 +27,7 @@ function _claimResolveOnBehalfName($pdo, array $params, int $selfControllerId): 
  * 
  * @return int|null
  */
-function _claimResolveClaimerControllerIdForWrite(array $params, int $selfControllerId) {
+function _claimResolveClaimerControllerIdForWrite(array $params, int $selfControllerId): int|null {
     if (empty($params['claim_controller_id'])) return $selfControllerId;
     if ($params['claim_controller_id'] === 'null') return null;
     return (int) $params['claim_controller_id'];
@@ -62,7 +62,11 @@ function _claimResolveClaimerControllerIdForWrite(array $params, int $selfContro
  *     'observers'             => array,  // active-non-cid workers in zone (worker_id + controller_id rows)
  *   ]
  */
-function claimMechanic($pdo, $mechanics) {
+function claimMechanic(PDO $pdo, array $mechanics): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . $mechanics['turncounter'], ['mechanics' => $mechanics], 'debug');
+
     $mode = getConfig($pdo, 'claimMode');
     if (!in_array($mode, ['worker', 'worker_leader'], true)) {
         echo "<div><h3>claimMechanic : mode '".htmlspecialchars((string)$mode)."' not supported, skipped</h3></div>";
@@ -70,7 +74,6 @@ function claimMechanic($pdo, $mechanics) {
     }
 
     $turn_number = $mechanics['turncounter'];
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
     $prefix = $_SESSION['GAME_PREFIX'];
 
     echo "<div><h3>claimMechanic (mode: ".htmlspecialchars((string)$mode).") : </h3>";
@@ -122,12 +125,13 @@ function claimMechanic($pdo, $mechanics) {
                 $uStmt->bindValue(':zid', (int)$r['zone_id'], PDO::PARAM_INT);
                 $uStmt->execute();
             } catch (PDOException $e) {
-                echo __FUNCTION__."(): UPDATE zones Failed: " . $e->getMessage()."<br />";
+                game_error_log(__FUNCTION__, 'UPDATE zones failed', ['error' => $e->getMessage(), 'zone_id' => (int)$r['zone_id']]);
             }
         }
     }
 
     echo '<p>claimMechanic : DONE</p></div>';
+    game_error_log(__FUNCTION__, 'DONE', ['resolutions_count' => count($resolutions)], 'debug');
     return true;
 }
 
@@ -147,9 +151,12 @@ function claimMechanic($pdo, $mechanics) {
  * 
  * @return array list of resolution descriptors (see claimMechanic doc)
  */
-function claimByWorkerMath($pdo, $mechanics) {
+function claimByWorkerMath(PDO $pdo, array $mechanics): array {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . $mechanics['turncounter'], ['mechanics' => $mechanics], 'debug');
+
     $turn_number = $mechanics['turncounter'];
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
     $prefix = $_SESSION['GAME_PREFIX'];
 
     $DISCRETECLAIMDIFF = (int) getConfig($pdo, 'DISCRETECLAIMDIFF');
@@ -176,10 +183,10 @@ function claimByWorkerMath($pdo, $mechanics) {
         $stmt->execute();
         $claimerArray = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT claimers failed: ".$e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT claimers failed', ['error' => $e->getMessage()]);
         return [];
     }
-    if ($debug) echo sprintf("claimByWorkerMath(): %d claimers<br>", count($claimerArray));
+    game_error_log(__FUNCTION__, sprintf('%d claimers', count($claimerArray)), [], 'debug');
 
     $allActiveByZone = [];
     $zoneIds = array_values(array_unique(array_column($claimerArray, 'zone_id')));
@@ -198,7 +205,7 @@ function claimByWorkerMath($pdo, $mechanics) {
                 $allActiveByZone[(int)$row['zone_id']][] = $row;
             }
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): SELECT active workers by zone failed: ".$e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'SELECT active workers by zone failed', ['error' => $e->getMessage()]);
             return [];
         }
     }
@@ -258,11 +265,9 @@ function claimByWorkerMath($pdo, $mechanics) {
             'observers'              => $observers,
         ];
 
-        if ($debug) {
-            echo sprintf("zone %d c %d w %d : violent=%s success=%s<br>",
-                $zone_id, $claimer_cid, $claimer['claimer_id'],
-                $isViolent ? 'true' : 'false', $success ? 'true' : 'false');
-        }
+        game_error_log(__FUNCTION__, sprintf('zone %d c %d w %d : violent=%s success=%s',
+            $zone_id, $claimer_cid, $claimer['claimer_id'],
+            $isViolent ? 'true' : 'false', $success ? 'true' : 'false'), [], 'debug');
     }
 
     return $resolutions;
@@ -288,9 +293,12 @@ function claimByWorkerMath($pdo, $mechanics) {
  * 
  * @return array list of resolution descriptors (see claimMechanic doc)
  */
-function claimByWorkerLeaderMath($pdo, $mechanics) {
+function claimByWorkerLeaderMath(PDO $pdo, array $mechanics): array {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . $mechanics['turncounter'], ['mechanics' => $mechanics], 'debug');
+
     $turn_number = $mechanics['turncounter'];
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
     $prefix = $_SESSION['GAME_PREFIX'];
 
     $claimDiff = (int) getConfig($pdo, 'claimDiff');
@@ -311,7 +319,7 @@ function claimByWorkerLeaderMath($pdo, $mechanics) {
         $stmt->execute();
         $candidates = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT candidates failed: ".$e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT candidates failed', ['error' => $e->getMessage()]);
         return [];
     }
 
@@ -376,7 +384,7 @@ function claimByWorkerLeaderMath($pdo, $mechanics) {
                 $paramsByLeader[(int)$row['worker_id']] = $row['action_params'];
             }
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): SELECT active workers by zone failed: ".$e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'SELECT active workers by zone failed', ['error' => $e->getMessage()]);
             return [];
         }
     }
@@ -394,11 +402,11 @@ function claimByWorkerLeaderMath($pdo, $mechanics) {
             $zStmt->execute();
             $zone = $zStmt->fetch(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): SELECT zones failed: ".$e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'SELECT zones failed', ['error' => $e->getMessage(), 'zone_id' => $zone_id]);
             continue;
         }
         if ((int)$zone['holder_controller_id'] === $cid) {
-            if ($debug) echo sprintf("zone %d c %d : holder == cid, claim path skipped (defender bonus already applied via recalculateZoneDefence supporting term)<br>", $zone_id, $cid);
+            game_error_log(__FUNCTION__, sprintf('zone %d c %d : holder == cid, claim path skipped (defender bonus already applied via recalculateZoneDefence supporting term)', $zone_id, $cid), [], 'debug');
             continue;
         }
         $calculated_defence_val = (int) $zone['calculated_defence_val'];
@@ -411,11 +419,9 @@ function claimByWorkerLeaderMath($pdo, $mechanics) {
 
         $threshold_passed = ($claimVal - $calculated_defence_val) >= $claimDiff;
         $success = $threshold_passed && empty($zoneClaimed[$zone_id]);
-        if ($debug) {
-            $outcome = $success ? 'WIN' : ($threshold_passed ? 'lose (zone already claimed this turn)' : 'lose');
-            echo sprintf("zone %d c %d : claim_val=%d calculated_defence_val=%d  >=  claimDiff=%d => %s<br>",
-                $zone_id, $cid, $claimVal, $calculated_defence_val, $claimDiff, $outcome);
-        }
+        $outcome = $success ? 'WIN' : ($threshold_passed ? 'lose (zone already claimed this turn)' : 'lose');
+        game_error_log(__FUNCTION__, sprintf('zone %d c %d : claim_val=%d calculated_defence_val=%d  >=  claimDiff=%d => %s',
+            $zone_id, $cid, $claimVal, $calculated_defence_val, $claimDiff, $outcome), [], 'debug');
 
         $observers = array_values(array_filter(
             $activeByZone[$zone_id] ?? [],

--- a/mechanics/endTurn.php
+++ b/mechanics/endTurn.php
@@ -5,9 +5,11 @@ require_once '../base/basePHP.php';
 
 require_once '../base/baseHTML.php';
 
+// $GLOBALS['DEBUG_LOG_SECTIONS'][] = 'endTurn_page';  // uncomment to log DEBUG events from this page
+
 $started = toggleMechanicsGamestate($gameReady, $mechanics, true);
 if (!$started) {
-    echo __FUNCTION__."(): Failed to start the game.";
+    game_error_log('endTurn_page', 'toggleMechanicsGamestate failed to start the game', [], 'warning');
     exit();
 }
 
@@ -20,12 +22,12 @@ if (getConfig($gameReady, 'ressource_management') == 'TRUE') {
     if (in_array($mechanics['end_step'], [null, ''])) {
         $ressourcesResult = updateRessources($gameReady, $mechanics);
         if ( !$ressourcesResult){
-            echo __FUNCTION__."(): Failed to update ressources: updateRessources <br />";
+            game_error_log('endTurn_page', 'updateRessources failed', [], 'warning');
             return false;
         }
         $beforeClaimGainResult = ressourceGainMechanic($gameReady, 'before_claim');
         if ( !$beforeClaimGainResult){
-            echo __FUNCTION__."(): Failed to apply before-claim ressource gain rules: ressourceGainMechanic <br />";
+            game_error_log('endTurn_page', 'ressourceGainMechanic before_claim failed', [], 'warning');
             return false;
         }
         changeEndTurnState($gameReady, 'updateRessources', $mechanics);
@@ -69,14 +71,14 @@ if (in_array($mechanics['end_step'], [null, '', 'calculateVals', 'updateRessourc
 
             // Update the report using your existing game context
             if ( !updateWorkerAction($gameReady, $worker['worker_id'], $mechanics['turncounter'], null, $reportAppendArray)){
-                echo __FUNCTION__."(): Failed to update worker action: calculateValsReport <br />";
+                game_error_log('endTurn_page', 'updateWorkerAction failed for calculateValsReport', ['worker_id' => $worker['worker_id']], 'warning');
                 return false;
             }
         }
         changeEndTurnState($gameReady, 'calculateValsReport', $mechanics);
         $mechanics['end_step'] = 'calculateValsReport';
     } else {
-        echo __FUNCTION__."(): endTurn actions Failed: calculateVals <br />";
+        game_error_log('endTurn_page', 'calculateVals failed', [], 'warning');
         return false;
     }
 }
@@ -88,7 +90,7 @@ if ($mechanics['end_step'] == 'calculateValsReport') {
     // check attacks
     $attackResult = attackMechanic($gameReady, $mechanics);
     if ( !$attackResult){
-        echo __FUNCTION__."(): Failed to attack: attackMechanic <br />";
+        game_error_log('endTurn_page', 'attackMechanic failed', [], 'warning');
         return false;
     }
     changeEndTurnState($gameReady, 'attackMechanic', $mechanics);
@@ -99,13 +101,13 @@ if ($mechanics['end_step'] == 'attackMechanic') {
     // recalculate base defence
     $bdrResult = recalculateBaseDefence($gameReady);
     if ( !$bdrResult){
-        echo __FUNCTION__."(): Failed to recalculate base defence: recalculateBaseDefence <br />";
+        game_error_log('endTurn_page', 'recalculateBaseDefence failed', [], 'warning');
         return false;
     }
     // recalculate zone defence (claimMode-aware single source of truth)
     $zdrResult = recalculateZoneDefence($gameReady, $mechanics);
     if ( !$zdrResult){
-        echo __FUNCTION__."(): Failed to recalculate zone defence: recalculateZoneDefence <br />";
+        game_error_log('endTurn_page', 'recalculateZoneDefence failed', [], 'warning');
         return false;
     }
     changeEndTurnState($gameReady, 'recalculateBaseZoneDefence', $mechanics);
@@ -116,7 +118,7 @@ if ($mechanics['end_step'] == 'recalculateBaseZoneDefence') {
     require_once 'locationAttackMechanic.php';
     $locationAttackResult = locationAttackMechanic($gameReady, $mechanics['turncounter']);
     if ( !$locationAttackResult){
-        echo __FUNCTION__."(): Failed to resolve queued location attacks: locationAttackMechanic <br />";
+        game_error_log('endTurn_page', 'locationAttackMechanic failed', [], 'warning');
         return false;
     }
     changeEndTurnState($gameReady, 'locationAttackMechanic', $mechanics);
@@ -127,7 +129,7 @@ if ($mechanics['end_step'] == 'locationAttackMechanic') {
     // check claiming territory
     $claimResult = claimMechanic($gameReady, $mechanics);
     if ( !$claimResult){
-        echo __FUNCTION__."(): Failed to claim: claimMechanic <br />";
+        game_error_log('endTurn_page', 'claimMechanic failed', [], 'warning');
         return false;
     }
     changeEndTurnState($gameReady, 'claimMechanic', $mechanics);
@@ -138,7 +140,7 @@ if ($mechanics['end_step'] == 'claimMechanic') {
     if (getConfig($gameReady, 'ressource_management') == 'TRUE') {
         $afterClaimGainResult = ressourceGainMechanic($gameReady, 'after_claim');
         if ( !$afterClaimGainResult){
-            echo __FUNCTION__."(): Failed to apply after-claim ressource gain rules: ressourceGainMechanic <br />";
+            game_error_log('endTurn_page', 'ressourceGainMechanic after_claim failed', [], 'warning');
             return false;
         }
     }
@@ -150,7 +152,7 @@ if ($mechanics['end_step'] == 'ressourceGainAfterClaim') {
     // check investigations
     $investigateResult = investigateMechanic($gameReady, $mechanics);
     if ( !$investigateResult){
-        echo __FUNCTION__."(): Failed to investigate: investigateMechanic <br />";
+        game_error_log('endTurn_page', 'investigateMechanic failed', [], 'warning');
         return false;
     }
     changeEndTurnState($gameReady, 'investigateMechanic', $mechanics);
@@ -161,7 +163,7 @@ if ($mechanics['end_step'] == 'investigateMechanic') {
     // check locations seach
     $locationsearchResult = locationSearchMechanic($gameReady, $mechanics);
     if ( !$locationsearchResult){
-        echo __FUNCTION__."(): Failed to location search: locationSearchMechanic <br />";
+        game_error_log('endTurn_page', 'locationSearchMechanic failed', [], 'warning');
         return false;
     }
     changeEndTurnState($gameReady, 'locationSearchMechanic', $mechanics);
@@ -174,7 +176,7 @@ if ($mechanics['end_step'] == 'locationSearchMechanic') {
     // create new turn lines
     $turnLinesResult = createNewTurnLines($gameReady, $turn);
     if ( !$turnLinesResult){
-        echo __FUNCTION__."(): Failed to create new turn lines: createNewTurnLines <br />";
+        game_error_log('endTurn_page', 'createNewTurnLines failed', ['turn' => $turn], 'warning');
         return false;
     }
     changeEndTurnState($gameReady, 'createNewTurnLines', $mechanics);
@@ -184,7 +186,7 @@ if ($mechanics['end_step'] == 'locationSearchMechanic') {
 if ($mechanics['end_step'] == 'createNewTurnLines') {
     $restartRecrutementCount = restartTurnRecrutementCount($gameReady);
     if ( !$restartRecrutementCount){
-        echo __FUNCTION__."(): Failed to restart turn recrutement count: restartTurnRecrutementCount <br />";
+        game_error_log('endTurn_page', 'restartTurnRecrutementCount failed', [], 'warning');
         return false;
     }
     changeEndTurnState($gameReady, 'restartTurnRecrutementCount', $mechanics);
@@ -200,7 +202,7 @@ if ($mechanics['end_step'] == 'restartTurnRecrutementCount') {
         $stmt = $gameReady->prepare($sql);
         $stmt->execute([':turncounter' => $turn, ':id' => $mechanics['id'] ]);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): UPDATE mechanics Failed: " . $e->getMessage()."<br />";
+        game_error_log('endTurn_page', 'UPDATE mechanics failed', ['error' => $e->getMessage()]);
     }
 }
 

--- a/mechanics/functions.php
+++ b/mechanics/functions.php
@@ -17,14 +17,17 @@ if (!defined('INVESTIGATE_ACTIONS_DEFAULT')) {
 
 /**
  * Start or Pause the game state
- * 
+ *
  * @param PDO $pdo : database connection
  * @param array $mechanics : mechanics array
  * @param bool $start : true to start, false to pause
  *
  * @return bool : success
  */
-function toggleMechanicsGamestate($pdo, $mechanics, $start = true) {
+function toggleMechanicsGamestate(PDO $pdo, array $mechanics, bool $start = true): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with start : ' . var_export($start, true), ['mechanics_id' => $mechanics['id'], 'gamestate' => $mechanics['gamestate']], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     // SQL query to update gamestate
@@ -41,7 +44,7 @@ function toggleMechanicsGamestate($pdo, $mechanics, $start = true) {
             $stmt = $pdo->prepare($sql);
             $stmt->execute([':id' => $mechanics['id']]);
         } catch (PDOException $e) {
-            echo __FUNCTION__."():UPDATE mechanics Failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'UPDATE mechanics failed', ['error' => $e->getMessage()]);
             return false;
         }
     }
@@ -55,9 +58,9 @@ function toggleMechanicsGamestate($pdo, $mechanics, $start = true) {
  * @param string $state : state to change to
  * @param array $mechanics : mechanics array
  *
- * @return bool : success
+ * @return void
  */
-function changeEndTurnState($pdo, $state, $mechanics) {
+function changeEndTurnState(PDO $pdo, string $state, array $mechanics): void {
     $prefix = $_SESSION['GAME_PREFIX'];
     $sql = "UPDATE {$prefix}mechanics set end_step = :end_step WHERE id = :id";
     $stmt = $pdo->prepare($sql);
@@ -68,9 +71,8 @@ function changeEndTurnState($pdo, $state, $mechanics) {
  * Build base randomization SQL
  *
  * @return string : SQL string
- *
  */
-function diceSQL() {
+function diceSQL(): string {
     $prefix = $_SESSION['GAME_PREFIX'];
     return sprintf(
         "FLOOR(
@@ -90,9 +92,12 @@ function diceSQL() {
  *
  * @param PDO $pdo : database connection
  *
- * @return int : rollvalue
+ * @return int|null : rollvalue, NULL on SQL failure
  */
-function diceRoll($pdo) {
+function diceRoll(PDO $pdo): int|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', [], 'debug');
+
     $diceSQL = diceSQL();
     $sql = "SELECT $diceSQL as roll";
 
@@ -101,7 +106,7 @@ function diceRoll($pdo) {
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT diceSQL Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT diceSQL failed', ['error' => $e->getMessage()]);
         return NULL;
     }
     $roll = $stmt->fetchALL(PDO::FETCH_ASSOC);
@@ -111,13 +116,13 @@ function diceRoll($pdo) {
 /**
  * Validate a configurable list of action_choice values and return a SQL-safe IN-list.
  *
- * @param string|null $configValue
- * @param array $allowedActions
- * @param array $defaultActions
+ * @param string|null $configValue : raw config value (may be null / empty)
+ * @param array $allowedActions : whitelist of allowed action_choice values
+ * @param array $defaultActions : fallback list when config is missing / invalid
  *
- * @return string
+ * @return string : comma-separated single-quoted list ready for SQL IN(...)
  */
-function validateActionChoiceListForSql($configValue, $allowedActions, $defaultActions) {
+function validateActionChoiceListForSql(string|null $configValue, array $allowedActions, array $defaultActions): string {
     $parsedActions = [];
     if (!empty($configValue)) {
         $normalized = trim((string)$configValue);
@@ -167,11 +172,11 @@ function validateActionChoiceListForSql($configValue, $allowedActions, $defaultA
 /**
  * Return validated investigation actions for SQL usage.
  *
- * @param PDO $pdo
+ * @param PDO $pdo : database connection
  *
- * @return string
+ * @return string : comma-separated single-quoted action list ready for SQL IN(...)
  */
-function getValidatedInvestigateActionsForSql($pdo) {
+function getValidatedInvestigateActionsForSql(PDO $pdo): string {
     $configuredActions = getConfig($pdo, 'investigateActionsList');
 
     return validateActionChoiceListForSql($configuredActions, WORKER_ACTION_CHOICES_ALLOWED, INVESTIGATE_ACTIONS_DEFAULT);
@@ -180,11 +185,11 @@ function getValidatedInvestigateActionsForSql($pdo) {
 /**
  * Return the investigation processing order ('asc' or 'desc') from config, falling back to 'asc' on unknown values.
  *
- * @param PDO $pdo
+ * @param PDO $pdo : database connection
  *
- * @return string
+ * @return string : 'asc' or 'desc'
  */
-function getInvestigateOrder($pdo) {
+function getInvestigateOrder(PDO $pdo): string {
     $value = strtolower(trim((string) getConfig($pdo, 'investigateOrder')));
     return in_array($value, ['asc', 'desc'], true) ? $value : 'asc';
 }
@@ -196,9 +201,11 @@ function getInvestigateOrder($pdo) {
  * @param array $mechanics : mechanics array
  *
  * @return bool : success
- *
  */
-function calculateVals($pdo, $mechanics){
+function calculateVals(PDO $pdo, array $mechanics): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with turncounter : ' . $mechanics['turncounter'], [], 'debug');
+
     $turn_number =  $mechanics['turncounter'];
     $prefix = $_SESSION['GAME_PREFIX'];
 
@@ -312,7 +319,7 @@ function calculateVals($pdo, $mechanics){
             $stmt = $pdo->prepare($sql['sql']);
             $stmt->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__." (): sql FAILED : ".$e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'UPDATE worker_actions val failed', ['error' => $e->getMessage(), 'config' => $sql['config']]);
             return false;
         }
         echo "DONE <br /></p>";
@@ -330,13 +337,14 @@ function calculateVals($pdo, $mechanics){
  * setting dead and captured status
  *
  * @param PDO $pdo : database connection
- * @param string $turn_number
+ * @param int $turn_number : new turn number to build lines for
  *
  * @return bool : success
- *
  */
-function createNewTurnLines($pdo, $turn_number){
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function createNewTurnLines(PDO $pdo, int $turn_number): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . $turn_number, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     echo '<div> <h3>  createNewTurnLines : </h3> ';
     $sqlInsert = "
@@ -359,7 +367,7 @@ function createNewTurnLines($pdo, $turn_number){
         $stmtInsert->bindValue(':turn_number_n_1', ((INT)$turn_number-1), PDO::PARAM_INT);
         $stmtInsert->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__." (): sql INSERT FAILED : ".$e->getMessage()."<br/> sql: $sqlInsert<br/>";
+        game_error_log(__FUNCTION__, 'INSERT worker_actions failed', ['error' => $e->getMessage(), 'sql' => $sqlInsert]);
         return false;
     }
 
@@ -379,7 +387,7 @@ function createNewTurnLines($pdo, $turn_number){
             $stmtSetInvestigate->bindValue(':turn_number_n_1', ((INT)$turn_number-1), PDO::PARAM_INT);
             $stmtSetInvestigate->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__." (): sql UPDATE investigate FAILED : ".$e->getMessage()."<br />$sqlSetInvestigate<br/>";
+            game_error_log(__FUNCTION__, 'UPDATE investigate action_choice failed', ['error' => $e->getMessage(), 'sql' => $sqlSetInvestigate]);
             return false;
         }
     }
@@ -399,13 +407,13 @@ function createNewTurnLines($pdo, $turn_number){
             $stmtSetClaim->bindValue(':turn_number_n_1', ((INT)$turn_number-1), PDO::PARAM_INT);
             $stmtSetClaim->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__." (): sql UPDATE claim FAILED : ".$e->getMessage()."<br />$sqlSetClaim<br/>";
+            game_error_log(__FUNCTION__, 'UPDATE claim action_choice failed', ['error' => $e->getMessage(), 'sql' => $sqlSetClaim]);
             return false;
         }
     }
 
     echo '<p>createNewTurnLines : DONE</p> </div>';
 
+    game_error_log(__FUNCTION__, 'DONE with turn_number : ' . $turn_number, [], 'debug');
     return true;
 }
-

--- a/mechanics/investigateMechanic.php
+++ b/mechanics/investigateMechanic.php
@@ -6,33 +6,33 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
 }
 
 /**
- *  Remove curly braces and quotes and Split the string by commas into an array
- * 
- * @param string $input
- * 
- * @return array 
- * 
+ * Remove curly braces and quotes and split the string by commas into an array
+ *
+ * @param string|null $input : raw aggregated string (GROUP_CONCAT / ARRAY_AGG may return NULL)
+ *
+ * @return array : trimmed pieces
  */
-function cleanAndSplitString($input) {
+function cleanAndSplitString(string|null $input): array {
     // Remove curly braces and quotes
-    $cleaned = str_replace(['{', '}', '"'], '', $input);
+    $cleaned = str_replace(['{', '}', '"'], '', (string) $input);
     // Split the string by commas into an array
     return array_map('trim', explode(',', $cleaned));
 }
 
 /**
- * gets the comparaison table between the workers on search/investigate and there possible targets
- * 
+ * Gets the comparison table between the workers on search/investigate and their possible targets
+ *
  * @param PDO $pdo : database connection
- * @param string|null $turn_number
- * @param string|null $searcher_id
- * 
- * @return array 
- * 
+ * @param int|null $turn_number : turn number to filter searchers on (falls back to current turn when NULL)
+ * @param int|null $searcher_id : optional single searcher id restriction
+ *
+ * @return array : list of (searcher, found) comparison rows
  */
-function getSearcherComparisons($pdo, $turn_number = NULL, $searcher_id = NULL) {
+function getSearcherComparisons(PDO $pdo, int|null $turn_number = NULL, int|null $searcher_id = NULL): array|false {
+    if (strtolower(getConfig($pdo, 'DEBUG_REPORT')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . ($turn_number ?? 'NULL'), ['searcher_id' => $searcher_id], 'debug');
 
-    $debug = strtolower(getConfig($pdo, 'DEBUG_REPORT')) === 'true';
     $prefix = $_SESSION['GAME_PREFIX'];
 
     if ( !isset($turn_number)) {
@@ -211,13 +211,13 @@ function getSearcherComparisons($pdo, $turn_number = NULL, $searcher_id = NULL) 
     // Whitelisted (asc|desc) — getInvestigateOrder enforces the only safe interpolation surface
     $order = strtoupper(getInvestigateOrder($pdo));
     $sql .= " ORDER BY s.searcher_enquete_val $order, s.searcher_id ASC";
-    if ($debug) echo sprintf("sql : %s <br/>", $sql);
+    game_error_log(__FUNCTION__, 'sql prepared', ['sql' => $sql], 'debug');
     try{
         $investigate_actions = getValidatedInvestigateActionsForSql($pdo);
         $active_actions = "'".implode("','", ACTIVE_ACTIONS)."'";
-        if ($debug) echo sprintf("turn_number : %s <br/>", $turn_number);
-        if ($debug) echo sprintf("investigate_actions : %s <br/>", $investigate_actions);
-        if ($debug) echo sprintf("active_actions : %s <br/>", $active_actions);
+        game_error_log(__FUNCTION__, 'turn_number : ' . $turn_number, [], 'debug');
+        game_error_log(__FUNCTION__, 'investigate_actions : ' . $investigate_actions, [], 'debug');
+        game_error_log(__FUNCTION__, 'active_actions : ' . $active_actions, [], 'debug');
         $sql = sprintf($sql, $investigate_actions, $active_actions);
 
         // Prepare and execute the statement
@@ -226,9 +226,10 @@ function getSearcherComparisons($pdo, $turn_number = NULL, $searcher_id = NULL) 
         $stmt->execute();
 
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): Error: " . $e->getMessage();
+        game_error_log(__FUNCTION__, 'SELECT searcher comparisons Failed: ' . $e->getMessage(), ['turn_number' => $turn_number, 'searcher_id' => $searcher_id], 'error');
+        return false;
     }
-    if ($debug) echo sprintf("stmt->rowCount() : %s <br/>", $stmt->rowCount());
+    game_error_log(__FUNCTION__, 'stmt->rowCount() : ' . $stmt->rowCount(), [], 'debug');
 
     // Fetch and return the results
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -238,15 +239,18 @@ function getSearcherComparisons($pdo, $turn_number = NULL, $searcher_id = NULL) 
  * Build the per-row HTML chunk for one (searcher, found) pair: variant-aware (no CKE / moved / still-here / upgrade).
  * Returns [reportElement, ckePowersFlag, ckeControllerId, ckeControllerName] — the caller passes the last 3 to addWorkerToCKE.
  *
- * @param PDO $pdo
+ * @param PDO $pdo : database connection
  * @param array $row : one getSearcherComparisons row
  * @param array|null $prevCke : CKE row read before this upsert (NULL = no prior entry)
  * @param array $zoneNameById : map of zone_id => zone name (for the "moved from <zone>" summary)
  * @param array $txtBag : pre-loaded text-config bag (slab templates, variant templates, action labels)
  *
- * @return array
+ * @return array : [reportElement HTML string, ckePowersFlag bool, ckeControllerId int|null, ckeControllerName string|null]
  */
-function buildInvestigateReportLine($pdo, $row, $prevCke, $zoneNameById, $txtBag) {
+function buildInvestigateReportLine(PDO $pdo, array $row, array|null $prevCke, array $zoneNameById, array $txtBag): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with found_id : ' . $row['found_id'], ['row' => $row, 'prevCke' => $prevCke], 'debug');
+
     $REPORTDIFF = $txtBag['REPORTDIFF'];
     $enqDiff = (int)$row['enquete_difference'];
 
@@ -440,14 +444,16 @@ function buildInvestigateReportLine($pdo, $row, $prevCke, $zoneNameById, $txtBag
  * @param PDO $pdo : database connection
  * @param array $mechanics : mechanics row
  *
- * @return bool success
+ * @return bool : true when the loop completed
  */
-function investigateMechanic($pdo, $mechanics) {
+function investigateMechanic(PDO $pdo, array $mechanics): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG_REPORT')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with turncounter : ' . $mechanics['turncounter'], ['mechanics' => $mechanics], 'debug');
+
     $turn_number = $mechanics['turncounter'];
     echo '<div> <h3> investigateMechanic : </h3> ';
     echo "turn_number : $turn_number <br>";
-
-    $debug = strtolower(getConfig($pdo, 'DEBUG_REPORT')) === 'true';
 
     $REPORTDIFF = [
         0 => (int)getConfig($pdo, 'REPORTDIFF0'),
@@ -455,12 +461,14 @@ function investigateMechanic($pdo, $mechanics) {
         2 => (int)getConfig($pdo, 'REPORTDIFF2'),
         3 => (int)getConfig($pdo, 'REPORTDIFF3'),
     ];
-    if ($debug) {
-        foreach ($REPORTDIFF as $k => $v) echo "REPORTDIFF$k : $v <br/>";
-    }
+    game_error_log(__FUNCTION__, 'REPORTDIFF thresholds loaded', ['REPORTDIFF' => $REPORTDIFF], 'debug');
 
     $investigations = getSearcherComparisons($pdo, $turn_number, NULL);
-    if ($debug) echo sprintf("investigations : %s <br/>", var_export($investigations, true));
+    if (!is_array($investigations)) {
+        game_error_log(__FUNCTION__, 'getSearcherComparisons returned non-array, aborting EOT step', ['turn_number' => $turn_number]);
+        return false;
+    }
+    game_error_log(__FUNCTION__, 'investigations loaded', ['investigations' => $investigations], 'debug');
 
     $txtBag = [
         'actions' => [
@@ -499,7 +507,7 @@ function investigateMechanic($pdo, $mechanics) {
     $reportArray = [];
 
     foreach ($investigations as $row) {
-        if ($debug) echo "<div><p> row : ".var_export($row, true)."</p>";
+        game_error_log(__FUNCTION__, 'processing row', ['row' => $row], 'debug');
 
         if (empty($reportArray[$row['searcher_id']])) {
             $reportArray[$row['searcher_id']] = sprintf($txtBag['textesStartInvestigate'], $row['zone_name']);
@@ -553,21 +561,21 @@ function investigateMechanic($pdo, $mechanics) {
                     );
                 }
             } catch (PDOException $e) {
-                echo __FUNCTION__."(): Error SELECT controller_id FROM controller_worker Failed: " . $e->getMessage()."<br />";
+                game_error_log(__FUNCTION__, 'SELECT controller_id FROM controller_worker Failed: ' . $e->getMessage(), ['searcher_id' => $row['searcher_id'], 'searcher_controller_id' => $row['searcher_controller_id']], 'error');
             }
         }
-
-        if ($debug) echo "</div>";
     }
 
     foreach ($reportArray as $worker_id => $report) {
         try {
             updateWorkerAction($pdo, $worker_id, $turn_number, NULL, ['investigate_report' => $report]);
         } catch (Exception $e) {
-            echo "updateWorkerAction() failed for worker_id $worker_id: " . $e->getMessage() . "<br />";
+            game_error_log(__FUNCTION__, 'updateWorkerAction failed for worker_id ' . $worker_id . ': ' . $e->getMessage(), ['worker_id' => $worker_id, 'turn_number' => $turn_number], 'error');
             break;
         }
     }
+
+    game_error_log(__FUNCTION__, 'DONE with turncounter : ' . $turn_number, ['reportArray_count' => count($reportArray)], 'debug');
 
     echo '<p>investigateMechanic : DONE </p> </div>';
     return true;

--- a/mechanics/locationAttackMechanic.php
+++ b/mechanics/locationAttackMechanic.php
@@ -5,15 +5,16 @@
  * attacker-only log entry. Used by both the cascade-destroyed branch
  * in locationAttackMechanic() and the cancel-on-move path in moveBase().
  *
- * @param PDO    $pdo
- * @param array  $queue_row controller_location_attacks row (needs id,
- *                          location_name, attacker_controller_id)
- * @param int    $turn_number
- * @param string $reason     'destroyed' | 'moved'
- *
- * @return bool
+ * @param PDO $pdo : database connection
+ * @param array $queue_row : controller_location_attacks row (needs id, location_name, attacker_controller_id)
+ * @param int $turn_number : current turn number
+ * @param string $reason : 'destroyed' | 'moved'
+ * @return bool : true on success, false on DB failure
  */
-function failQueuedLocationAttack($pdo, array $queue_row, $turn_number, $reason) {
+function failQueuedLocationAttack(PDO $pdo, array $queue_row, int $turn_number, string $reason): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with queue_row_id : ' . $queue_row['id'], ['queue_row' => $queue_row, 'turn_number' => $turn_number, 'reason' => $reason], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $textKey = $reason === 'moved' ? 'textLocationAttackMoved' : 'textLocationAttackDestroyed';
     $attackerText = sprintf((string)getConfig($pdo, $textKey), $queue_row['location_name']);
@@ -28,7 +29,7 @@ function failQueuedLocationAttack($pdo, array $queue_row, $turn_number, $reason)
         $u->bindParam(':id', $queue_row['id'], PDO::PARAM_INT);
         $u->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): UPDATE controller_location_attacks Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'UPDATE controller_location_attacks Failed: ' . $e->getMessage(), ['queue_row' => $queue_row, 'turn_number' => $turn_number, 'reason' => $reason], 'error');
         return false;
     }
 
@@ -43,7 +44,7 @@ function failQueuedLocationAttack($pdo, array $queue_row, $turn_number, $reason)
         $log->bindParam(':attacker_text', $attackerText, PDO::PARAM_STR);
         $log->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): INSERT location_attack_logs Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'INSERT location_attack_logs Failed: ' . $e->getMessage(), ['queue_row' => $queue_row, 'turn_number' => $turn_number, 'reason' => $reason, 'attackerText' => $attackerText], 'error');
         return false;
     }
 
@@ -51,13 +52,19 @@ function failQueuedLocationAttack($pdo, array $queue_row, $turn_number, $reason)
 }
 
 /**
+ * Resolve every queued location attack for the given turn: fetch the
+ * queue, compute attacker/defender values, apply effects, and update
+ * the queue row with the outcome. Skips work when locationAttackMode
+ * config is not 'endTurn'.
  *
- * @param PDO $pdo
- * @param int $turn_number
- *
- * @return array $return
+ * @param PDO $pdo : database connection
+ * @param int $turn_number : current turn number
+ * @return bool : true when the loop completed (or mode was skipped), false on DB failure
  */
-function locationAttackMechanic($pdo, $turn_number) {
+function locationAttackMechanic(PDO $pdo, int $turn_number): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . $turn_number, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $mode = getConfig($pdo, 'locationAttackMode');
 
@@ -76,7 +83,7 @@ function locationAttackMechanic($pdo, $turn_number) {
         $stmt->execute();
         $queued = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT queued attacks failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT queued attacks failed: ' . $e->getMessage(), ['turn_number' => $turn_number], 'error');
         return false;
     }
 
@@ -114,10 +121,12 @@ function locationAttackMechanic($pdo, $turn_number) {
             $u->bindParam(':id', $row['id'], PDO::PARAM_INT);
             $u->execute();
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): UPDATE queue row failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'UPDATE queue row failed: ' . $e->getMessage(), ['row' => $row, 'turn_number' => $turn_number, 'resolvedAttack' => $resolvedAttack, 'resolvedDefence' => $resolvedDefence, 'result' => $result], 'error');
             return false;
         }
     }
+
+    game_error_log(__FUNCTION__, 'DONE with turn_number : ' . $turn_number, ['queued_count' => count($queued)], 'debug');
 
     echo '<p> locationAttackMechanic : DONE </p> </div>';
     return true;

--- a/mechanics/locationSearchMechanic.php
+++ b/mechanics/locationSearchMechanic.php
@@ -7,15 +7,17 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
 
 /**
  * gets the comparaison table between the workers on search/investigate and there possible targets locations
- * 
+ *
  * @param PDO $pdo : database connection
- * @param string|null $turn_number
- * @param string|null $searcher_id
- * 
- * @return array 
- * 
+ * @param int|null $turn_number : turn number to filter searchers on
+ * @param int|null $searcher_id : optional single searcher to restrict the comparison to
+ *
+ * @return array : list of (searcher, found_location) comparison rows
  */
-function getLocationSearcherComparisons($pdo, $turn_number = NULL, $searcher_id = NULL) {
+function getLocationSearcherComparisons(PDO $pdo, int|null $turn_number = NULL, int|null $searcher_id = NULL): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . $turn_number, ['searcher_id' => $searcher_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $investigate_actions = getValidatedInvestigateActionsForSql($pdo);
     // Whitelisted (asc|desc) — getInvestigateOrder enforces the only safe interpolation surface
@@ -69,7 +71,7 @@ function getLocationSearcherComparisons($pdo, $turn_number = NULL, $searcher_id 
         if (!empty($searcher_id)) $stmt->bindParam(':searcher_id', $searcher_id, PDO::PARAM_INT);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__ . "(): Error: " . $e->getMessage();
+        game_error_log(__FUNCTION__, 'SELECT searchers/locations comparisons Failed: ' . $e->getMessage(), ['turn_number' => $turn_number, 'searcher_id' => $searcher_id], 'error');
         return [];
     }
 
@@ -82,14 +84,17 @@ function getLocationSearcherComparisons($pdo, $turn_number = NULL, $searcher_id 
  * The artefact list is appended VISIBLE (outside the fold) when current investigation reaches LOCATIONARTEFACTSDIFF and artefacts exist.
  * Returns [reportElement, foundSecretFlag] — the caller passes foundSecretFlag to addLocationToCKL when current reached INFORMATIONDIFF.
  *
- * @param PDO $pdo
+ * @param PDO $pdo : database connection
  * @param array $row : one getLocationSearcherComparisons row
  * @param array|null $prevCkl : CKL row read before this upsert (NULL = no prior entry)
  * @param array $txtBag : pre-loaded text-config bag (slab templates, variant templates, diff thresholds)
  *
- * @return array
+ * @return array : [reportElement HTML string, foundSecretFlag bool]
  */
-function buildLocationSearchReportLine($pdo, $row, $prevCkl, $txtBag) {
+function buildLocationSearchReportLine(PDO $pdo, array $row, array|null $prevCkl, array $txtBag): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with found_id : ' . $row['found_id'], ['row' => $row, 'prevCkl' => $prevCkl, 'txtBag' => $txtBag], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $NAMEDIFF      = $txtBag['LOCATIONNAMEDIFF'];
     $INFODIFF      = $txtBag['LOCATIONINFORMATIONDIFF'];
@@ -159,19 +164,20 @@ function buildLocationSearchReportLine($pdo, $row, $prevCkl, $txtBag) {
  * Searcher dimension is sorted by SQL ORDER BY (config-driven asc/desc, age tiebreak), so weak-then-strong dedup gives every searcher a chance to discover something new.
  *
  * @param PDO $pdo : database connection
- * @param array $mechanics : mechanics row
+ * @param array $mechanics : mechanics row (needs turncounter)
  *
- * @return bool success
+ * @return bool : true when the loop completed
  */
-function locationSearchMechanic($pdo, $mechanics) {
+function locationSearchMechanic(PDO $pdo, array $mechanics): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG_REPORT')) == 'true') $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with turncounter : ' . $mechanics['turncounter'], ['mechanics' => $mechanics], 'debug');
+
     echo '<div><h3>locationSearchMechanic :</h3>';
     $turn_number = $mechanics['turncounter'];
     echo "turn_number : $turn_number <br>";
 
-    $debug = strtolower(getConfig($pdo, 'DEBUG_REPORT')) === 'true';
-
     $locationsInvestigation = getLocationSearcherComparisons($pdo, $turn_number);
-    if ($debug) echo "<p>locationsInvestigation : " . var_export($locationsInvestigation, true) . "</p>";
+    game_error_log(__FUNCTION__, 'locationsInvestigation loaded', ['locationsInvestigation' => $locationsInvestigation], 'debug');
 
     $LOCATIONNAMEDIFF        = (int) getConfig($pdo, 'LOCATIONNAMEDIFF');
     $LOCATIONINFORMATIONDIFF = (int) getConfig($pdo, 'LOCATIONINFORMATIONDIFF');
@@ -193,7 +199,7 @@ function locationSearchMechanic($pdo, $mechanics) {
     $reportArray = [];
 
     foreach ($locationsInvestigation as $row) {
-        if ($debug) echo "<div><p>row: " . var_export($row, true) . "</p>";
+        game_error_log(__FUNCTION__, 'processing row', ['row' => $row], 'debug');
 
         // First row for this searcher → emit zone preamble + holder context
         if (empty($reportArray[$row['searcher_id']])) {
@@ -240,12 +246,14 @@ function locationSearchMechanic($pdo, $mechanics) {
             addLocationToCKL($pdo, $row['searcher_controller_id'], $row['found_id'], $turn_number, $foundSecretFlag);
         }
 
-        if ($debug) echo "<p>Updated reportArray: " . var_export($reportArray[$row['searcher_id']], true) . "</p></div>";
+        game_error_log(__FUNCTION__, 'updated reportArray for searcher_id ' . $row['searcher_id'], ['report' => $reportArray[$row['searcher_id']]], 'debug');
     }
 
     foreach ($reportArray as $worker_id => $report) {
         updateWorkerAction($pdo, $worker_id, $turn_number, NULL, ['secrets_report' => $report]);
     }
+
+    game_error_log(__FUNCTION__, 'DONE with turncounter : ' . $turn_number, ['reportArray_count' => count($reportArray)], 'debug');
 
     echo '<p> locationSearchMechanic : DONE </p> </div>';
     return true;

--- a/mechanics/ressourceGainMechanic.php
+++ b/mechanics/ressourceGainMechanic.php
@@ -9,15 +9,17 @@ if (!defined('RESSOURCE_GAIN_CONDITION_TYPES')) {
 
 /**
  * Apply end-of-turn ressource gain rules whose timing matches $timing.
- * Each rule produces amount × COUNT(matching entities for the controller).
+ * Each rule produces amount x COUNT(matching entities for the controller).
  * Malformed rules are logged and skipped (graceful degradation).
  *
- * @param PDO    $pdo
- * @param string $timing 'before_claim' | 'after_claim'
- *
- * @return bool
+ * @param PDO $pdo : database connection
+ * @param string $timing : 'before_claim' | 'after_claim'
+ * @return bool : true when every UPDATE succeeded (or nothing needed to run)
  */
-function ressourceGainMechanic($pdo, $timing) {
+function ressourceGainMechanic(PDO $pdo, string $timing): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with timing : ' . $timing, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $hasErrors = false;
     echo "<div><h3>ressourceGainMechanic : timing '".htmlspecialchars($timing)."'</h3>";
@@ -33,7 +35,7 @@ function ressourceGainMechanic($pdo, $timing) {
         $stmt->execute();
         $configRows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT gain_rules failed: ".$e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT gain_rules failed: ' . $e->getMessage(), ['timing' => $timing], 'error');
         return false;
     }
 
@@ -41,10 +43,10 @@ function ressourceGainMechanic($pdo, $timing) {
     foreach ($configRows as $row) {
         $ressourceId = (int)$row['ressource_id'];
 
-        // Extract the gain rules 
+        // Extract the gain rules
         $rules = json_decode($row['gain_rules'], true);
         if (!is_array($rules)) {
-            echo __FUNCTION__."(): Invalid gain_rules JSON for ressource_id={$ressourceId}, skipping<br />";
+            game_error_log(__FUNCTION__, 'Invalid gain_rules JSON for ressource_id=' . $ressourceId . ', skipping', ['ressourceId' => $ressourceId, 'gain_rules' => $row['gain_rules']], 'error');
             continue;
         }
 
@@ -55,7 +57,7 @@ function ressourceGainMechanic($pdo, $timing) {
             $multiplier = (int)$rule['amount'];
             if ($multiplier === 0) continue;
 
-            // Check if the rule's condition apply's to à controller
+            // Check if the rule's condition apply's to a controller
             // list of ['controller_id' => int, 'match_count' => int]
             $matches = ressourceGainEvaluateCondition($pdo, $rule['condition']);
             // For each contoller found
@@ -74,18 +76,19 @@ function ressourceGainMechanic($pdo, $timing) {
                     $u->execute();
                     // rowCount=0 = controller doesn't own this ressource — legitimate
                     // for sparse scenarios (Japon1555 etc.) where not every controller
-                    // has every ressource_config row. Echo for visibility but don't
-                    // flag as error; abort propagates and breaks the whole EOT.
+                    // has every ressource_config row. Logged as warning for visibility.
                     if ($u->rowCount() === 0) {
-                        echo __FUNCTION__."(): no controller_ressources row for c={$controllerId},r={$ressourceId} (skipped)<br />";
+                        game_error_log(__FUNCTION__, 'no controller_ressources row for c=' . $controllerId . ',r=' . $ressourceId . ' (skipped)', ['controllerId' => $controllerId, 'ressourceId' => $ressourceId, 'gainAmount' => $gainAmount], 'warning');
                     }
                 } catch (PDOException $e) {
                     $hasErrors = true;
-                    echo __FUNCTION__."(): UPDATE failed for c={$controllerId},r={$ressourceId}: ".$e->getMessage()."<br />";
+                    game_error_log(__FUNCTION__, 'UPDATE failed for c=' . $controllerId . ',r=' . $ressourceId . ': ' . $e->getMessage(), ['controllerId' => $controllerId, 'ressourceId' => $ressourceId, 'gainAmount' => $gainAmount], 'error');
                 }
             }
         }
     }
+
+    game_error_log(__FUNCTION__, 'DONE with timing : ' . $timing, ['hasErrors' => $hasErrors], 'debug');
 
     echo "<p>ressourceGainMechanic : DONE</p></div>";
     return !$hasErrors;
@@ -94,12 +97,14 @@ function ressourceGainMechanic($pdo, $timing) {
 /**
  * Validate a single gain rule's structural shape and timing match.
  *
- * @param mixed  $rule
- * @param string $timing
- *
- * @return bool
+ * @param mixed $rule : rule payload from ressources_config.gain_rules JSON
+ * @param string $timing : 'before_claim' | 'after_claim' timing filter
+ * @return bool : true when the rule is well-formed and matches $timing
  */
-function ressourceGainRuleIsValid($rule, $timing) {
+function ressourceGainRuleIsValid(mixed $rule, string $timing): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with timing : ' . $timing, ['rule' => $rule], 'debug');
+
     if (!is_array($rule)) return false;
     if (!isset($rule['amount']) || !is_numeric($rule['amount'])) return false;
     if (!isset($rule['timing']) || $rule['timing'] !== $timing) return false;
@@ -113,12 +118,14 @@ function ressourceGainRuleIsValid($rule, $timing) {
  * Evaluate a condition and return per-controller match counts.
  * Filter keys outside the whitelist are silently dropped.
  *
- * @param PDO   $pdo
- * @param array $condition
- *
- * @return array list of ['controller_id' => int, 'match_count' => int]
+ * @param PDO $pdo : database connection
+ * @param array $condition : condition payload (holds_zone | claims_zone | owns_location_type)
+ * @return array : list of ['controller_id' => int, 'match_count' => int]
  */
-function ressourceGainEvaluateCondition($pdo, array $condition) {
+function ressourceGainEvaluateCondition(PDO $pdo, array $condition): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with type : ' . ($condition['type'] ?? 'NULL'), ['condition' => $condition], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $conditionType = $condition['type'];
 
@@ -148,7 +155,7 @@ function ressourceGainEvaluateCondition($pdo, array $condition) {
             $stmt->execute();
             return $stmt->fetchAll(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): zone SELECT failed: ".$e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'zone SELECT failed: ' . $e->getMessage(), ['condition' => $condition, 'params' => $params], 'error');
             return [];
         }
     }
@@ -178,7 +185,7 @@ function ressourceGainEvaluateCondition($pdo, array $condition) {
             $stmt->execute();
             $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
-            echo __FUNCTION__."(): location SELECT failed: ".$e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'location SELECT failed: ' . $e->getMessage(), ['condition' => $condition, 'params' => $params], 'error');
             return [];
         }
 

--- a/powers/functions.php
+++ b/powers/functions.php
@@ -375,10 +375,9 @@ function getRuleCostForPower($pdo, $power, $controller_id, $worker_id, $turn_num
 
     if ($direct_cost !== null && $or_cost !== null){
         if ($direct_cost['ressource_name'] !== $or_cost['ressource_name']){
-            error_log(sprintf(
-                'getRuleCostForPower: cross-resource cost not supported, using direct (direct=%s, or=%s)',
-                $direct_cost['ressource_name'], $or_cost['ressource_name']
-            ));
+            game_error_log(__FUNCTION__, 'cross-resource cost not supported, using direct',
+                ['direct' => $direct_cost['ressource_name'], 'or' => $or_cost['ressource_name']],
+                'warning');
         }
         $or_cost = null;
     }
@@ -387,7 +386,8 @@ function getRuleCostForPower($pdo, $power, $controller_id, $worker_id, $turn_num
 
     $rid = resolveRessourceIdByName($pdo, $cost['ressource_name']);
     if ($rid === null){
-        error_log(sprintf('getRuleCostForPower: ressource not found in ressources_config (name=%s)', $cost['ressource_name']));
+        game_error_log(__FUNCTION__, 'ressource not found in ressources_config',
+            ['ressource_name' => $cost['ressource_name']], 'warning');
         return null;
     }
     return ['ressource_id' => $rid, 'ressource_name' => $cost['ressource_name'], 'amount' => $cost['amount']];
@@ -442,7 +442,7 @@ function evaluateRuleKeysAllMatch(array $keys, array $context, $turn_number){
     foreach ($keys as $key => $value){
         if ($key === 'OR') continue;
         if (!in_array($key, $ALLOWED_KEYS, true)){
-            error_log(sprintf('evaluateRuleKeysAllMatch: unknown rule key %s — failing closed', var_export($key, true)));
+            game_error_log(__FUNCTION__, 'unknown rule key — failing closed', ['key' => (string)$key]);
             return false;
         }
 
@@ -480,18 +480,20 @@ function evaluateRuleKeysAllMatch(array $keys, array $context, $turn_number){
         }
         elseif ($key === 'controller_has_ressource'){
             if (!is_array($value)){
-                error_log('controller_has_ressource: malformed rule (not an object)');
+                game_error_log(__FUNCTION__, 'controller_has_ressource: malformed rule (not an object)');
                 return false;
             }
             $rname = $value['ressource_name'] ?? null;
             $rawAmount = $value['amount'] ?? null;
             $amountIsStrictInt = is_int($rawAmount) || (is_string($rawAmount) && ctype_digit($rawAmount));
             if (!is_string($rname) || $rname === '' || !$amountIsStrictInt || (int)$rawAmount <= 0){
-                error_log(sprintf('controller_has_ressource: invalid ressource_name or amount (rname=%s, amount=%s)', var_export($rname, true), var_export($rawAmount, true)));
+                game_error_log(__FUNCTION__, 'controller_has_ressource: invalid ressource_name or amount',
+                    ['ressource_name' => var_export($rname, true), 'amount' => var_export($rawAmount, true)]);
                 return false;
             }
             if (array_key_exists('consume', $value) && !is_bool($value['consume'])){
-                error_log(sprintf('controller_has_ressource: consume must be bool if present (got %s)', var_export($value['consume'], true)));
+                game_error_log(__FUNCTION__, 'controller_has_ressource: consume must be bool if present',
+                    ['consume' => var_export($value['consume'], true)]);
                 return false;
             }
             $amount = (int)$rawAmount;
@@ -535,7 +537,7 @@ function resolveRessourceIdByName($pdo, $ressource_name){
         $rid = $stmt->fetchColumn();
         return $rid !== false ? (int)$rid : null;
     } catch (PDOException $e) {
-        error_log('resolveRessourceIdByName: '.$e->getMessage());
+        game_error_log(__FUNCTION__, 'SELECT ressource_id by name failed', ['error' => $e->getMessage()]);
         return null;
     }
 }

--- a/powers/functions.php
+++ b/powers/functions.php
@@ -2,12 +2,14 @@
 /**
  * Get the description for a power_type
  *
- * @param PDO $pdo
- * @param string $name
- *
- * @return string|NULL : $description
+ * @param PDO $pdo : database connection
+ * @param string $name : power_type name
+ * @return string|null : description
  */
-function getPowerTypesDescription($pdo, $name){
+function getPowerTypesDescription(PDO $pdo, string $name): string|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with name : ' . $name, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try{
         $stmt = $pdo->prepare("SELECT description
@@ -15,9 +17,10 @@ function getPowerTypesDescription($pdo, $name){
             WHERE name = :name
         ");
         $stmt->execute([':name' => $name]);
-        return $stmt->fetchColumn();
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : NULL;
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $name failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT description failed', ['name' => $name, 'error' => $e->getMessage()]);
         return NULL;
     }
 }
@@ -25,11 +28,10 @@ function getPowerTypesDescription($pdo, $name){
 /**
  * Get the format for a power text
  *
- * @param bool $short
- *
- * @return string
+ * @param bool $short : short format flag
+ * @return string : SQL fragment
  */
-function getSQLPowerText($short = true) {
+function getSQLPowerText(bool $short = true): string {
     $sql = "CONCAT(p.name, ' (', p.enquete, ', ', p.attack, '/', p.defence, ')') AS power_text";
     if (!$short) {
         $sql = "CONCAT('<strong>', p.name, ' (', p.enquete, ', ', p.attack, '/', p.defence, ')</strong> ', p.description) AS power_text";
@@ -43,12 +45,14 @@ function getSQLPowerText($short = true) {
 /**
  * Gets array of powers for a worker id
  *
- * @param PDO $pdo
- * @param string $worker_id_str
- *
- * @return array
+ * @param PDO $pdo : database connection
+ * @param int|string $worker_id_str : one worker id or comma-separated ids for the IN clause
+ * @return array : worker_powers rows
  */
-function getPowersByWorkers($pdo, $worker_id_str) {
+function getPowersByWorkers(PDO $pdo, int|string $worker_id_str): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with worker_id_str : ' . $worker_id_str, [], 'debug');
+
     $power_text = getSQLPowerText(false);
     $prefix = $_SESSION['GAME_PREFIX'];
     $sql = "SELECT
@@ -68,13 +72,12 @@ function getPowersByWorkers($pdo, $worker_id_str) {
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT powers by workers failed', ['sql' => $sql, 'error' => $e->getMessage()]);
         return array();
     }
     // Fetch the results
     $workers_powers = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    if ($_SESSION['DEBUG'] == true)
-        echo sprintf("workers_powers %s <br /> <br />", var_export($workers_powers,true));
+    game_error_log(__FUNCTION__, 'DONE', ['workers_powers' => $workers_powers], 'debug');
 
     return $workers_powers;
 }
@@ -82,13 +85,14 @@ function getPowersByWorkers($pdo, $worker_id_str) {
 /**
  *  get a number of random elements from the type of power given
  *
- * @param PDO $pdo
- * @param string $type
- * @param array $newWorker
- *
- * @return array : $newWorker
+ * @param PDO $pdo : database connection
+ * @param string $type : link_power_type id
+ * @param array $newWorker : worker being built
+ * @return array|null : $newWorker with power_<type> filled, or NULL on SQL error
  */
-function randomPowersByType($pdo, $type, $newWorker) {
+function randomPowersByType(PDO $pdo, string $type, array $newWorker): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with type : ' . $type, ['newWorker' => $newWorker], 'debug');
 
     // TODO : Add a select limit by controller_id like in the getPowersByType function
     // TODO : Allow locking certain Hobbys/Metiers by origin or controler !
@@ -126,7 +130,7 @@ function randomPowersByType($pdo, $type, $newWorker) {
         $stmt = $pdo->prepare($sql);
         $stmt->execute([':turn' => $turn_number]);
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT random power failed', ['sql' => $sql, 'error' => $e->getMessage()]);
         return NULL;
     }
 
@@ -143,14 +147,16 @@ function randomPowersByType($pdo, $type, $newWorker) {
  *  - powers linked to a controller by faction
  *  - base power from config
  *
- * @param PDO $pdo
- * @param int $type_list  // TODO change from ID of link_power_type to a type name ?
- * @param int $controller_id
- * @param bool $add_base
- *
+ * @param PDO $pdo : database connection
+ * @param string $type_list : link_power_type id list  // TODO change from ID of link_power_type to a type name ?
+ * @param int|null $controller_id : controller id, or NULL to skip controller filter
+ * @param bool $add_base : whether to add basePowerNames from config
  * @return array|null : $powerArray
  */
-function getPowersByType($pdo, $type_list, $controller_id = NULL, $add_base = true) {
+function getPowersByType(PDO $pdo, string $type_list, int|null $controller_id = NULL, bool $add_base = true): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with type_list : ' . $type_list, ['controller_id' => $controller_id, 'add_base' => $add_base], 'debug');
+
     $powerArray = array();
     $power_text = getSQLPowerText();
 
@@ -189,15 +195,13 @@ function getPowersByType($pdo, $type_list, $controller_id = NULL, $add_base = tr
         $conditions,
         $power_text,
     );
-    if ($_SESSION['DEBUG'] == true){
-        echo __FUNCTION__."(): $sql <br />";
-    }
+    game_error_log(__FUNCTION__, 'SQL', ['sql' => $sql], 'debug');
 
     try{
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT powers by type failed', ['sql' => $sql, 'error' => $e->getMessage()]);
         return NULL;
     }
 
@@ -209,13 +213,16 @@ function getPowersByType($pdo, $type_list, $controller_id = NULL, $add_base = tr
 /**
  * builds the discipline select field from an array of Disciplines
  *
- * @param PDO $pdo
+ * @param PDO $pdo : database connection
  * @param array $powerDisciplineArray
  * @param bool $showText default: true
  *
  * @return string: $showDisciplineSelect
  */
-function showDisciplineSelect($pdo, $powerDisciplineArray, $showText = true){
+function showDisciplineSelect(PDO $pdo, array $powerDisciplineArray, bool $showText = true): string {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['powerDisciplineArray' => $powerDisciplineArray, 'showText' => $showText], 'debug');
+
     if (empty($powerDisciplineArray)) return '';
 
     $disciplinesOptions = '';
@@ -241,7 +248,7 @@ function showDisciplineSelect($pdo, $powerDisciplineArray, $showText = true){
         $disciplinesOptions
     );
 
-    if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): showDisciplineSelect: ".var_export($showDisciplineSelect, true)."<br /><br />";
+    game_error_log(__FUNCTION__, 'DONE', ['showDisciplineSelect' => $showDisciplineSelect], 'debug');
 
     return $showDisciplineSelect;
 }
@@ -249,11 +256,19 @@ function showDisciplineSelect($pdo, $powerDisciplineArray, $showText = true){
 /**
  * Filter a list of powers by JSON-driven unlock rules at `[$state_text]`.
  * Pure-check: never mutates DB. Delegates per-power gating to findMatchingBranch.
- *
+ * 
+ * @param PDO $pdo : database connection
+ * @param array $powerArray : power array
+ * @param int $controller_id : controller id
+ * @param int $worker_id : worker id
+ * @param int $turn_number : turn number
+ * @param string $state_text : state text
  * @return array|null surviving powers (NULL when empty)
  */
-function cleanPowerListFromJsonConditions($pdo, $powerArray, $controller_id, $worker_id, $turn_number, $state_text ){
-    $debug = (strtolower(getConfig($pdo, 'DEBUG_TRANSFORM')) == 'true');
+function cleanPowerListFromJsonConditions(PDO $pdo, array $powerArray, int $controller_id, int|null $worker_id, int $turn_number, string $state_text): array|null {
+    if (strtolower(getConfig($pdo, 'DEBUG_TRANSFORM')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['powerArray' => $powerArray, 'worker_id' => $worker_id, 'turn_number' => $turn_number, 'state_text' => $state_text], 'debug');
 
     $workersPowersList = array();
     if (!empty($worker_id)){
@@ -265,7 +280,7 @@ function cleanPowerListFromJsonConditions($pdo, $powerArray, $controller_id, $wo
 
     foreach ( $powerArray AS $key => $power ) {
         if (!empty($worker_id) && in_array($power['id'], $workersPowersList, true)){
-            if ($debug) echo sprintf("kill power(%s) — already possessed<br>", $key);
+            game_error_log(__FUNCTION__, 'kill power(' . $key . ') — already possessed', [], 'debug');
             unset($powerArray[$key]);
             continue;
         }
@@ -275,7 +290,7 @@ function cleanPowerListFromJsonConditions($pdo, $powerArray, $controller_id, $wo
 
         $match = findMatchingBranch($pdo, $powerConditions, $controller_id, $worker_id, $turn_number, $state_text);
         if (!$match['keep']){
-            if ($debug) echo sprintf("kill power(%s)<br>", $key);
+            game_error_log(__FUNCTION__, 'kill power(' . $key . ')', [], 'debug');
             unset($powerArray[$key]);
         }
     }
@@ -288,9 +303,18 @@ function cleanPowerListFromJsonConditions($pdo, $powerArray, $controller_id, $wo
  * branch fired. Single source of truth for gate semantics across display
  * (cleanPowerListFromJsonConditions) and commit (getRuleCostForPower).
  *
+ * @param PDO $pdo : database connection
+ * @param array $powerConditions : power conditions
+ * @param int $controller_id : controller id
+ * @param int $worker_id : worker id
+ * @param int $turn_number : turn number
+ * @param string $state_text : state text
  * @return array ['keep' => bool, 'matching_branch' => ?array]
  */
-function findMatchingBranch($pdo, $powerConditions, $controller_id, $worker_id, $turn_number, $state_text){
+function findMatchingBranch(PDO $pdo, array $powerConditions, int $controller_id, int|null $worker_id, int $turn_number, string $state_text): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['powerConditions' => $powerConditions, 'worker_id' => $worker_id, 'turn_number' => $turn_number, 'state_text' => $state_text], 'debug');
+
     static $contextCache = [];
 
     $result = ['keep' => true, 'matching_branch' => null];
@@ -353,10 +377,19 @@ function findMatchingBranch($pdo, $powerConditions, $controller_id, $worker_id, 
  * both the direct-level controller_has_ressource and the matched OR branch
  * (via findMatchingBranch). Direct precedence on cross-resource collision +
  * error_log warning. Returns null when no deducting cost applies.
- *
+ * 
+ * @param PDO $pdo : database connection
+ * @param array $power : power to evaluate
+ * @param int $controller_id : controller id
+ * @param int $worker_id : worker id
+ * @param int $turn_number : turn number
+ * @param string $state_text : state text
  * @return array|null ['ressource_id' => int, 'ressource_name' => string, 'amount' => int]
  */
-function getRuleCostForPower($pdo, $power, $controller_id, $worker_id, $turn_number, $state_text){
+function getRuleCostForPower(PDO $pdo, array $power, int $controller_id, int|null $worker_id, int $turn_number, string $state_text): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['power' => $power, 'worker_id' => $worker_id, 'state_text' => $state_text], 'debug');
+
     if (empty($power['other'])) return null;
     $powerConditions = json_decode($power['other'], true);
     if (!is_array($powerConditions) || empty($powerConditions[$state_text]) || !is_array($powerConditions[$state_text])) return null;
@@ -396,8 +429,16 @@ function getRuleCostForPower($pdo, $power, $controller_id, $worker_id, $turn_num
 /**
  * Pre-fetch all per-controller / per-worker data the rule keys need.
  * Cached inside findMatchingBranch for the request.
+ *
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : controller id
+ * @param int|null $worker_id : worker id, or NULL when no worker context
+ * @return array : ['worker', 'controllersArray', 'zonesArray', 'zonesArrayHolder', 'ressourcesArray']
  */
-function buildRuleEvaluationContext($pdo, $controller_id, $worker_id){
+function buildRuleEvaluationContext(PDO $pdo, int $controller_id, int|null $worker_id): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['worker_id' => $worker_id], 'debug');
+
     $worker = null;
     if (!empty($worker_id)){
         $workersArray = getWorkers($pdo, [$worker_id]);
@@ -427,8 +468,16 @@ function buildRuleEvaluationContext($pdo, $controller_id, $worker_id){
  * Fail-closed on unknown keys: a typo like `controller_has_resource` (English
  * single-`s` spelling) would otherwise unlock the power instead of hiding it.
  * When the rule grammar is extended, add the new key here.
+ * 
+ * @param array $keys : keys to evaluate
+ * @param array $context : context to evaluate the keys
+ * @param int $turn_number : turn number
+ * @return bool true if all keys match, false otherwise
  */
-function evaluateRuleKeysAllMatch(array $keys, array $context, $turn_number){
+function evaluateRuleKeysAllMatch(array $keys, array $context, int $turn_number): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with turn_number : ' . $turn_number, ['keys_count' => count($keys), 'context' => $context], 'debug');
+
     static $ALLOWED_KEYS = [
         'age', 'worker_is_alive', 'unlock_turn', 'controller_faction',
         'controller_has_zone', 'worker_in_zone', 'controller_has_ressource',
@@ -442,7 +491,7 @@ function evaluateRuleKeysAllMatch(array $keys, array $context, $turn_number){
     foreach ($keys as $key => $value){
         if ($key === 'OR') continue;
         if (!in_array($key, $ALLOWED_KEYS, true)){
-            game_error_log(__FUNCTION__, 'unknown rule key — failing closed', ['key' => (string)$key]);
+            game_error_log(__FUNCTION__, 'unknown rule key — failing closed', ['key' => (string)$key], 'debug');
             return false;
         }
 
@@ -488,12 +537,12 @@ function evaluateRuleKeysAllMatch(array $keys, array $context, $turn_number){
             $amountIsStrictInt = is_int($rawAmount) || (is_string($rawAmount) && ctype_digit($rawAmount));
             if (!is_string($rname) || $rname === '' || !$amountIsStrictInt || (int)$rawAmount <= 0){
                 game_error_log(__FUNCTION__, 'controller_has_ressource: invalid ressource_name or amount',
-                    ['ressource_name' => var_export($rname, true), 'amount' => var_export($rawAmount, true)]);
+                    ['ressource_name' => var_export($rname, true), 'amount' => var_export($rawAmount, true)], 'debug');
                 return false;
             }
             if (array_key_exists('consume', $value) && !is_bool($value['consume'])){
                 game_error_log(__FUNCTION__, 'controller_has_ressource: consume must be bool if present',
-                    ['consume' => var_export($value['consume'], true)]);
+                    ['consume' => var_export($value['consume'], true)], 'debug');
                 return false;
             }
             $amount = (int)$rawAmount;
@@ -512,8 +561,11 @@ function evaluateRuleKeysAllMatch(array $keys, array $context, $turn_number){
 /**
  * Extract the gate/cost form of a controller_has_ressource value.
  * Returns null when consume === false (gate-only) or malformed.
+ *
+ * @param array|null $ressourceRule : controller_has_ressource sub-object, or null
+ * @return array|null : ['ressource_name' => string, 'amount' => int]
  */
-function extractRessourceCostFromRule($ressourceRule){
+function extractRessourceCostFromRule(array|null $ressourceRule): array|null {
     if (!is_array($ressourceRule)) return null;
     if (array_key_exists('consume', $ressourceRule)){
         if (!is_bool($ressourceRule['consume'])) return null;
@@ -528,8 +580,14 @@ function extractRessourceCostFromRule($ressourceRule){
 
 /**
  * Resolve a ressource_id from its ressource_name.
+ * @param PDO $pdo : database connection
+ * @param string $ressource_name : ressource name
+ * @return int|null ressource id
  */
-function resolveRessourceIdByName($pdo, $ressource_name){
+function resolveRessourceIdByName(PDO $pdo, string $ressource_name): int|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with ressource_name : ' . $ressource_name, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
         $stmt = $pdo->prepare("SELECT id FROM {$prefix}ressources_config WHERE ressource_name = :name LIMIT 1");
@@ -546,13 +604,14 @@ function resolveRessourceIdByName($pdo, $ressource_name){
  * Build select field for Transformations in array
  *
  * @param PDO $pdo : database connection
- * @param array $powerTransformationArray
- * @param bool $showText default true
- *
+ * @param array $powerTransformationArray : transformation rows with power_text
+ * @param bool $showText : whether to show the leading label, default true
  * @return string : $showTransformationSelect
- *
  */
-function showTransformationSelect($pdo, $powerTransformationArray, $showText = true){
+function showTransformationSelect(PDO $pdo, array $powerTransformationArray, bool $showText = true): string {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['powerTransformationArray' => $powerTransformationArray, 'showText' => $showText], 'debug');
+
     if (empty($powerTransformationArray)) return '';
 
     $transformationsOptions = '';
@@ -578,7 +637,7 @@ function showTransformationSelect($pdo, $powerTransformationArray, $showText = t
         $transformationsOptions
     );
 
-    if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): showTransformationSelect: ".var_export($showTransformationSelect, true)."<br /><br />";
+    game_error_log(__FUNCTION__, 'DONE', ['showTransformationSelect' => $showTransformationSelect], 'debug');
 
     return $showTransformationSelect;
 }

--- a/ressources/functions.php
+++ b/ressources/functions.php
@@ -260,7 +260,7 @@ function spendRessourcesToRepairLocation(PDO $pdo, int $controller_id): bool {
 function spendRessourcesByCostField(PDO $pdo, int $controller_id, string $costField): bool {
     static $allowed = ['base_building_cost', 'base_moving_cost', 'location_repaire_cost'];
     if (!in_array($costField, $allowed, true)) {
-        error_log(__FUNCTION__.": unknown cost field {$costField}");
+        game_error_log(__FUNCTION__, 'unknown cost field', ['costField' => $costField]);
         return false;
     }
     if (getConfig($pdo, 'ressource_management') !== 'TRUE') return true;
@@ -433,7 +433,7 @@ function consumeRessource(PDO $pdo, int $controller_id, int $ressource_id, int $
         ]);
         return $stmt->rowCount() === 1;
     } catch (PDOException $e) {
-        error_log(__FUNCTION__.": ".$e->getMessage());
+        game_error_log(__FUNCTION__, 'consume ressource failed', ['error' => $e->getMessage()]);
         return false;
     }
 }

--- a/ressources/functions.php
+++ b/ressources/functions.php
@@ -1,14 +1,17 @@
 <?php
 
 /**
- * Update the ressources for a controller
+ * Update the ressources for a controller.
  *
- * @param PDO $pdo
- * @param array $mechanics
+ * @param PDO   $pdo        : DB connection
+ * @param array $mechanics  : mechanics row (turncounter etc.)
  *
- * @return bool
+ * @return bool true on success
  */
-function updateRessources($pdo, $mechanics) {
+function updateRessources(PDO $pdo, array $mechanics): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['mechanics' => $mechanics], 'debug');
+
     echo '<div> <h3>  updateRessources : </h3> ';
 
     /** Foreach controller :
@@ -51,15 +54,14 @@ function updateRessources($pdo, $mechanics) {
 }
 
 /**
- * Get the ressources for a controller
+ * Get the ressources for a controller.
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return array
- * 
+ * @return array joined controller_ressources + ressources_config rows
  */
-function getRessources($pdo, $controller_id) {
+function getRessources(PDO $pdo, int $controller_id): array {
     $prefix = $_SESSION['GAME_PREFIX'];
     $sql = "SELECT rc.id as rc_id, rc.*, r.id as ressource_id, r.*
         FROM {$prefix}controller_ressources rc
@@ -81,6 +83,11 @@ function getRessources($pdo, $controller_id) {
  * by the Ressources page so a ressource the controller is about to acquire
  * surfaces ahead of its first non-zero turn. The faction-page recap omits
  * this param and stays strict.
+ *
+ * @param array $ressources    : rows from getRessources
+ * @param array $gainEstimate  : optional map ressource_id => ['total' => int]
+ *
+ * @return array filtered rows (0-indexed)
  */
 function filterVisibleRessources(array $ressources, array $gainEstimate = []): array {
     return array_values(array_filter($ressources, function ($r) use ($gainEstimate) {
@@ -94,14 +101,14 @@ function filterVisibleRessources(array $ressources, array $gainEstimate = []): a
 }
 
 /**
- * Does the controller have enought ressources to build a base ?
+ * Does the controller have enough ressources to build a base ?
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return bool
+ * @return bool true if all base_building_cost fields are covered
  */
-function hasEnoughRessourcesToBuildBase($pdo, $controller_id) {
+function hasEnoughRessourcesToBuildBase(PDO $pdo, int $controller_id): bool {
     if (getConfig($pdo, 'ressource_management') === 'TRUE') {
         $controllerRessources = getRessources($pdo, $controller_id);
         foreach ($controllerRessources as $controllerRessource) {
@@ -122,6 +129,9 @@ function hasEnoughRessourcesToBuildBase($pdo, $controller_id) {
  * ressource_management is off, or when no ressource carries a positive
  * base_building_cost (nothing to spend).
  *
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
+ *
  * @return bool true on full deduction (or no-op), false on any shortfall.
  */
 function spendRessourcesToBuildBase(PDO $pdo, int $controller_id): bool {
@@ -129,14 +139,14 @@ function spendRessourcesToBuildBase(PDO $pdo, int $controller_id): bool {
 }
 
 /**
- * Get the cost HTML to build a base
+ * Get the cost HTML to build a base.
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return string
+ * @return string HTML fragment listing positive base_building_cost entries
  */
-function buildBaseCostHTML($pdo, $controller_id) {
+function buildBaseCostHTML(PDO $pdo, int $controller_id): string {
     $html = '';
     if (getConfig($pdo, 'ressource_management') === 'TRUE') {
         $controllerRessources = getRessources($pdo, $controller_id);
@@ -153,14 +163,14 @@ function buildBaseCostHTML($pdo, $controller_id) {
 }
 
 /**
- * Does the controller have enought ressources to move a base ?
+ * Does the controller have enough ressources to move a base ?
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return bool
+ * @return bool true if all base_moving_cost fields are covered
  */
-function hasEnoughRessourcesToMoveBase($pdo, $controller_id) {
+function hasEnoughRessourcesToMoveBase(PDO $pdo, int $controller_id): bool {
     if (getConfig($pdo, 'ressource_management') === 'TRUE') {
         $controllerRessources = getRessources($pdo, $controller_id);
         foreach ($controllerRessources as $controllerRessource) {
@@ -178,6 +188,9 @@ function hasEnoughRessourcesToMoveBase($pdo, $controller_id) {
  * Spend the ressources to move a base. Atomic; rolls back on any shortfall.
  * See spendRessourcesToBuildBase for the contract.
  *
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
+ *
  * @return bool true on full deduction (or no-op), false on any shortfall.
  */
 function spendRessourcesToMoveBase(PDO $pdo, int $controller_id): bool {
@@ -185,14 +198,14 @@ function spendRessourcesToMoveBase(PDO $pdo, int $controller_id): bool {
 }
 
 /**
- * Get the cost HTML to move a base
+ * Get the cost HTML to move a base.
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return string
+ * @return string HTML fragment listing positive base_moving_cost entries
  */
-function moveBaseCostHTML($pdo, $controller_id) {
+function moveBaseCostHTML(PDO $pdo, int $controller_id): string {
     $html = '';
     if (getConfig($pdo, 'ressource_management') === 'TRUE') {
         $controllerRessources = getRessources($pdo, $controller_id);
@@ -209,14 +222,14 @@ function moveBaseCostHTML($pdo, $controller_id) {
 }
 
 /**
- * Does the controller have enought ressources to repair a location ?
+ * Does the controller have enough ressources to repair a location ?
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return bool
+ * @return bool true if all location_repaire_cost fields are covered
  */
-function hasEnoughRessourcesToRepairLocation($pdo, $controller_id) {
+function hasEnoughRessourcesToRepairLocation(PDO $pdo, int $controller_id): bool {
 
     if (getConfig($pdo, 'ressource_management') === 'TRUE') {
         $controllerRessources = getRessources($pdo, $controller_id);
@@ -232,12 +245,13 @@ function hasEnoughRessourcesToRepairLocation($pdo, $controller_id) {
 }
 
 /**
- * Spend the ressources to repair a location
+ * Spend the ressources to repair a location. Atomic; rolls back on any shortfall.
+ * See spendRessourcesToBuildBase for the contract.
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return bool
+ * @return bool true on full deduction (or no-op), false on any shortfall.
  */
 function spendRessourcesToRepairLocation(PDO $pdo, int $controller_id): bool {
     return spendRessourcesByCostField($pdo, $controller_id, 'location_repaire_cost');
@@ -254,10 +268,17 @@ function spendRessourcesToRepairLocation(PDO $pdo, int $controller_id): bool {
  * them, so the old "rowCount on no-op UPDATE" noise is impossible by
  * construction.
  *
- * @param string $costField one of: base_building_cost, base_moving_cost,
- *                          location_repaire_cost. Whitelist enforced.
+ * @param PDO    $pdo            : DB connection
+ * @param int    $controller_id  : controller id
+ * @param string $costField      : one of base_building_cost, base_moving_cost,
+ *                                 location_repaire_cost. Whitelist enforced.
+ *
+ * @return bool true on full deduction (or no-op), false on any shortfall.
  */
 function spendRessourcesByCostField(PDO $pdo, int $controller_id, string $costField): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['costField' => $costField], 'debug');
+
     static $allowed = ['base_building_cost', 'base_moving_cost', 'location_repaire_cost'];
     if (!in_array($costField, $allowed, true)) {
         game_error_log(__FUNCTION__, 'unknown cost field', ['costField' => $costField]);
@@ -285,14 +306,14 @@ function spendRessourcesByCostField(PDO $pdo, int $controller_id, string $costFi
 }
 
 /**
- * Get the cost HTML to repair a location
+ * Get the cost HTML to repair a location.
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return string
+ * @return string HTML fragment listing positive location_repaire_cost entries
  */
-function repairLocationCostHTML($pdo, $controller_id) {
+function repairLocationCostHTML(PDO $pdo, int $controller_id): string {
     $html = '';
     if (getConfig($pdo, 'ressource_management') === 'TRUE') {
         $controllerRessources = getRessources($pdo, $controller_id);
@@ -313,12 +334,12 @@ function repairLocationCostHTML($pdo, $controller_id) {
  * $zoneTypeLabel is the resolved `textForZoneType` config ("zone" / "quartier"
  * / "territoire"). Caller fetches it once and passes it in.
  *
- * @param array  $rule
- * @param string $zoneTypeLabel
+ * @param array  $rule           : gain rule structure
+ * @param string $zoneTypeLabel  : resolved zone-type label
  *
- * @return string
+ * @return string natural-French condition rendering
  */
-function gainRuleToText(array $rule, $zoneTypeLabel = 'zone') {
+function gainRuleToText(array $rule, string $zoneTypeLabel = 'zone'): string {
     $type = $rule['condition']['type'] ?? '';
     switch ($type) {
         case 'holds_zone':
@@ -350,12 +371,15 @@ function gainRuleToText(array $rule, $zoneTypeLabel = 'zone') {
  *   'total'        => sum of all rule contributions for this ressource,
  * ].
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
  *
- * @return array
+ * @return array grouped gain estimate, empty on DB error
  */
-function ressourceGainEstimateForController($pdo, $controller_id) {
+function ressourceGainEstimateForController(PDO $pdo, int $controller_id): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
+
     require_once __DIR__ . '/../mechanics/ressourceGainMechanic.php';
     $prefix = $_SESSION['GAME_PREFIX'];
     $estimate = [];
@@ -371,7 +395,7 @@ function ressourceGainEstimateForController($pdo, $controller_id) {
         $stmt->execute();
         $configRows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT gain_rules failed: ".$e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT gain_rules failed', ['error' => $e->getMessage()]);
         return [];
     }
 
@@ -416,9 +440,17 @@ function ressourceGainEstimateForController($pdo, $controller_id) {
  * Single-row UPDATE with the `WHERE amount >= :amt` guard (TOCTOU-safe).
  * Caller is responsible for the surrounding transaction.
  *
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : controller id
+ * @param int $ressource_id   : ressource id
+ * @param int $amount         : quantity to subtract (must be > 0)
+ *
  * @return bool true on success; false on insufficient amount, missing row, or DB error.
  */
 function consumeRessource(PDO $pdo, int $controller_id, int $ressource_id, int $amount): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['ressource_id' => $ressource_id, 'amount' => $amount], 'debug');
+
     if ($amount <= 0 || $controller_id <= 0 || $ressource_id <= 0) return false;
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
@@ -443,13 +475,16 @@ function consumeRessource(PDO $pdo, int $controller_id, int $ressource_id, int $
  * Validates inputs, wraps the decrement / increment / log writes in a
  * transaction so partial failure cannot vanish ressources.
  *
- * @param PDO   $pdo
- * @param int   $giver_id
- * @param array $post  expects 'ressource_id', 'target_controller_id', 'amount'
+ * @param PDO   $pdo       : DB connection
+ * @param int   $giver_id  : giver controller id
+ * @param array $post      : expects 'ressource_id', 'target_controller_id', 'amount'
  *
  * @return array ['success' => bool, 'message' => string]
  */
-function giftRessource($pdo, $giver_id, array $post) {
+function giftRessource(PDO $pdo, int $giver_id, array $post): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with giver_id : ' . $giver_id, ['post' => $post], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $ressource_id = (int)($post['ressource_id'] ?? 0);
     $target_id    = (int)($post['target_controller_id'] ?? 0);
@@ -492,6 +527,7 @@ function giftRessource($pdo, $giver_id, array $post) {
         $stmt = $pdo->query("SELECT turncounter FROM {$prefix}mechanics LIMIT 1");
         $turn = (int)($stmt->fetchColumn() ?: 0);
     } catch (PDOException $e) {
+        game_error_log(__FUNCTION__, 'gift validation failed', ['error' => $e->getMessage()]);
         return ['success' => false, 'message' => 'Erreur de validation.'];
     }
 
@@ -525,6 +561,7 @@ function giftRessource($pdo, $giver_id, array $post) {
         return ['success' => true, 'message' => sprintf('Don de %d effectué.', $amount)];
     } catch (PDOException $e) {
         $pdo->rollBack();
+        game_error_log(__FUNCTION__, 'gift transaction failed', ['error' => $e->getMessage()]);
         return ['success' => false, 'message' => 'Erreur lors du don.'];
     }
 }
@@ -533,12 +570,15 @@ function giftRessource($pdo, $giver_id, array $post) {
  * Fetch ressource gifts received by a controller, newest first.
  * Each row: ['turn', 'amount', 'giver', 'ressource'].
  *
- * @param PDO $pdo
- * @param int $controller_id
+ * @param PDO $pdo            : DB connection
+ * @param int $controller_id  : recipient controller id
  *
- * @return array
+ * @return array rows ordered by (turn DESC, created_at DESC), empty on DB error
  */
-function getRessourceGiftsReceived($pdo, $controller_id) {
+function getRessourceGiftsReceived(PDO $pdo, int $controller_id): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
         $sql = "SELECT
@@ -556,7 +596,7 @@ function getRessourceGiftsReceived($pdo, $controller_id) {
         $stmt->execute([':recipient_id' => $controller_id]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT ressource_gift_logs failed: ".$e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT ressource_gift_logs failed', ['error' => $e->getMessage()]);
         return [];
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import os
 import pymysql
 import pytest
+import requests
 
 # Docker MySQL connection defaults (override via env for alt setups)
 MYSQL_HOST = os.environ.get("MYSQL_HOST", "127.0.0.1")
@@ -32,6 +33,110 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 CSV_DIR = os.path.join(PROJECT_ROOT, "var", "csv")
 SQL_DIR = os.path.join(PROJECT_ROOT, "var", "mysql")
 
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "expects_errors: test intentionally triggers game_error_log ERROR entries; skip the log-tail assertion.",
+    )
+
+
+# Module-level HTTP session for /base/admin_logs.php queries.
+# UI-only per feedback_demo_ui_only: no direct filesystem access.
+_admin_logs_session = None
+_admin_logs_available = False
+
+
+def _ensure_admin_logs_session():
+    """Login as gm once (session-scoped) and return the shared requests.Session.
+    Returns None if login or endpoint is unreachable (fixture will silently skip)."""
+    global _admin_logs_session, _admin_logs_available
+    if _admin_logs_session is not None:
+        return _admin_logs_session if _admin_logs_available else None
+    session = requests.Session()
+    try:
+        session.post(
+            f"{PHP_BASE_URL}/connection/loginForm.php",
+            data={"username": "gm", "passwd": "orga"},
+            allow_redirects=True,
+            timeout=10,
+        )
+        probe = session.get(
+            f"{PHP_BASE_URL}/base/admin_logs.php",
+            timeout=10,
+            allow_redirects=False,
+        )
+        _admin_logs_available = (probe.status_code == 200)
+    except Exception:
+        _admin_logs_available = False
+    _admin_logs_session = session
+    return session if _admin_logs_available else None
+
+
+def _count_admin_logs_errors():
+    """Fetch admin_logs.php filtered by current prefix + ERROR level via UI.
+    Returns count of ERROR spans on the rendered page, or None if unreachable."""
+    session = _ensure_admin_logs_session()
+    if session is None:
+        return None
+    try:
+        response = session.get(
+            f"{PHP_BASE_URL}/base/admin_logs.php",
+            params={"prefix": GAME_PREFIX, "level": "ERROR"},
+            timeout=10,
+        )
+        if response.status_code != 200:
+            return None
+        # Each rendered ERROR line is wrapped in <span style="color:#c0392b;">…</span>.
+        return response.text.count('style="color:#c0392b')
+    except Exception:
+        return None
+
+
+def _count_admin_logs_warnings():
+    session = _ensure_admin_logs_session()
+    if session is None:
+        return None
+    try:
+        response = session.get(
+            f"{PHP_BASE_URL}/base/admin_logs.php",
+            params={"prefix": GAME_PREFIX, "level": "WARNING"},
+            timeout=10,
+        )
+        if response.status_code != 200:
+            return None
+        return response.text.count('style="color:#e67e22')
+    except Exception:
+        return None
+
+
+_session_warning_count_start = None
+
+
+def pytest_sessionstart(session):
+    """Snapshot the WARNING count at session start via admin_logs.php UI so
+    pytest_terminal_summary can report the session delta."""
+    global _session_warning_count_start
+    _session_warning_count_start = _count_admin_logs_warnings()
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Non-blocking WARNING report at session end via admin_logs.php UI."""
+    if _session_warning_count_start is None:
+        return
+    end_count = _count_admin_logs_warnings()
+    if end_count is None or end_count <= _session_warning_count_start:
+        return
+    delta = end_count - _session_warning_count_start
+    terminalreporter.write_sep(
+        "=",
+        f"WARNING report for '{GAME_PREFIX}' ({delta} new during session)"
+    )
+    terminalreporter.write_line(
+        f"  See {PHP_BASE_URL}/base/admin_logs.php?prefix={GAME_PREFIX}&level=WARNING"
+    )
+
 # PHP app URL (Docker)
 PHP_BASE_URL = os.environ.get("PHP_BASE_URL", "http://localhost:8080/RPGConquestGameTest")
 
@@ -61,6 +166,39 @@ def _php_error_guard(request):
     register_php_error_listener(page)
     yield
     assert_no_collected_php_errors(page)
+
+
+@pytest.fixture(autouse=True)
+def _assert_no_new_game_log_errors(request):
+    """Fail the test when the [GAME_PREFIX] [ERROR] count reported by
+    /base/admin_logs.php grows during the test's execution.
+
+    UI-only (respects feedback_demo_ui_only): reads via the admin viewer
+    HTTP endpoint, never touches the filesystem. Silently skips when the
+    admin viewer is unreachable (Demo without admin auth, endpoint down).
+
+    WARNING and DEBUG entries are ignored. Opt out with
+    `@pytest.mark.expects_errors` for tests that intentionally trigger
+    ERROR entries to verify error behavior.
+    """
+    if request.node.get_closest_marker("expects_errors"):
+        yield
+        return
+
+    pre_count = _count_admin_logs_errors()
+    yield
+    if pre_count is None:
+        return
+    post_count = _count_admin_logs_errors()
+    if post_count is None or post_count <= pre_count:
+        return
+    delta = post_count - pre_count
+    pytest.fail(
+        f"New game_error_log [ERROR] entries during '{request.node.name}' "
+        f"(prefix '{GAME_PREFIX}'): +{delta}. "
+        f"See {PHP_BASE_URL}/base/admin_logs.php?prefix={GAME_PREFIX}&level=ERROR "
+        f"(or mark @pytest.mark.expects_errors if intentional)."
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_zone_rules_e2e.py
+++ b/tests/test_zone_rules_e2e.py
@@ -433,6 +433,7 @@ class TestApplyZoneRulesBehaviour:
             f"got holder={post['holder_controller_id']!r}"
         )
 
+    @pytest.mark.expects_errors
     def test_rule_with_unknown_condition_is_skipped(self, browser):
         """Rule with an unrecognised `condition` string must be skipped
         (fail-open). A second well-formed rule on the same adjacent
@@ -507,6 +508,7 @@ class TestApplyZoneRulesBehaviour:
             f"{post['holder_controller_id']!r}"
         )
 
+    @pytest.mark.expects_errors
     def test_rule_with_both_shapes_is_skipped(self, browser):
         """A rule specifying BOTH `zone_name` and `adjacent_zones: true`
         is malformed — the helper cannot pick a semantic. Skipped with
@@ -530,6 +532,7 @@ class TestApplyZoneRulesBehaviour:
             f"{post['holder_controller_id']!r}"
         )
 
+    @pytest.mark.expects_errors
     def test_rule_with_neither_shape_is_skipped(self, browser):
         """A rule specifying NEITHER `zone_name` NOR `adjacent_zones: true`
         is malformed — no target defined. Skipped with error_log.
@@ -551,6 +554,7 @@ class TestApplyZoneRulesBehaviour:
             f"{post['holder_controller_id']!r}"
         )
 
+    @pytest.mark.expects_errors
     def test_rule_with_adjacent_zones_false_is_skipped(self, browser):
         """`adjacent_zones: false` (explicit false, not truthy) must fall
         through to the 'neither shape' branch since the discriminator is

--- a/var/.htaccess
+++ b/var/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/workers/action.php
+++ b/workers/action.php
@@ -1,6 +1,9 @@
 <?php
 
 require_once '../base/basePHP.php';
+
+// $GLOBALS['DEBUG_LOG_SECTIONS'][] = 'workers_action_page';  // uncomment to log DEBUG events from this page
+
 $pageName = 'workers_action';
 
 // Check if the user is logged in
@@ -47,7 +50,7 @@ if (empty($_SESSION['is_privileged'])) {
             exit();
         }
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT controller_worker Failed: " . $e->getMessage()."<br />";
+        game_error_log('workers_action_page', 'SELECT controller_worker failed : ' . $e->getMessage(), ['worker_id' => $worker_id, 'controller_id' => $session_controller_id], 'error');
         http_response_code(403);
         exit();
     }

--- a/workers/functions.php
+++ b/workers/functions.php
@@ -5,14 +5,14 @@ define('INACTIVE_ACTIONS', [ 'dead', 'captured', 'trace' ]);
 
 /**
  * Generate a new worker
- * 
+ *
  * @param PDO $pdo : database connection
- * @param int $controller_id
- * @param string $buttonClicked
- * 
- * @return array $newWorker
+ * @param int $controller_id : controller who is recruiting
+ * @param string $buttonClicked : recruitment button key (used to pick origin list)
+ *
+ * @return array : new worker draft with origin/powers filled in
  */
-function generateNewWorker($pdo, $controller_id, $buttonClicked) {
+function generateNewWorker(PDO $pdo, int $controller_id, string $buttonClicked): array {
     $newWorker = array('controller_id' => $controller_id);
 
     $generationOrder = getConfig($pdo, 'generation_order');
@@ -41,16 +41,18 @@ function generateNewWorker($pdo, $controller_id, $buttonClicked) {
  * Update worker action table for a turn and change the action and/or add to the report
  *
  * @param PDO $pdo : database connection
- * @param int $workerId
- * @param int $turnNumber
- * @param string|null $actionChoice
- * @param string|null $reportAppendArray
- * @param array|null $jsonArray
+ * @param int $workerId : id of the worker whose action row is updated
+ * @param int $turnNumber : turn number of the action row
+ * @param string|null $actionChoice : new action_choice, null to leave unchanged
+ * @param array|null $reportAppendArray : keyed report chunks to append
+ * @param array|null $jsonArray : action_params payload
  *
- * @return bool success
+ * @return bool : true on successful UPDATE, false otherwise
  */
-function updateWorkerAction($pdo, $workerId, $turnNumber, $actionChoice = null, $reportAppendArray = null, $jsonArray = null) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function updateWorkerAction(PDO $pdo, int $workerId, int $turnNumber, string|null $actionChoice = null, array|null $reportAppendArray = null, array|null $jsonArray = null): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true') $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with workerId : ' . $workerId, ['turnNumber' => $turnNumber, 'actionChoice' => $actionChoice, 'reportAppendArray' => $reportAppendArray, 'jsonArray' => $jsonArray], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     $query = "UPDATE {$prefix}worker_actions SET ";
@@ -64,7 +66,7 @@ function updateWorkerAction($pdo, $workerId, $turnNumber, $actionChoice = null, 
         $updates[] = "action_params = :json";
         $params['json'] = empty($jsonArray) ? '{}' : json_encode($jsonArray);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            echo  __FUNCTION__."(): Failed to encode JSON: " . json_last_error_msg()."<br />";
+            game_error_log(__FUNCTION__, 'Failed to encode JSON : ' . json_last_error_msg(), ['jsonArray' => $jsonArray], 'error');
             return false;
         }
     }
@@ -76,7 +78,7 @@ function updateWorkerAction($pdo, $workerId, $turnNumber, $actionChoice = null, 
         $stmt->execute();
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         if (!$row) {
-            echo  __FUNCTION__."(): No record found for worker_id $workerId and turn_number $turnNumber.<br />";
+            game_error_log(__FUNCTION__, 'No record found for worker_id ' . $workerId . ' and turn_number ' . $turnNumber, [], 'error');
             return false;
         }
         // Step 2: Decode the JSON report
@@ -84,6 +86,7 @@ function updateWorkerAction($pdo, $workerId, $turnNumber, $actionChoice = null, 
         if (!empty($row['report'])) {
             $report = json_decode($row['report'], true);
             if (json_last_error() !== JSON_ERROR_NONE) {
+                game_error_log(__FUNCTION__, 'Failed to decode JSON : ' . json_last_error_msg(), ['row' => $row], 'error');
                 throw new Exception(__FUNCTION__."():Failed to decode JSON: " . json_last_error_msg());
             }
         }
@@ -99,20 +102,20 @@ function updateWorkerAction($pdo, $workerId, $turnNumber, $actionChoice = null, 
         $updates[] = "report = :report";
         $params['report'] = json_encode($report);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            echo  __FUNCTION__."(): Failed to encode JSON: " . json_last_error_msg()."<br />";
+            game_error_log(__FUNCTION__, 'Failed to encode JSON : ' . json_last_error_msg(), ['report' => $report], 'error');
             return false;
         }
     }
 
     if (count($updates)>0) {
         $query .= implode(", ", $updates) . " WHERE worker_id = :worker_id AND turn_number = :turn_number";
-        if ($debug) echo sprintf(" query : %s, Params : %s ", $query, var_export($params, true));
+        game_error_log(__FUNCTION__, 'query prepared', ['query' => $query, 'params' => $params], 'debug');
 
         try{
             $stmt = $pdo->prepare($query);
             $stmt->execute($params);
         } catch (PDOException $e) {
-            echo  __FUNCTION__."(): $query failed: " . $e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'UPDATE worker_actions failed : ' . $e->getMessage(), ['query' => $query, 'params' => $params], 'error');
             return false;
         }
         return true;
@@ -124,11 +127,14 @@ function updateWorkerAction($pdo, $workerId, $turnNumber, $actionChoice = null, 
  * Function to get worker and return as an array
  *
  * @param PDO $pdo : database connection
- * @param array $workerIds
+ * @param array|null $workerIds : worker ids to fetch
  *
- * @return array|null workersArray
+ * @return array|null : workers with powers + actions attached, or NULL on empty/error
  */
-function getWorkers($pdo, $workerIds) {
+function getWorkers(PDO $pdo, array|null $workerIds): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['workerIds' => $workerIds], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     if ( empty($workerIds) ) return NULL;
@@ -170,12 +176,12 @@ function getWorkers($pdo, $workerIds) {
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT workers failed : ' . $e->getMessage(), ['sql' => $sql], 'error');
         return NULL;
     }
     // Fetch the results
     $workersArray = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    if ($_SESSION['DEBUG'] == true) echo sprintf("workersArray %s <br /> <br />", var_export($workersArray,true));
+    game_error_log(__FUNCTION__, 'workersArray fetched', ['workersArray' => $workersArray], 'debug');
 
     $workers_powers = getPowersByWorkers($pdo, $worker_id_str);
 
@@ -206,7 +212,7 @@ function getWorkers($pdo, $workerIds) {
         $workersArray[$key]['powers'] = $workerPowersById[$worker['id']] ?? []; // Add powers or empty array if none
         $workersArray[$key]['actions'] = $workerActionsById[$worker['id']] ?? []; // Add actions or empty array if none
     }
-    if ($_SESSION['DEBUG'] == true) echo sprintf("workersArray %s <br /> <br />", var_export($workersArray,true));
+    game_error_log(__FUNCTION__, 'DONE', ['workersArray' => $workersArray], 'debug');
 
     return $workersArray;
 }
@@ -215,12 +221,15 @@ function getWorkers($pdo, $workerIds) {
  * Get workers linked to a controller (primary OR double-agent), optionally filtered to a single zone.
  *
  * @param PDO $pdo : database connection
- * @param int $controller_id
- * @param int|null $zone_id  when set, restrict to workers currently in this zone
+ * @param int $controller_id : controller whose linked workers to fetch
+ * @param int|null $zone_id : when set, restrict to workers currently in this zone
  *
- * @return array|null workersArray
+ * @return array|null : workers array from getWorkers(), or NULL on error
  */
-function getWorkersByController($pdo, $controller_id, $zone_id = null) {
+function getWorkersByController(PDO $pdo, int $controller_id, int|null $zone_id = null): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['zone_id' => $zone_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     $zoneJoin = ($zone_id !== null)
@@ -237,7 +246,7 @@ function getWorkersByController($pdo, $controller_id, $zone_id = null) {
         $stmt = $pdo->prepare($sql);
         $stmt->execute($params);
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT controller_worker failed : ' . $e->getMessage(), ['sql' => $sql, 'controller_id' => $controller_id, 'zone_id' => $zone_id], 'error');
         return NULL;
     }
 
@@ -251,16 +260,14 @@ function getWorkersByController($pdo, $controller_id, $zone_id = null) {
 }
 
 /**
- * Determin current action for worker
+ * Determine current action for worker
  *
- * 
- * @param PDO $pdo : database connection
- * @param int $controller_id
+ * @param array $workerActions : list of worker_actions rows for the worker
+ * @param int $turncounter : current turn number to match against
  *
- * @return array|null workersArray
- *
+ * @return array : the matching action row, or empty array when none found
  */
-function setWorkerCurrentAction($workerActions, $turncounter) {
+function setWorkerCurrentAction(array $workerActions, int $turncounter): array {
     foreach($workerActions as $action) {
         if ( $_SESSION['DEBUG'] == true )
             echo sprintf('workersArray as worker => worker[actions] as action : %s  <br>', var_export($action,true));
@@ -278,15 +285,14 @@ function setWorkerCurrentAction($workerActions, $turncounter) {
 }
 
 /**
- * get Worker satus
- * 
- * @param array $worker : must contain following keys
- * - ['actions'][current_turn_number]['action_choice']
- * - 'is_primary_controller'
- * 
- * @return string 
+ * Get Worker status
+ *
+ * @param array $worker : must contain keys ['actions'][turncounter]['action_choice'] and 'is_primary_controller'
+ * @param array $mechanics : must contain key 'turncounter'
+ *
+ * @return string : one of 'alive', 'double_agent', 'prisoner', 'dead', 'unfound'
  */
-function getWorkerStatus($worker, $mechanics) {
+function getWorkerStatus(array $worker, array $mechanics): string {
     $workerStatus = 'unfound';
     // alive: worker alive and active and that we control
     if (
@@ -322,20 +328,13 @@ function getWorkerStatus($worker, $mechanics) {
  * show Worker view Short version
  *
  * @param PDO $pdo : database connection
- * @param array $worker : must contain following keys
- *   - 'id'
- *   - 'firstname'
- *   - 'lastname'
- *   - 'zone_name'
- *   - 'total_enquete'
- *   - 'total_attack'
- *   - 'total_defence'
- *   - 'actions'
+ * @param array $worker : must contain 'id', 'firstname', 'lastname', 'zone_name', 'total_enquete', 'total_attack', 'total_defence', 'actions'
  * @param array $mechanics : must contain key 'turncounter'
+ * @param bool $showCheckBox : when true, prepend a select checkbox
  *
- * @return string
+ * @return string : rendered HTML fragment
  */
-function showWorkerShort($pdo, $worker, $mechanics, $showCheckBox = false) {
+function showWorkerShort(PDO $pdo, array $worker, array $mechanics, bool $showCheckBox = false): string {
 
     $currentAction = setWorkerCurrentAction($worker['actions'], $mechanics['turncounter']);
 
@@ -418,11 +417,14 @@ function showWorkerShort($pdo, $worker, $mechanics, $showCheckBox = false) {
  * getActionsByWorkers
  *
  * @param PDO $pdo : database connection
- * @param string $worker_id_str
+ * @param string $worker_id_str : comma-separated list of worker ids
  *
- * @return array|null workerActions
+ * @return array|null : worker_actions rows, or NULL on SQL error
  */
-function getActionsByWorkers($pdo, $worker_id_str){
+function getActionsByWorkers(PDO $pdo, string $worker_id_str): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with worker_id_str : ' . $worker_id_str, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $sql = "SELECT * FROM {$prefix}worker_actions w
         WHERE worker_id IN ($worker_id_str)
@@ -432,12 +434,12 @@ function getActionsByWorkers($pdo, $worker_id_str){
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT worker_actions failed : ' . $e->getMessage(), ['sql' => $sql], 'error');
         return NULL;
     }
     // Fetch the results
     $workerActions = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    if ($_SESSION['DEBUG'] == true) echo sprintf("workerActions: %s <br /> <br />", var_export($workerActions,true));
+    game_error_log(__FUNCTION__, 'DONE', ['workerActions' => $workerActions], 'debug');
 
     return $workerActions;
 }
@@ -446,12 +448,15 @@ function getActionsByWorkers($pdo, $worker_id_str){
  * Function get a random Origin for Worker
  *
  * @param PDO $pdo : database connection
- * @param array $newWorker
- * @param string|null $originList
+ * @param array $newWorker : worker draft (may carry power_1/power_2 with origin_list lock)
+ * @param string $buttonClicked : recruitment button key (used for <button>_origin_list config)
  *
- * @return array|null originsArray
+ * @return array|null : worker with origin_id + origin filled in, or NULL on SQL error
  */
-function randomWorkerOrigin($pdo, $newWorker, $buttonClicked) {
+function randomWorkerOrigin(PDO $pdo, array $newWorker, string $buttonClicked): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with buttonClicked : ' . $buttonClicked, ['newWorker' => $newWorker], 'debug');
+
     $randCommand = 'RANDOM()';
     if ($_SESSION['DBTYPE'] == 'mysql')
         $randCommand = 'RAND()';
@@ -493,7 +498,7 @@ function randomWorkerOrigin($pdo, $newWorker, $buttonClicked) {
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT worker_origins failed : ' . $e->getMessage(), ['sql' => $sql], 'error');
         return NULL;
     }
 
@@ -503,8 +508,7 @@ function randomWorkerOrigin($pdo, $newWorker, $buttonClicked) {
     // Store worker_origins in the array
     $newWorker['origin_id'] = $workerOrigins[0]['id'];
     $newWorker['origin'] = $workerOrigins[0]['name'];
-    if ($_SESSION['DEBUG'] == true) 
-        echo sprintf("newWorker: %s <br /> <br />", var_export($newWorker,true));
+    game_error_log(__FUNCTION__, 'DONE', ['newWorker' => $newWorker], 'debug');
 
     return $newWorker;
 }
@@ -513,12 +517,13 @@ function randomWorkerOrigin($pdo, $newWorker, $buttonClicked) {
  * Function get random Name for Worker for originList
  *
  * @param PDO $pdo : database connection
- * @param array $newWorker
+ * @param array $newWorker : worker draft (must carry origin_id)
  *
- * @return array|null nameArray
- *
+ * @return array|null : worker with firstname + lastname filled in, or NULL on SQL error
  */
-function randomWorkerName($pdo, $newWorker) {
+function randomWorkerName(PDO $pdo, array $newWorker): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['newWorker' => $newWorker], 'debug');
 
     // Get 2 random values from worker_names for and origin ID
     $randCommand = 'RANDOM()';
@@ -538,7 +543,7 @@ function randomWorkerName($pdo, $newWorker) {
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT worker_names failed : ' . $e->getMessage(), ['sql' => $sql], 'error');
         return NULL;
     }
 
@@ -555,28 +560,16 @@ function randomWorkerName($pdo, $newWorker) {
 }
 
 /**
- * Function to create worker and assing the controler
+ * Function to create worker and assign the controller
  *
  * @param PDO $pdo : database connection
- * @param array $array : $GET should contain :
- *     "creation"="true"
- *     firstname
- *     lastname
- *     origin
- *     power_hobby
- *     power_metier
- *     origin_id
- *     power_hobby_id
- *     power_metier_id
- *     zone
- *     discipline
- *     transformation
- *     controller_id
+ * @param array $array : must contain firstname, lastname, origin_id, controller_id, zone_id and optionally power_hobby_id, power_metier_id, discipline, transformation
  *
- * @return string workerId
+ * @return string|false : new worker id, existing worker id, or false when required fields are missing / INSERT fails
  */
-function createWorker($pdo, $array) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function createWorker(PDO $pdo, array $array): string|false {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true') $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START', ['array' => $array], 'debug');
 
     // If a necessary element of data is missing
     $requiredFields = [
@@ -595,7 +588,7 @@ function createWorker($pdo, $array) {
         foreach ($missing as $label) {
             echo sprintf("Champ obligatoire manquant : %s<br />", $label);
         }
-        if ($debug) echo sprintf("%s() => Unfound necessary element <br>", __FUNCTION__);
+        game_error_log(__FUNCTION__, 'Unfound necessary element', ['missing' => $missing], 'warning');
         return false;
     }
 
@@ -613,7 +606,7 @@ function createWorker($pdo, $array) {
         $stmt->bindParam(':controller_id', $array['controller_id'], PDO::PARAM_INT);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): SELECT workers Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT workers failed : ' . $e->getMessage(), ['array' => $array], 'error');
         return false;
     }
     $worker = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -629,7 +622,7 @@ function createWorker($pdo, $array) {
         $stmt->bindParam(':zone_id', $array['zone_id'], PDO::PARAM_INT);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): INSERT workers Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'INSERT workers failed : ' . $e->getMessage(), ['array' => $array], 'error');
         return false;
     }
     // Get the last inserted ID
@@ -649,7 +642,7 @@ function createWorker($pdo, $array) {
         $stmt->bindParam(':worker_id', $workerId, PDO::PARAM_INT);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): INSERT controller_worker Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'INSERT controller_worker failed : ' . $e->getMessage(), ['workerId' => $workerId, 'controller_id' => $array['controller_id']], 'warning');
     }
 
     // Add powers to worker
@@ -659,7 +652,7 @@ function createWorker($pdo, $array) {
     if (!empty($array['discipline']) && $array['discipline'] != "\'\'" ) $link_power_type_id_array[] = $array['discipline'];
     if (!empty($array['transformation']) && $array['transformation'] != "\'\'" ) $link_power_type_id_array[] = $array['transformation'];
     foreach($link_power_type_id_array as $link_power_type_id ) {
-        if ($debug) echo sprintf("%s() => add to worker : %s, link_power_type_id: %s <br>",  __FUNCTION__, $workerId, var_export($link_power_type_id, true));
+        game_error_log(__FUNCTION__, 'add to worker', ['workerId' => $workerId, 'link_power_type_id' => $link_power_type_id], 'debug');
         upgradeWorker($pdo, $workerId, $link_power_type_id, true);
     }
 
@@ -671,7 +664,7 @@ function createWorker($pdo, $array) {
             ':controller_id' => $array['controller_id']
         ]);
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): UPDATE controllers SET recruited_workers  Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'UPDATE controllers.recruited_workers failed : ' . $e->getMessage(), ['controller_id' => $array['controller_id']], 'warning');
     }
 
     return $workerId;
@@ -681,14 +674,16 @@ function createWorker($pdo, $array) {
  * Function to update Worker with a power
  *
  * @param PDO $pdo : database connection
- * @param int $workerId
- * @param int $link_power_type_id
- * @param bool $isRecrutment
+ * @param int $workerId : id of the worker receiving the power
+ * @param int $link_power_type_id : id of the link_power_type row to bind
+ * @param bool $isRecrutment : true when called during recruitment (applies on_recrutment effects)
  *
- * @return bool success
+ * @return bool : true on success, false on INSERT / SELECT failure
  */
-function upgradeWorker($pdo, $workerId, $link_power_type_id, $isRecrutment = false){
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function upgradeWorker(PDO $pdo, int $workerId, int $link_power_type_id, bool $isRecrutment = false): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true') $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with workerId : ' . $workerId, ['link_power_type_id' => $link_power_type_id, 'isRecrutment' => $isRecrutment], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     try{
@@ -698,7 +693,7 @@ function upgradeWorker($pdo, $workerId, $link_power_type_id, $isRecrutment = fal
         $stmt->bindParam(':worker_id', $workerId, PDO::PARAM_INT);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): INSERT worker_powers Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'INSERT worker_powers failed : ' . $e->getMessage(), ['workerId' => $workerId, 'link_power_type_id' => $link_power_type_id], 'error');
         return false;
     }
 
@@ -714,11 +709,11 @@ function upgradeWorker($pdo, $workerId, $link_power_type_id, $isRecrutment = fal
         $stmt = $pdo->prepare($sql);
         $stmt->execute([':link_power_type_id' => $link_power_type_id]);
         $power = $stmt->fetch(PDO::FETCH_ASSOC);
-        if ($debug) echo sprintf("%s() => power other ? %s ",  __FUNCTION__, var_export($power, true));
+        game_error_log(__FUNCTION__, 'power other fetched', ['power' => $power], 'debug');
 
         if (!empty($power['other'])) {
             $otherJson = json_decode($power['other'], true);
-            if ($debug) echo __FUNCTION__ . "(): otherJson: " . var_export($otherJson, true) . "<br />";
+            game_error_log(__FUNCTION__, 'otherJson decoded', ['otherJson' => $otherJson], 'debug');
 
             if (json_last_error() === JSON_ERROR_NONE && is_array($otherJson)) {
                 // Apply effect if found
@@ -726,7 +721,7 @@ function upgradeWorker($pdo, $workerId, $link_power_type_id, $isRecrutment = fal
             }
         }
     } catch (PDOException $e) {
-        echo __FUNCTION__ . "(): Failed to fetch power effect: " . $e->getMessage() . "<br />";
+        game_error_log(__FUNCTION__, 'SELECT power effect failed : ' . $e->getMessage(), ['link_power_type_id' => $link_power_type_id], 'error');
         return false;
     }
 
@@ -734,22 +729,25 @@ function upgradeWorker($pdo, $workerId, $link_power_type_id, $isRecrutment = fal
 }
 
 /**
+ * Apply the on_recrutment / on_gain side-effects encoded in a power's `other` JSON.
  *
  * @param PDO $pdo : database connection
- * @param int $workerId
- * @param array $otherJson
- * @param bool $isRecrutment
+ * @param int $workerId : worker receiving the effect
+ * @param array $otherJson : decoded power.other JSON
+ * @param bool $isRecrutment : true when triggered during recruitment
  *
- * @return bool success
+ * @return bool : always true (soft-failure path logs and continues)
  */
-function applyPowerObtentionEffect($pdo, $workerId, $otherJson, $isRecrutment = false) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function applyPowerObtentionEffect(PDO $pdo, int $workerId, array $otherJson, bool $isRecrutment = false): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true') $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with workerId : ' . $workerId, ['otherJson' => $otherJson, 'isRecrutment' => $isRecrutment], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     // If it is a recrutment effect
     if ($isRecrutment && !empty($otherJson['on_recrutment']) && is_array($otherJson['on_recrutment']) ){
         foreach ($otherJson['on_recrutment'] AS $key => $element ){
-            if ($debug) echo sprintf( "%s():key : %s, element: %s<br />",__FUNCTION__, $key, var_export($element, true));
+            game_error_log(__FUNCTION__, 'on_recrutment iteration', ['key' => $key, 'element' => $element], 'debug');
             // If it is an action and we have a type
             if (
                 $key == 'action'
@@ -766,17 +764,17 @@ function applyPowerObtentionEffect($pdo, $workerId, $otherJson, $isRecrutment = 
                         $stmtExists = $pdo->prepare($sqlExists);
                         $stmtExists->execute([':lastname' => $element['controller_lastname'], ':worker_id' => $workerId]);
                         if ($stmtExists->fetchColumn() !== false) {
-                            if ($debug) echo __FUNCTION__ . "(): go_traitor skipped — target controller already linked to worker.<br />";
+                            game_error_log(__FUNCTION__, 'go_traitor skipped — target controller already linked to worker', ['workerId' => $workerId, 'controller_lastname' => $element['controller_lastname']], 'debug');
                         } else {
                             // Add non primary controller for the worker
                             $sql = "INSERT INTO {$prefix}controller_worker (controller_id, worker_id, is_primary_controller)
                                     VALUES ( (SELECT id FROM {$prefix}controllers WHERE lastname = :lastname), :worker_id, False)";
-                            if ($debug) echo __FUNCTION__ . "(): sql: " . var_export($sql, true) . "<br />";
+                            game_error_log(__FUNCTION__, 'go_traitor INSERT prepared', ['sql' => $sql], 'debug');
                             $stmt = $pdo->prepare($sql);
                             $stmt->execute([':lastname' => $element['controller_lastname'], ':worker_id' => $workerId]);
                         }
                     } catch (PDOException $e) {
-                        echo __FUNCTION__."(): go_traitor => INSERT controller_worker Failed: " . $e->getMessage()."<br />";
+                        game_error_log(__FUNCTION__, 'go_traitor INSERT controller_worker failed : ' . $e->getMessage(), ['workerId' => $workerId, 'controller_lastname' => $element['controller_lastname']], 'warning');
                     }
                 }
                 if ( $element['type'] == 'add_opposition' ){
@@ -797,13 +795,17 @@ function applyPowerObtentionEffect($pdo, $workerId, $otherJson, $isRecrutment = 
  * Function add Action to Worker_action table for worker
  *
  * @param PDO $pdo : database connection
- * @param int $workerId
- * @param int $controllerId
- * @param int $zoneId
+ * @param int $workerId : id of the worker
+ * @param int $controllerId : controller owning the action
+ * @param int $zoneId : zone the action happens in
+ * @param array|null $reportArray : optional report chunks to seed the row
  *
- * @return int|null lastInsertId
+ * @return string|false|null : lastInsertId (string on success, false when no sequence), or null on INSERT failure
  */
-function addWorkerAction($pdo, $workerId, $controllerId, $zoneId, $reportArray = null){
+function addWorkerAction(PDO $pdo, int $workerId, int $controllerId, int $zoneId, array|null $reportArray = null): string|false|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with workerId : ' . $workerId, ['controllerId' => $controllerId, 'zoneId' => $zoneId, 'reportArray' => $reportArray], 'debug');
+
     // Get turn nubmer
     $mechanics = getMechanics($pdo);
     $prefix = $_SESSION['GAME_PREFIX'];
@@ -817,7 +819,7 @@ function addWorkerAction($pdo, $workerId, $controllerId, $zoneId, $reportArray =
         // Encode the report
         $reportJson = json_encode($reportArray);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            echo "JSON encoding error: " . json_last_error_msg() . "<br />";
+            game_error_log(__FUNCTION__, 'JSON encoding error : ' . json_last_error_msg(), ['reportArray' => $reportArray], 'warning');
         }else{
             $sql = "INSERT
                 INTO {$prefix}worker_actions (worker_id, turn_number, zone_id, controller_id, report)
@@ -826,7 +828,7 @@ function addWorkerAction($pdo, $workerId, $controllerId, $zoneId, $reportArray =
         }
     }
 
-    if (!empty($_SESSION['debug'])) echo __METHOD__."() : insertsqL $sql <br/>";
+    game_error_log(__FUNCTION__, 'insert sql prepared', ['sql' => $sql], 'debug');
 
     try{
         // Insert new controller_worker value into the database
@@ -838,7 +840,7 @@ function addWorkerAction($pdo, $workerId, $controllerId, $zoneId, $reportArray =
         if (!empty($hasReport)) $stmt->bindParam(':report', $reportJson);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): INSERT controller_worker Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'INSERT worker_actions failed : ' . $e->getMessage(), ['sql' => $sql, 'workerId' => $workerId], 'error');
         return null;
     }
     // Get the last inserted ID
@@ -849,11 +851,14 @@ function addWorkerAction($pdo, $workerId, $controllerId, $zoneId, $reportArray =
  * Function to count disciplines of worker
  *
  * @param PDO $pdo : database connection
- * @param array $workerIds
+ * @param array|null $workerIds : optional worker id filter; NULL counts across all workers
  *
- * @return array {int worker_id, int discipline_count}
+ * @return array : rows of {worker_id, discipline_count}, empty on SQL error
  */
-function countWorkerDisciplines($pdo, $workerIds = NULL) {
+function countWorkerDisciplines(PDO $pdo, array|null $workerIds = NULL): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['workerIds' => $workerIds], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
         $sql = sprintf("SELECT
@@ -878,24 +883,26 @@ function countWorkerDisciplines($pdo, $workerIds = NULL) {
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo __FUNCTION__." (): Error counting worker disciplines: " . $e->getMessage();
+        game_error_log(__FUNCTION__, 'Error counting worker disciplines : ' . $e->getMessage(), ['workerIds' => $workerIds], 'error');
         return [];
     }
 }
 
 /**
- * Function to assing worker to new zone
+ * Function to assign worker to new zone
  *
  * @param PDO $pdo : database connection
- * @param int $workerId
- * @param int $zoneId
+ * @param int $workerId : id of the worker being moved
+ * @param int $zoneId : destination zone id
  *
- * @return int|null :
+ * @return int|null : $workerId on success, null when the first UPDATE fails
  */
-function moveWorker($pdo, $workerId, $zoneId) {
-    $debug = $_SESSION['DEBUG'];
+function moveWorker(PDO $pdo, int $workerId, int $zoneId): int|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with workerId : ' . $workerId, ['zoneId' => $zoneId], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
-    if ($debug) echo __FUNCTION__."(): Step 1 UPDATE workers <br/>";
+    game_error_log(__FUNCTION__, 'Step 1 UPDATE workers', [], 'debug');
     try{
         // UPDATE workers value
         $stmt = $pdo->prepare("UPDATE {$prefix}workers SET zone_id = :zone_id WHERE id = :id ");
@@ -903,11 +910,11 @@ function moveWorker($pdo, $workerId, $zoneId) {
         $stmt->bindParam(':zone_id', $zoneId, PDO::PARAM_INT);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): UPDATE workers Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'UPDATE workers failed : ' . $e->getMessage(), ['workerId' => $workerId, 'zoneId' => $zoneId], 'error');
         return null;
     }
 
-    if ($debug) echo __FUNCTION__."(): Step 2 UPDATE worker_actions <br/>";
+    game_error_log(__FUNCTION__, 'Step 2 UPDATE worker_actions', [], 'debug');
     $actions = getWorkerActions($pdo, $workerId);
 
     $mechanics = getMechanics($pdo);
@@ -921,22 +928,26 @@ function moveWorker($pdo, $workerId, $zoneId) {
         $stmt->bindParam(':id', $actions[0]['id'], PDO::PARAM_INT);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): UPDATE workers Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'UPDATE worker_actions failed : ' . $e->getMessage(), ['workerId' => $workerId, 'zoneId' => $zoneId], 'warning');
     }
-    if ($debug) echo __FUNCTION__."(): DONE <br/>"; 
+    game_error_log(__FUNCTION__, 'DONE with workerId : ' . $workerId, [], 'debug');
 
     return $workerId;
 }
 
 /**
  * get worker action status for turn
- * 
+ *
  * @param PDO $pdo : database connection
- * @param int $workerId
- * @param int|null $turn_number
- * 
+ * @param int $workerId : id of the worker
+ * @param int|null $turn_number : turn to fetch, or NULL to use mechanics.turncounter
+ *
+ * @return array|null : worker_actions rows for the turn, or NULL on SQL error
  */
-function getWorkerActions($pdo, $workerId, $turn_number = null ){
+function getWorkerActions(PDO $pdo, int $workerId, int|null $turn_number = null): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with workerId : ' . $workerId, ['turn_number' => $turn_number], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
 
     if (empty($turn_number)) {
@@ -949,33 +960,35 @@ function getWorkerActions($pdo, $workerId, $turn_number = null ){
         AND turn_number = $turn_number
         ORDER BY id DESC
     ";
-    if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): sql: ".var_export($sql, true)."<br/><br/>";
+    game_error_log(__FUNCTION__, 'sql prepared', ['sql' => $sql], 'debug');
 
     try {
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT worker_actions failed : ' . $e->getMessage(), ['sql' => $sql], 'error');
         return NULL;
     }
     // Fetch the results
     $workerActions = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): workerActions: ".var_export($workerActions, true)."<br/><br/>";
+    game_error_log(__FUNCTION__, 'DONE', ['workerActions' => $workerActions], 'debug');
     return $workerActions;
 }
 
 /**
- * Activates workers depending opn give action
- * 
+ * Activates workers depending on given action
+ *
  * @param PDO $pdo : database connection
- * @param int $workerId
- * @param string $action
- * @param int|array|null $extraVal
- * 
- * @return int $workerId
+ * @param int $workerId : id of the worker being activated
+ * @param string $action : action key (attack / claim / gift / recallDoubleAgent / returnPrisoner / hide / passive / investigate)
+ * @param int|array|null $extraVal : per-action payload (worker id list, controller id, or associative array)
+ *
+ * @return int : $workerId (returned even on soft-failure paths)
  */
-function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
+function activateWorker(PDO $pdo, int $workerId, string $action, int|array|null $extraVal = NULL): int {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with workerId : ' . $workerId, ['action' => $action, 'extraVal' => $extraVal], 'debug');
 
     $mechanics = getMechanics($pdo);
     $turn_number = $mechanics['turncounter'];
@@ -983,7 +996,7 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
 
     // get worker action status for turn
     $worker_actions = getWorkerActions($pdo, $workerId);
-    if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): worker_action: ".var_export($worker_actions, true)."<br/><br/>";
+    game_error_log(__FUNCTION__, 'worker_action fetched', ['worker_actions' => $worker_actions], 'debug');
     $currentAction = $worker_actions[0];
 
     // Decode the existing JSON into an associative array
@@ -991,18 +1004,16 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
     if (!empty($currentAction['report'])) {
         $currentReport = json_decode($currentAction['report'], true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            echo __FUNCTION__."():JSON decoding error: " . json_last_error_msg() . "<br />";
+            game_error_log(__FUNCTION__, 'JSON decoding error : ' . json_last_error_msg(), ['report' => $currentAction['report']], 'warning');
         }
     }
     $sql_worker_actions = "UPDATE {$prefix}worker_actions SET ";
-    if ($_SESSION['DEBUG'] == true) echo sprintf("%s(): activate : %s <br/>", __FUNCTION__, $action);
+    game_error_log(__FUNCTION__, 'activate action : ' . $action, [], 'debug');
     $new_action = $action;
     $jsonOutput = '{}';
     switch($action) {
         case 'attack' :
-            if ($_SESSION['DEBUG_ATTACK'] == true){
-                echo sprintf("%s(): attack %s <br/><br/>",__FUNCTION__, var_export($extraVal,true)) ;
-            }
+            game_error_log(__FUNCTION__, 'attack', ['extraVal' => $extraVal], 'debug');
             // Build attack JSON
             $chosenAttackOptions = array();
             foreach ($extraVal as $val){
@@ -1025,14 +1036,14 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
             $jsonOutput = json_encode($chosenAttackOptions);
             break;
         case 'claim' :
-            if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): claim <br/><br/>";
+            game_error_log(__FUNCTION__, 'claim', ['extraVal' => $extraVal], 'debug');
             // Create JSON table
             $jsonOutput = json_encode([
                 'claim_controller_id' => $extraVal
             ]);
             break;
         case 'gift' :
-            if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): gift <br/><br/>";
+            game_error_log(__FUNCTION__, 'gift', ['extraVal' => $extraVal], 'debug');
 
             // get new controller name
             $newControllerName = getControllerName($pdo, $extraVal);
@@ -1043,11 +1054,11 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
 
             // Create Trace
             if (createTraceWorker($pdo, $workerId, $currentAction['controller_id']) === false) {
-                echo __FUNCTION__." (): Failed to create trace worker ! <br />";
+                game_error_log(__FUNCTION__, 'Failed to create trace worker', ['workerId' => $workerId, 'controller_id' => $currentAction['controller_id']], 'warning');
             }
             // Check for existing trace
             if (destroyTraceWorker($pdo, $workerId, $extraVal) === false) {
-                echo __FUNCTION__." (): Failed to destroy trace worker ! <br />";
+                game_error_log(__FUNCTION__, 'Failed to destroy trace worker', ['workerId' => $workerId, 'extraVal' => $extraVal], 'warning');
             }
 
             // Check that the entry controller_id:extraVal and worker_id:workerId is not already in the controller_worker table and delete it if it is
@@ -1059,7 +1070,7 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
                     ':worker_id' => $workerId
                 ]);
             } catch (PDOException $e) {
-               // echo __FUNCTION__." (): Failed to delete entry from controller_worker table: " . $e->getMessage() . "<br />";
+                game_error_log(__FUNCTION__, 'DELETE controller_worker failed : ' . $e->getMessage(), ['workerId' => $workerId, 'extraVal' => $extraVal], 'warning');
             }
             // Set controller_worker controller_id and set worker_actions controller_id where turn_numer = current_turn to $extraVal
             try {
@@ -1080,15 +1091,15 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
                     ':turn_number' => $turn_number
                 ]);
             } catch (PDOException $e) {
-                echo __FUNCTION__." (): Failed to update tables: " . $e->getMessage() . "<br />";
+                game_error_log(__FUNCTION__, 'gift UPDATE tables failed : ' . $e->getMessage(), ['workerId' => $workerId, 'extraVal' => $extraVal], 'error');
             }
             return $workerId;
             break;
         case 'recallDoubleAgent' :
-            if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): recallDoubleAgent <br/><br/>";
+            game_error_log(__FUNCTION__, 'recallDoubleAgent', ['extraVal' => $extraVal], 'debug');
 
             if (!createTraceWorker($pdo, $workerId, $currentAction['controller_id'])) {
-                echo __FUNCTION__." (): Failed to create trace worker ! <br />";
+                game_error_log(__FUNCTION__, 'Failed to create trace worker', ['workerId' => $workerId, 'controller_id' => $currentAction['controller_id']], 'warning');
             }
 
             try {
@@ -1129,12 +1140,12 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
                     ':turn_number' => $turn_number
                 ]);
             } catch (PDOException $e) {
-                echo __FUNCTION__." (): Failed to update tables: " . $e->getMessage() . "<br />";
+                game_error_log(__FUNCTION__, 'recallDoubleAgent UPDATE tables failed : ' . $e->getMessage(), ['workerId' => $workerId, 'extraVal' => $extraVal], 'error');
             }
 
             break;
         case 'returnPrisoner' :
-            if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): returnPrisoner <br/><br/>";
+            game_error_log(__FUNCTION__, 'returnPrisoner', ['extraVal' => $extraVal], 'debug');
             if (empty($currentReport['life_report'])) $currentReport['life_report'] ='';
             $currentReport['life_report'] .= sprintf(
                 "J'ai été <strong>relâché</strong> par le <strong>réseau %s</strong> vers %s %s.<br />",
@@ -1144,10 +1155,10 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
             );
 
             if (createTraceWorker($pdo, $workerId, $extraVal['recall_controller_id']) === false) {
-                echo __FUNCTION__." (): Failed to create trace worker ! <br />";
+                game_error_log(__FUNCTION__, 'Failed to create trace worker', ['workerId' => $workerId, 'recall_controller_id' => $extraVal['recall_controller_id']], 'warning');
             }
             if (destroyTraceWorker($pdo, $workerId, $extraVal['return_controller_id']) === false) {
-                echo __FUNCTION__." (): Failed to destroy trace worker ! <br />";
+                game_error_log(__FUNCTION__, 'Failed to destroy trace worker', ['workerId' => $workerId, 'return_controller_id' => $extraVal['return_controller_id']], 'warning');
             }
             try {
                 // Update the controller_worker table
@@ -1172,12 +1183,12 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
                     ':turn_number' => $turn_number
                 ]);
             } catch (PDOException $e) {
-                echo __FUNCTION__." (): Failed to update tables: " . $e->getMessage() . "<br />";
+                game_error_log(__FUNCTION__, 'returnPrisoner UPDATE tables failed : ' . $e->getMessage(), ['workerId' => $workerId, 'extraVal' => $extraVal], 'error');
             }
             if ( !empty($extraVal['double_controller_id']) ) {
-                // Clean the secondary controllers' capture-trace 
+                // Clean the secondary controllers' capture-trace
                 if (destroyTraceWorker($pdo, $workerId, $extraVal['double_controller_id']) === false) {
-                    echo __FUNCTION__." (): Failed to destroy secondary capture-trace ! <br />";
+                    game_error_log(__FUNCTION__, 'Failed to destroy secondary capture-trace', ['workerId' => $workerId, 'double_controller_id' => $extraVal['double_controller_id']], 'warning');
                 }
                 try {
                     // Add non primary controller for the worker
@@ -1186,7 +1197,7 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
                     $stmt = $pdo->prepare($sql);
                     $stmt->execute([':extraVal' => $extraVal['double_controller_id'], ':worker_id' => $workerId]);
                 } catch (PDOException $e) {
-                    echo __FUNCTION__."(): returnPrisoner and go_traitor => INSERT controller_worker Failed: " . $e->getMessage()."<br />";
+                    game_error_log(__FUNCTION__, 'returnPrisoner + go_traitor INSERT controller_worker failed : ' . $e->getMessage(), ['workerId' => $workerId, 'double_controller_id' => $extraVal['double_controller_id']], 'warning');
                 }
             }
 
@@ -1200,10 +1211,12 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
     $updatedReportJson = json_encode($currentReport);
     if (json_last_error() === JSON_ERROR_NONE) {
         $sql_worker_actions .= ", report = :report ";
-    } else { echo "JSON encoding error: " . json_last_error_msg() . "<br />"; }
+    } else {
+        game_error_log(__FUNCTION__, 'JSON encoding error : ' . json_last_error_msg(), ['currentReport' => $currentReport], 'warning');
+    }
     try{
         $sql_worker_actions .= " WHERE id = :id AND turn_number = :turn_number ";
-        if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): sql_worker_actions : ".var_export($sql_worker_actions, true)." <br/><br/>";
+        game_error_log(__FUNCTION__, 'final sql_worker_actions prepared', ['sql_worker_actions' => $sql_worker_actions], 'debug');
         // Insert new workers value into the database
         $stmt = $pdo->prepare($sql_worker_actions);
         $stmt->bindParam(':id', $worker_actions[0]['id'], PDO::PARAM_INT);
@@ -1211,34 +1224,30 @@ function activateWorker($pdo, $workerId, $action, $extraVal = NULL) {
         $stmt->bindParam(':report', $updatedReportJson, PDO::PARAM_STR);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): UPDATE workers Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'UPDATE worker_actions failed : ' . $e->getMessage(), ['sql_worker_actions' => $sql_worker_actions, 'workerId' => $workerId], 'error');
     }
     return $workerId;
 }
 
 /**
- * Get the know enemy workers for the controller and the zone
- * 
+ * Get the known enemy workers for the controller and the zone
+ *
  * @param PDO $pdo : database connection
- * @param int $zone_id
- * @param int|null $controller_id
- * 
- * @return array (
- *   -'workers_without_controller'
- *   -'workers_with_controller'
- * 
+ * @param int $zone_id : zone to scope the CKE lookup to
+ * @param int|null $controller_id : optional controller filter (NULL = across all controllers)
+ *
+ * @return array : ['workers_without_controller' => [...], 'workers_with_controller' => [...]], empty on SQL error
  */
-function getEnemyWorkers($pdo, $zone_id, $controller_id = NULL) {
+function getEnemyWorkers(PDO $pdo, int $zone_id, int|null $controller_id = NULL): array {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with zone_id : ' . $zone_id, ['controller_id' => $controller_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     // Select from controllers_known_enemies by $zone_id, $controller_id
         // return table of :
         // A worker discovered_worker_id with no discovered_controller_id
         // B workers discovered_worker_id with identical discovered_controller_id
             // Optional discovered_controller_name if is associated to a
-    if ($_SESSION['DEBUG_ATTACK'] == true) {
-        echo sprintf("zone_id: %s <br/> " , var_export($zone_id, true));
-        echo sprintf("controller_id: %s <br/> " , var_export($controller_id, true));
-    }
     try {
         // Query for workers with no discovered_controller_id (A)
         $sqlA = sprintf("
@@ -1299,7 +1308,7 @@ function getEnemyWorkers($pdo, $zone_id, $controller_id = NULL) {
         ];
 
     } catch (PDOException $e) {
-        echo __FUNCTION__." (): Error fetching enemy workers: " . $e->getMessage();
+        game_error_log(__FUNCTION__, 'Error fetching enemy workers : ' . $e->getMessage(), ['zone_id' => $zone_id, 'controller_id' => $controller_id], 'error');
         return [];
     }
 }
@@ -1307,15 +1316,15 @@ function getEnemyWorkers($pdo, $zone_id, $controller_id = NULL) {
 /**
  * Structured enemy listing for a zone — shared by attack select + zone box.
  *
- * @param PDO $pdo
- * @param int $zone_id
- * @param int $controller_id
- * @param int|null $turn_number  default mechanics.turncounter
- * @param int|null $window       default getConfig('attackTimeWindow'); falls back to $turn_number when empty
+ * @param PDO $pdo : database connection
+ * @param int $zone_id : zone to scope the listing to
+ * @param int $controller_id : viewing controller
+ * @param int|null $turn_number : reference turn; defaults to mechanics.turncounter
+ * @param int|null $window : recency window in turns; defaults to attackTimeWindow config, then $turn_number
  *
- * @return array shape: recent/older → ['unaffiliated' => [...rows], 'networks' => [<cid> => ['name', 'workers' => [...rows]]]]
+ * @return array : shape recent/older → ['unaffiliated' => [...rows], 'networks' => [<cid> => ['name', 'workers' => [...rows]]]]
  */
-function buildEnemyWorkerListing($pdo, $zone_id, $controller_id, $turn_number = null, $window = null) {
+function buildEnemyWorkerListing(PDO $pdo, int $zone_id, int $controller_id, int|null $turn_number = null, int|null $window = null): array {
     if (empty($turn_number)) {
         $mechanics = getMechanics($pdo);
         $turn_number = $mechanics['turncounter'];
@@ -1357,26 +1366,25 @@ function buildEnemyWorkerListing($pdo, $zone_id, $controller_id, $turn_number = 
  * Build the HTML select for the known enemy workers for the controller in the zone
  *
  * @param PDO $pdo : database connection
- * @param int $zone_id
- * @param int $controller_id
- * @param int|null $turn_number
+ * @param int $zone_id : zone the listing is scoped to
+ * @param int $controller_id : viewing controller
+ * @param int|null $turn_number : reference turn; defaults to mechanics.turncounter
  *
- * @return string
+ * @return string : rendered HTML <select> block, or '' when the listing is empty
  */
-function showEnemyWorkersSelect($pdo, $zone_id, $controller_id, $turn_number = NULL) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function showEnemyWorkersSelect(PDO $pdo, int $zone_id, int $controller_id, int|null $turn_number = NULL): string {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true') $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with zone_id : ' . $zone_id, ['controller_id' => $controller_id, 'turn_number' => $turn_number], 'debug');
 
     if (empty($turn_number)) {
         $mechanics = getMechanics($pdo);
         $turn_number = $mechanics['turncounter'];
     }
-    if ($debug) echo "turn_number : $turn_number <br>";
+    game_error_log(__FUNCTION__, 'turn_number resolved : ' . $turn_number, [], 'debug');
 
     $listing = buildEnemyWorkerListing($pdo, $zone_id, $controller_id, $turn_number);
 
-    if ($_SESSION['DEBUG_ATTACK']) {
-        echo sprintf("listing: %s <br/> ", var_export($listing, true));
-    }
+    game_error_log(__FUNCTION__, 'listing built', ['listing' => $listing], 'debug');
 
     $recent = $listing['recent'];
     $older  = $listing['older'];
@@ -1417,7 +1425,7 @@ function showEnemyWorkersSelect($pdo, $zone_id, $controller_id, $turn_number = N
         ",
         $enemyWorkerOptions
     );
-    if ($_SESSION['DEBUG'] == true) echo __FUNCTION__."(): enemyWorkersSelect: ".var_export($enemyWorkersSelect, true)."<br /><br />";
+    game_error_log(__FUNCTION__, 'DONE', ['enemyWorkersSelect' => $enemyWorkersSelect], 'debug');
 
     return $enemyWorkersSelect;
 }
@@ -1426,44 +1434,43 @@ function showEnemyWorkersSelect($pdo, $zone_id, $controller_id, $turn_number = N
  * Create a copy of the worker and worker_actions tables to the active controller as primary controller
  *  the new worker should be alive and active and the new worker_actions should be empty
  *  if the active controller has a previous copy of the woker it must be destroyed first
- * 
- * @param PDO $pdo : database connection
- * @param int $worker_id
- * @param int $controller_id
- * 
- * @return $new_worker_id
  *
- */ 
-function createTraceWorker($pdo, $worker_id, $controller_id) {
+ * @param PDO $pdo : database connection
+ * @param int $worker_id : source worker to trace-clone
+ * @param int $controller_id : controller receiving the trace worker as primary
+ *
+ * @return string|false : lastInsertId of the new trace worker, or false on transaction rollback
+ */
+function createTraceWorker(PDO $pdo, int $worker_id, int $controller_id): string|false {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true') $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with worker_id : ' . $worker_id, ['controller_id' => $controller_id], 'debug');
 
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
     $prefix = $_SESSION['GAME_PREFIX'];
 
-    if ($debug) echo __FUNCTION__."(): createTraceWorker <br/><br/>";
     try {
         // Begin transaction
         $pdo->beginTransaction();
 
         // Step 1 : Copy the worker table except id
         $query = "
-            INSERT INTO {$prefix}workers (firstname, lastname, origin_id, zone_id) 
+            INSERT INTO {$prefix}workers (firstname, lastname, origin_id, zone_id)
             SELECT firstname, lastname, origin_id, zone_id
             FROM {$prefix}workers WHERE id = :worker_id
         ";
-        if ($debug) echo sprintf("%s(): Step 1 : %s <br/><br/>",  __FUNCTION__, $query);
+        game_error_log(__FUNCTION__, 'Step 1 prepared', ['query' => $query], 'debug');
         $stmt = $pdo->prepare($query);
         $stmt->bindValue(':worker_id', $worker_id, PDO::PARAM_INT);
         $stmt->execute();
         $new_worker_id = $pdo->lastInsertId();
-        if ($debug) echo sprintf("%s(): Step 1 : new_worker_id = %s <br/><br/>",  __FUNCTION__, $new_worker_id);
+        game_error_log(__FUNCTION__, 'Step 1 new_worker_id : ' . $new_worker_id, [], 'debug');
 
         // Step 2 : Copy the worker_actions table except id, worker_id = new worker_id and action_choice = 'trace'
         $query = "
             INSERT INTO {$prefix}worker_actions (worker_id, turn_number, zone_id, controller_id, enquete_val, attack_val, defence_val, action_choice, action_params, report)
-            SELECT :new_worker_id, turn_number, zone_id, controller_id, enquete_val, attack_val, defence_val, 'trace', action_params, report 
+            SELECT :new_worker_id, turn_number, zone_id, controller_id, enquete_val, attack_val, defence_val, 'trace', action_params, report
             FROM {$prefix}worker_actions WHERE worker_id = :worker_id
         ";
-        if ($debug) echo sprintf("%s(): Step 2 : %s <br/><br/>",  __FUNCTION__, $query);
+        game_error_log(__FUNCTION__, 'Step 2 prepared', ['query' => $query], 'debug');
         $stmt = $pdo->prepare($query);
         $stmt->bindParam(':new_worker_id', $new_worker_id, PDO::PARAM_INT);
         $stmt->bindParam(':worker_id', $worker_id, PDO::PARAM_INT);
@@ -1475,7 +1482,7 @@ function createTraceWorker($pdo, $worker_id, $controller_id) {
             SELECT :new_worker_id, link_power_type_id
             FROM {$prefix}worker_powers WHERE worker_id = :worker_id
         ";
-        if ($debug) echo sprintf("%s(): Step 3 : %s <br/><br/>",  __FUNCTION__, $query);
+        game_error_log(__FUNCTION__, 'Step 3 prepared', ['query' => $query], 'debug');
         $stmt = $pdo->prepare($query);
         $stmt->bindParam(':new_worker_id', $new_worker_id, PDO::PARAM_INT);
         $stmt->bindParam(':worker_id', $worker_id, PDO::PARAM_INT);
@@ -1486,7 +1493,7 @@ function createTraceWorker($pdo, $worker_id, $controller_id) {
             INSERT INTO {$prefix}controller_worker (controller_id, worker_id, is_primary_controller)
             SELECT :controller_id, :new_worker_id, true
         ";
-        if ($debug) echo sprintf("%s(): Step 4 : %s <br/><br/>",  __FUNCTION__, $query);
+        game_error_log(__FUNCTION__, 'Step 4 prepared', ['query' => $query], 'debug');
         $stmt = $pdo->prepare($query);
         $stmt->bindParam(':controller_id', $controller_id, PDO::PARAM_INT);
         $stmt->bindParam(':new_worker_id', $new_worker_id, PDO::PARAM_INT);
@@ -1497,7 +1504,7 @@ function createTraceWorker($pdo, $worker_id, $controller_id) {
             INSERT INTO {$prefix}workers_trace_links (primary_worker_id, trace_worker_id, controller_id)
             SELECT  :worker_id, :new_worker_id, :controller_id
         ";
-        if ($debug) echo sprintf("%s(): Step 5 : %s <br/><br/>",  __FUNCTION__, $query);
+        game_error_log(__FUNCTION__, 'Step 5 prepared', ['query' => $query], 'debug');
         $stmt = $pdo->prepare($query);
         $stmt->bindParam(':worker_id', $worker_id, PDO::PARAM_INT);
         $stmt->bindParam(':new_worker_id', $new_worker_id, PDO::PARAM_INT);
@@ -1511,8 +1518,7 @@ function createTraceWorker($pdo, $worker_id, $controller_id) {
         if ($pdo->inTransaction()) {
             $pdo->rollBack();
         }
-        echo __FUNCTION__." (): Error creating trace worker: " . $e->getMessage();
-        echo  __FUNCTION__."(): Transaction failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'Transaction failed : ' . $e->getMessage(), ['worker_id' => $worker_id, 'controller_id' => $controller_id], 'error');
         return false;
     }
     return $new_worker_id;
@@ -1522,40 +1528,38 @@ function createTraceWorker($pdo, $worker_id, $controller_id) {
 /**
  * Destroy the trace of the worker, the worker_actions tables, the links to the controller as primary controller
  *  the worker links to his powers
- * 
- * @param PDO $pdo : database connection
- * @param int $worker_id
- * @param int $controller_id
- * 
- * @return $success
  *
- */ 
-function destroyTraceWorker($pdo, $worker_id, $controller_id) {
+ * @param PDO $pdo : database connection
+ * @param int $worker_id : primary worker whose trace clone is destroyed
+ * @param int $controller_id : controller that held the trace
+ *
+ * @return bool : true on success (including nothing-to-do), false on transaction rollback
+ */
+function destroyTraceWorker(PDO $pdo, int $worker_id, int $controller_id): bool {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true') $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with worker_id : ' . $worker_id, ['controller_id' => $controller_id], 'debug');
 
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
     $prefix = $_SESSION['GAME_PREFIX'];
-
-    if ($debug) echo __FUNCTION__."(): destroyTraceWorker <br/><br/>";
 
     // Step 1 : find the trace_worker_id in the workers_trace_links table
     $query = "
         SELECT trace_worker_id FROM {$prefix}workers_trace_links WHERE primary_worker_id = :worker_id AND controller_id = :controller_id
     ";
-    if ($debug) echo sprintf("%s(): Step 1 : %s <br/><br/>",  __FUNCTION__, $query);
+    game_error_log(__FUNCTION__, 'Step 1 prepared', ['query' => $query], 'debug');
     $stmt = $pdo->prepare($query);
     $stmt->bindParam(':worker_id', $worker_id, PDO::PARAM_INT);
     $stmt->bindParam(':controller_id', $controller_id, PDO::PARAM_INT);
     $stmt->execute();
     $traceWorkers = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    if ($debug) echo sprintf("%s(): Step 1 : traceWorkers: %s <br/><br/>",  __FUNCTION__, var_export($traceWorkers, true));
-    if (empty($traceWorkers) && $debug == true ) {
-        echo __FUNCTION__." (): No trace worker found for the primary worker_id: " . $worker_id . " and controller_id: " . $controller_id . "<br />";
+    game_error_log(__FUNCTION__, 'Step 1 traceWorkers fetched', ['traceWorkers' => $traceWorkers], 'debug');
+    if (empty($traceWorkers)) {
+        game_error_log(__FUNCTION__, 'No trace worker found for primary worker_id : ' . $worker_id, ['controller_id' => $controller_id], 'debug');
     }
     if  ($traceWorkers !== false && !empty($traceWorkers)) {
         foreach ($traceWorkers as $traceWorker) {
             try {
                 $trace_worker_id = $traceWorker['trace_worker_id'];
-                if ($debug) echo sprintf("%s(): Step 2 : trace_worker_id: %s <br/><br/>",  __FUNCTION__, $trace_worker_id);
+                game_error_log(__FUNCTION__, 'Step 2 trace_worker_id : ' . $trace_worker_id, [], 'debug');
                 // Begin transaction
                 $pdo->beginTransaction();
 
@@ -1621,8 +1625,7 @@ function destroyTraceWorker($pdo, $worker_id, $controller_id) {
                 if ($pdo->inTransaction()) {
                     $pdo->rollBack();
                 }
-                echo __FUNCTION__." (): Error destroying trace worker: " . $e->getMessage();
-                echo  __FUNCTION__."(): Transaction failed: " . $e->getMessage()."<br />";
+                game_error_log(__FUNCTION__, 'Transaction failed : ' . $e->getMessage(), ['worker_id' => $worker_id, 'controller_id' => $controller_id, 'trace_worker_id' => $trace_worker_id ?? null], 'error');
                 return false;
             }
         }
@@ -1632,10 +1635,10 @@ function destroyTraceWorker($pdo, $worker_id, $controller_id) {
 
 /**
  * Sort the worker buckets by the given sort key
- * 
- * @param array &$bucket
- * @param string $sort
- * 
+ *
+ * @param array &$bucket : bucket of worker rows (mutated in place)
+ * @param string $sort : sort key ('zone' | 'investigate' | 'attack' | 'age')
+ *
  * @return void
  */
 function sortWorkerBuckets(array &$bucket, string $sort): void {
@@ -1660,7 +1663,13 @@ function sortWorkerBuckets(array &$bucket, string $sort): void {
  * Mirrors viewAll.php bucket logic so the agent page navigates within
  * the same bucket the user was browsing, in the same sort order.
  *
- * @return array ['prev' => ?int, 'next' => ?int] — null when at edge or unfound
+ * @param PDO $pdo : database connection
+ * @param int $controller_id : viewing controller
+ * @param int $current_worker_id : worker currently displayed
+ * @param string $sort : sort key ('zone' | 'investigate' | 'attack' | 'age')
+ * @param int $turn_number : turn used for status classification
+ *
+ * @return array : ['prev' => ?int, 'next' => ?int] — null entries at bucket edges or when the worker isn't found
  */
 function getPrevNextWorkerIds(PDO $pdo, int $controller_id, int $current_worker_id, string $sort, int $turn_number): array {
     $result = ['prev' => null, 'next' => null];

--- a/workers/massAction.php
+++ b/workers/massAction.php
@@ -2,6 +2,8 @@
 
 require_once '../base/basePHP.php';
 
+// $GLOBALS['DEBUG_LOG_SECTIONS'][] = 'workers_mass_action_page';  // uncomment to log DEBUG events from this page
+
 // Check if the user is logged in
 if (
     (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true)
@@ -28,12 +30,18 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
     }
 
     if ($mass_action_requested && !empty($worker_ids)) {
-        if (!is_array($worker_ids)) { http_response_code(403); exit(); }
+        if (!is_array($worker_ids)) {
+            game_error_log('workers_mass_action_page', 'worker_ids not an array', ['worker_ids' => $worker_ids], 'warning');
+            http_response_code(403); exit();
+        }
         $worker_ids = array_map('intval', $worker_ids);
 
         if (empty($_SESSION['is_privileged'])) {
             $session_controller_id = $_SESSION['controller']['id'] ?? null;
-            if (empty($session_controller_id)) { http_response_code(403); exit(); }
+            if (empty($session_controller_id)) {
+                game_error_log('workers_mass_action_page', 'missing session controller_id', [], 'warning');
+                http_response_code(403); exit();
+            }
 
             try {
                 $prefix = $_SESSION['GAME_PREFIX'];
@@ -44,10 +52,11 @@ if ( $_SERVER['REQUEST_METHOD'] === 'GET') {
                 );
                 $stmt->execute(array_merge([$session_controller_id], $worker_ids));
                 if ((int)$stmt->fetchColumn() !== count($worker_ids)) {
+                    game_error_log('workers_mass_action_page', 'controller_worker ownership mismatch', ['session_controller_id' => $session_controller_id, 'worker_ids' => $worker_ids], 'warning');
                     http_response_code(403); exit();
                 }
             } catch (PDOException $e) {
-                echo __FUNCTION__."(): SELECT controller_worker Failed: " . $e->getMessage()."<br />";
+                game_error_log('workers_mass_action_page', 'SELECT controller_worker failed : ' . $e->getMessage(), ['session_controller_id' => $session_controller_id, 'worker_ids' => $worker_ids], 'error');
                 http_response_code(403); exit();
             }
         }

--- a/workers/newPerfectWorker.php
+++ b/workers/newPerfectWorker.php
@@ -5,6 +5,8 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
     exit();
 }
 
+// $GLOBALS['DEBUG_LOG_SECTIONS'][] = 'workers_new_perfect_page';  // uncomment to log DEBUG events from this page
+
     $title = 'Admin - Create Perfect Agent';
 
     // Select a controller from controllers
@@ -23,7 +25,7 @@ if (realpath($_SERVER['SCRIPT_FILENAME']) === realpath(__FILE__)) {
         $stmt = $gameReady->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log('workers_new_perfect_page', 'worker_names JOIN worker_origins SELECT failed : ' . $e->getMessage(), ['sql' => $sql], 'error');
         return NULL;
     }
     // Fetch the results

--- a/zones/functions.php
+++ b/zones/functions.php
@@ -1055,7 +1055,7 @@ function applyZoneRules($pdo, $type, $zone_id, $controller_id, $value) {
         $stmt->execute();
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        error_log("applyZoneRules: zone fetch failed for zone $zone_id: " . $e->getMessage());
+        game_error_log(__FUNCTION__, 'zone fetch failed', ['zone_id' => $zone_id, 'error' => $e->getMessage()]);
         return $value;
     }
     if (!$row || empty($row['zone_rules'])) {
@@ -1064,7 +1064,7 @@ function applyZoneRules($pdo, $type, $zone_id, $controller_id, $value) {
 
     $rules = json_decode($row['zone_rules'], true);
     if (!is_array($rules)) {
-        error_log("applyZoneRules: invalid JSON in zone_rules on zone $zone_id");
+        game_error_log(__FUNCTION__, 'invalid JSON in zone_rules', ['zone_id' => $zone_id]);
         return $value;
     }
     if (!isset($rules[$type]) || !is_array($rules[$type])) {
@@ -1073,24 +1073,24 @@ function applyZoneRules($pdo, $type, $zone_id, $controller_id, $value) {
 
     foreach ($rules[$type] as $rule) {
         if (!is_array($rule) || !isset($rule['condition'], $rule['value_delta'])) {
-            error_log("applyZoneRules: malformed rule on zone $zone_id for type $type (missing condition/value_delta)");
+            game_error_log(__FUNCTION__, 'malformed rule (missing condition/value_delta)', ['zone_id' => $zone_id, 'type' => $type]);
             continue;
         }
         $condition = (string)$rule['condition'];
         $delta = (int)$rule['value_delta'];
         if ($condition !== 'held_by_actor' && $condition !== 'not_held_by_actor') {
-            error_log("applyZoneRules: unknown condition '$condition' on zone $zone_id");
+            game_error_log(__FUNCTION__, 'unknown condition', ['zone_id' => $zone_id, 'condition' => $condition]);
             continue;
         }
 
         $isSpecific = isset($rule['zone_name']);
         $isAdjacent = (($rule['adjacent_zones'] ?? null) === true);
         if ($isSpecific && $isAdjacent) {
-            error_log("applyZoneRules: rule has both zone_name and adjacent_zones on zone $zone_id");
+            game_error_log(__FUNCTION__, 'rule has both zone_name and adjacent_zones', ['zone_id' => $zone_id]);
             continue;
         }
         if (!$isSpecific && !$isAdjacent) {
-            error_log("applyZoneRules: rule has neither zone_name nor adjacent_zones on zone $zone_id");
+            game_error_log(__FUNCTION__, 'rule has neither zone_name nor adjacent_zones', ['zone_id' => $zone_id]);
             continue;
         }
 
@@ -1116,11 +1116,11 @@ function applyZoneRuleSpecific($pdo, $name, $condition, $delta, $controller_id, 
         $lookup->execute();
         $ref = $lookup->fetch(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        error_log("applyZoneRules: lookup failed for '$name' on zone $zone_id: " . $e->getMessage());
+        game_error_log(__FUNCTION__, 'lookup failed', ['zone_id' => $zone_id, 'name' => $name, 'error' => $e->getMessage()]);
         return 0;
     }
     if (!$ref) {
-        error_log("applyZoneRules: zone_name '$name' not found for zone $zone_id");
+        game_error_log(__FUNCTION__, 'zone_name not found', ['zone_id' => $zone_id, 'name' => $name], 'warning');
         return 0;
     }
     $isHeld = ((int)$ref['holder_controller_id'] === (int)$controller_id);
@@ -1149,7 +1149,7 @@ function applyZoneRuleAdjacent($pdo, $adjacent_zones_csv, $condition, $delta, $c
         $lookup->execute($adjacentIds);
         $rows = $lookup->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        error_log("applyZoneRules: adjacent lookup failed for zone $zone_id: " . $e->getMessage());
+        game_error_log(__FUNCTION__, 'adjacent lookup failed', ['zone_id' => $zone_id, 'error' => $e->getMessage()]);
         return 0;
     }
     $total = 0;

--- a/zones/functions.php
+++ b/zones/functions.php
@@ -3,18 +3,22 @@
 /**
  * Recupere le nom de la zone
  *
- * @param PDO $pdo
- * @param int $zone_id
+ * @param PDO $pdo : database connection
+ * @param int $zone_id : zone id
  *
+ * @return string|null : zone name or NULL on failure
  */
-function getZoneName($pdo, $zone_id){
+function getZoneName(PDO $pdo, int $zone_id): string|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with zone_id : ' . $zone_id, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try{
         $sql = "SELECT name FROM {$prefix}zones AS z WHERE id=$zone_id";
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT zone name failed', ['zone_id' => $zone_id, 'error' => $e->getMessage()]);
         return NULL;
     }
     // Fetch the results
@@ -25,13 +29,17 @@ function getZoneName($pdo, $zone_id){
 /**
  * Function to get ZONEs and return as an array
  *
- * @param PDO $pdo
- * @param int|null $controller_id
- * @param int|null $zone_id
+ * @param PDO $pdo : database connection
+ * @param int|null $controller_id : filter on claimer controller id
+ * @param int|null $holder_controller_id : filter on holder controller id
+ * @param int|null $zone_id : filter on zone id
  *
- * @return array $zonesArray
+ * @return array|null $zonesArray or NULL on failure
  */
-function getZonesArray($pdo, $controller_id = null, $holder_controller_id = null, $zone_id = null) {
+function getZonesArray(PDO $pdo, int|null $controller_id = null, int|null $holder_controller_id = null, int|null $zone_id = null): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['controller_id' => $controller_id, 'holder_controller_id' => $holder_controller_id, 'zone_id' => $zone_id], 'debug');
+
     $zonesArray = array();
     $prefix = $_SESSION['GAME_PREFIX'];
 
@@ -73,17 +81,29 @@ function getZonesArray($pdo, $controller_id = null, $holder_controller_id = null
         // Fetch the results
         $zonesArray = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT zones failed', ['controller_id' => $controller_id, 'holder_controller_id' => $holder_controller_id, 'zone_id' => $zone_id, 'error' => $e->getMessage()]);
         return NULL;
     }
 
     return $zonesArray;
 }
 
-// Unified visibility gate covering both is_hidden (persistent) and hide_turn_zero (turn-0).
-// $bypassVisibility: true only in god-view (privileged session without a controller selected).
-// Otherwise holder/claimer sees their own hidden zones; hide_turn_zero becomes public past turn 0.
-function canControllerSeeZone(PDO $pdo, array $zone, ?int $controller_id, bool $bypassVisibility): bool {
+/**
+ * Unified visibility gate covering both is_hidden (persistent) and hide_turn_zero (turn-0).
+ * $bypassVisibility: true only in god-view (privileged session without a controller selected).
+ * Otherwise holder/claimer sees their own hidden zones; hide_turn_zero becomes public past turn 0.
+ *
+ * @param PDO $pdo : database connection
+ * @param array $zone : zone row (must include is_hidden, hide_turn_zero, holder_controller_id, claimer_controller_id)
+ * @param int|null $controller_id : viewer controller id (null when no controller selected)
+ * @param bool $bypassVisibility : true in god-view (privileged, no controller)
+ *
+ * @return bool : true when the controller may see the zone
+ */
+function canControllerSeeZone(PDO $pdo, array $zone, int|null $controller_id, bool $bypassVisibility): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['zone' => $zone, 'controller_id' => $controller_id, 'bypassVisibility' => $bypassVisibility], 'debug');
+
     if ($bypassVisibility) return true;
     $isHidden = !empty($zone['is_hidden']);
     $hideTurn0 = !empty($zone['hide_turn_zero']);
@@ -104,18 +124,21 @@ function canControllerSeeZone(PDO $pdo, array $zone, ?int $controller_id, bool $
 /**
  * Function to prepare the zone selector from à list of zones
  *
- * @param PDO $pdo
- * @param array $zonesArray
+ * @param PDO $pdo : database connection
+ * @param array $zonesArray : list of zones (as returned by getZonesArray)
  * @param int|null $selectedID : ID of the selected zone (optional)
- * @param bool $showText default: false ->
- * @param bool $place_holder default: false -> Do we start with and empty spot
- * @param bool $hideZones default: false -> Do we hide the zones in the list
+ * @param bool $showText : default false -> render the label above the select
+ * @param bool $place_holder : default false -> start with an empty option
+ * @param bool $hideZones : default false -> filter zones through canControllerSeeZone
  *
- * @return string $showZoneSelect
+ * @return string $showZoneSelect : HTML markup (empty string when zonesArray is empty)
  */
-function showZoneSelect($pdo, $zonesArray, $selectedID = null, $showText = false, $place_holder = false, $hideZones = false) {
-        $mechanics = getMechanics($pdo);
-        $turn_number = $mechanics['turncounter'];
+function showZoneSelect(PDO $pdo, array $zonesArray, int|null $selectedID = null, bool $showText = false, bool $place_holder = false, bool $hideZones = false): string {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['zonesArray' => $zonesArray, 'selectedID' => $selectedID, 'showText' => $showText, 'place_holder' => $place_holder, 'hideZones' => $hideZones], 'debug');
+
+    $mechanics = getMechanics($pdo);
+    $turn_number = $mechanics['turncounter'];
 
     if (empty($zonesArray)) return '';
 
@@ -151,18 +174,22 @@ function showZoneSelect($pdo, $zonesArray, $selectedID = null, $showText = false
         $zoneOptions
     );
 
-    if (!empty($_SESSION['DEBUG']) && $_SESSION['DEBUG'] == true) echo __FUNCTION__."(): showZoneSelect: ".var_export($showZoneSelect, true)."<br /><br />";
+    game_error_log(__FUNCTION__, 'DONE', ['showZoneSelect' => $showZoneSelect], 'debug');
 
     return $showZoneSelect;
 }
 
-/** Function to get Locations and return as an array
- * @param PDO $pdo
+/**
+ * Function to get Locations and return as an array
  *
- * @return array|null $locationsArray
+ * @param PDO $pdo : database connection
  *
-*/
-function getLocationsArray($pdo) {
+ * @return array|null $locationsArray or NULL on failure
+ */
+function getLocationsArray(PDO $pdo): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', [], 'debug');
+
     $locationsArray = array();
     $prefix = $_SESSION['GAME_PREFIX'];
 
@@ -174,7 +201,7 @@ function getLocationsArray($pdo) {
         $stmt = $pdo->prepare($sql);
         $stmt->execute();
     } catch (PDOException $e) {
-        echo  __FUNCTION__."(): $sql failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'SELECT locations failed', ['error' => $e->getMessage()]);
         return NULL;
     }
 
@@ -191,18 +218,22 @@ function getLocationsArray($pdo) {
 
 /**
  * Function to recalculateZoneDefence
- * @param PDO $pdo
- * @param array $mechanics : mechanics array
  *
- * @return bool
- * 
  * Recompute zones.calculated_defence_val for every zone.
  * Dispatches on claimMode:
  * - 'worker': SQL formula (z.defence_val + COUNT of holder's active workers).
  * - 'worker_leader': calculateControllerValue('ZoneDefence', ...) per zone.
  * - any other value: no-op (echoes "not supported, skipped" and returns true).
+ *
+ * @param PDO $pdo : database connection
+ * @param array $mechanics : mechanics array (must include turncounter)
+ *
+ * @return bool : true on success, false on SQL failure
  */
-function recalculateZoneDefence($pdo, $mechanics) {
+function recalculateZoneDefence(PDO $pdo, array $mechanics): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['mechanics' => $mechanics], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $mode = getConfig($pdo, 'claimMode');
 
@@ -227,7 +258,7 @@ function recalculateZoneDefence($pdo, $mechanics) {
                 $uStmt->execute();
             }
         } catch (PDOException $e) {
-            echo __FUNCTION__." (): sql FAILED : ".$e->getMessage()."<br />";
+            game_error_log(__FUNCTION__, 'worker_leader recompute failed', ['error' => $e->getMessage()]);
             return false;
         }
         echo 'DONE (worker_leader) </p></div>';
@@ -287,7 +318,7 @@ function recalculateZoneDefence($pdo, $mechanics) {
         $stmt->execute();
 
     } catch (PDOException $e) {
-        echo __FUNCTION__." (): sql FAILED : ".$e->getMessage()."<br />$sql<br />";
+        game_error_log(__FUNCTION__, 'worker recompute failed', ['sql' => $sql, 'error' => $e->getMessage()]);
         return false;
     }
     echo 'DONE </p></div>';
@@ -296,11 +327,15 @@ function recalculateZoneDefence($pdo, $mechanics) {
 
 /**
  * Function to recalculateBaseDefence
- * @param PDO $pdo
  *
- * @return bool
+ * @param PDO $pdo : database connection
+ *
+ * @return bool : true on success, false on SQL failure
  */
-function recalculateBaseDefence($pdo) {
+function recalculateBaseDefence(PDO $pdo): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', [], 'debug');
+
     echo "<div><h3>Recalculating base defence</h3><br />";
     $prefix = $_SESSION['GAME_PREFIX'];
 
@@ -330,10 +365,11 @@ function recalculateBaseDefence($pdo) {
                 ':id' => $base['id']
             ]);
         } catch (PDOException $e) {
-            echo __FUNCTION__." (): sql FAILED : ".$e->getMessage()."<br />$sql<br/>";
+            game_error_log(__FUNCTION__, 'UPDATE locations discovery_diff failed', ['sql' => $sql, 'error' => $e->getMessage()]);
             return false;
         }
 
+        game_error_log(__FUNCTION__, 'Updated base to difficulty', ['controller_id' => $controller_id, 'zone_id' => $zone_id, 'new_diff' => $new_diff], 'debug');
         echo sprintf("Updated base (C: %s, Z: %s) to difficulty: %s<br/>", $controller_id, $zone_id, $new_diff);
     }
     echo "</div>";
@@ -343,16 +379,18 @@ function recalculateBaseDefence($pdo) {
 /**
  * Calculate the value 'DEF, ATK, SEARCH, CLAIM, ZONE_DEFENCE' for the controller, and optionnal zone or location
  *
- * @param PDO $pdo
- * @param int $controller_id
- * @param string $type in ['DiscoveryDiff', 'Defence', 'Attack', 'Claim', 'ZoneDefence']
- * @param int $zone_id
- * @param int|null $location_id
+ * @param PDO $pdo : database connection
+ * @param string $type : one of 'DiscoveryDiff' | 'Defence' | 'Attack' | 'Claim' | 'ZoneDefence'
+ * @param int $zone_id : zone id
+ * @param int|null $controller_id : actor controller id (null for anonymous)
+ * @param int|null $location_id : location id (only for DiscoveryDiff / Defence on secret locations)
  *
- * @return int $value
+ * @return int $value : computed value after all rules
  */
-function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, $location_id = null) {
-    $debug = strtolower(getConfig($pdo, 'DEBUG')) === 'true';
+function calculateControllerValue(PDO $pdo, string $type, int $zone_id, int|null $controller_id = null, int|null $location_id = null): int {
+    if (strtolower(getConfig($pdo, 'DEBUG')) == 'true')
+        $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;
+    game_error_log(__FUNCTION__, 'START with type : ' . $type, ['zone_id' => $zone_id, 'controller_id' => $controller_id, 'location_id' => $location_id], 'debug');
 
     $value = 0;
     $prefix = $_SESSION['GAME_PREFIX'];
@@ -360,12 +398,10 @@ function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, 
     $mechanics = getMechanics($pdo);
     $turn_number = $mechanics['turncounter'];
 
-    if ($debug) echo sprintf("<p> <b>calculateControllerValue (type : %s, zone: %s, controller: %s, location: %s)</b><br>", $type, $zone_id, $controller_id, $location_id);
-
     // Base value
     $base = (int)getConfig($pdo, "base{$type}");
     $value = $base;
-    if ($debug) echo sprintf("%s (base) : %d<br>", $type, $value);
+    game_error_log(__FUNCTION__, sprintf('%s (base) : %d', $type, $value), [], 'debug');
 
     // Add +1 if controller owns or claims the zone
     $zoneStmt = $pdo->prepare("
@@ -377,28 +413,28 @@ function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, 
     $zone = $zoneStmt->fetch(PDO::FETCH_ASSOC);
 
     if ($controller_id !== null) {
-        // Holders & Claimers 
+        // Holders & Claimers
         if ($zone) {
             if ($type === 'Claim') {
                 if ($zone['claimer_controller_id'] == $controller_id && $zone['holder_controller_id'] != $controller_id) {
                     $vrBonus = (int) getConfig($pdo, 'claimVisibleToRealBonus');
                     $value += $vrBonus;
-                    if ($debug) echo sprintf("visibleToRealBonus +%d<br>", $vrBonus);
+                    game_error_log(__FUNCTION__, sprintf('visibleToRealBonus +%d', $vrBonus), [], 'debug');
                 }
             } else {
                 // Si le controller n'est pas 0, '' ou NULL alors on peut comparer aux holders ou claimers
                 if (!empty ($controller_id) && ($zone['holder_controller_id'] == $controller_id || $zone['claimer_controller_id'] == $controller_id)) {
                     $value += 1;
-                    if ($debug) echo sprintf("%s (+zone control) : %d<br>", $type, $value);
+                    game_error_log(__FUNCTION__, sprintf('%s (+zone control) : %d', $type, $value), [], 'debug');
                 }
             }
         }
-    
+
         // Powers
         $powerMultiplier = floatval(getConfig($pdo, "base{$type}AddPowers"));
-        if ($debug) echo sprintf("powerMultiplier : %f<br>", $powerMultiplier);
+        game_error_log(__FUNCTION__, sprintf('powerMultiplier : %f', $powerMultiplier), [], 'debug');
         $maxPowerBonus = (int)getConfig($pdo, "maxBonus{$type}Powers");
-        if ($debug) echo sprintf("maxPowerBonus : %d<br>", $maxPowerBonus);
+        game_error_log(__FUNCTION__, sprintf('maxPowerBonus : %d', $maxPowerBonus), [], 'debug');
         if ($powerMultiplier !== 0) {
             switch ($type){ // 'defence', 'attack' or 'enquete'
                 case 'DiscoveryDiff' :
@@ -422,15 +458,17 @@ function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, 
                 }
                 if ($maxPowerBonus > 0) $bonus = min($bonus, $maxPowerBonus);
                 $value += $bonus;
-                if ($debug) echo sprintf("%s (+powers) : %d<br>", $type, $value);
-            } else echo sprintf("%s : attribute is NULL <br>", $type);
+                game_error_log(__FUNCTION__, sprintf('%s (+powers) : %d', $type, $value), [], 'debug');
+            } else {
+                game_error_log(__FUNCTION__, sprintf('%s : attribute is NULL', $type), [], 'warning');
+            }
         }
 
         // Workers
         $workerMultiplier = floatval(getConfig($pdo, "base{$type}AddWorkers"));
-        if ($debug) echo sprintf("workerMultiplier : %f<br>", $workerMultiplier);
+        game_error_log(__FUNCTION__, sprintf('workerMultiplier : %f', $workerMultiplier), [], 'debug');
         $maxWorkerBonus = (int)getConfig($pdo, "maxBonus{$type}Workers");
-        if ($debug) echo sprintf("maxWorkerBonus : %d<br>", $maxWorkerBonus);
+        game_error_log(__FUNCTION__, sprintf('maxWorkerBonus : %d', $maxWorkerBonus), [], 'debug');
         if ($workerMultiplier !== 0) {
             $active_actions = "'".implode("','", ACTIVE_ACTIONS)."'";
             $sql = sprintf('
@@ -442,7 +480,7 @@ function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, 
                 AND w.zone_id = :zone_id
                 AND wa.action_choice IN (%2$s)
             ', $prefix, $active_actions);
-            if ($debug) echo sprintf("worker_count sql : %s<br> controller_id: %s, zone_id: %s, turn_number: %s, ", $sql, $controller_id, $zone_id, $turn_number);
+            game_error_log(__FUNCTION__, 'worker_count sql', ['sql' => $sql, 'controller_id' => $controller_id, 'zone_id' => $zone_id, 'turn_number' => $turn_number], 'debug');
             $stmt = $pdo->prepare($sql);
             $stmt->bindParam(':controller_id', $controller_id, PDO::PARAM_INT);
             $stmt->bindParam(':zone_id', $zone_id, PDO::PARAM_INT);
@@ -450,14 +488,14 @@ function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, 
             $stmt->execute();
 
             $result = $stmt->fetch(PDO::FETCH_ASSOC);
-            if ($debug) echo sprintf( "result: %s<br>", var_export($result, true));
+            game_error_log(__FUNCTION__, 'worker_count result', ['result' => $result], 'debug');
             $worker_count = $result['worker_count'];
-            if ($debug) echo sprintf( "worker_count: %s<br>", $worker_count);
+            game_error_log(__FUNCTION__, sprintf('worker_count: %s', $worker_count), [], 'debug');
 
             $bonus = ceil($worker_count * $workerMultiplier);
             if ($maxWorkerBonus > 0) $bonus = min($bonus, $maxWorkerBonus);
             $value += $bonus;
-            if ($debug) echo sprintf("%s (+workers) : %d<br>", $type, $value);
+            game_error_log(__FUNCTION__, sprintf('%s (+workers) : %d', $type, $value), [], 'debug');
         }
 
         // Owned-locations term — fires only for 'Claim' and 'ZoneDefence' types
@@ -476,7 +514,7 @@ function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, 
                 $ownedBonus = ceil($owned_count * $ownedMultiplier);
                 if ($maxOwnedBonus > 0) $ownedBonus = min($ownedBonus, $maxOwnedBonus);
                 $value += $ownedBonus;
-                if ($debug) echo sprintf("%s (+owned_locations) : %d<br>", $type, $value);
+                game_error_log(__FUNCTION__, sprintf('%s (+owned_locations) : %d', $type, $value), [], 'debug');
             }
         }
 
@@ -511,21 +549,21 @@ function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, 
                 $supporters = max(0, $count - $supportOnNth);
                 $supportBonus = ceil($supporters * $supportMultiplier);
                 $value += $supportBonus;
-                if ($debug) echo sprintf("%s (+supporting_agents %d) : %d<br>", $type, $supporters, $value);
+                game_error_log(__FUNCTION__, sprintf('%s (+supporting_agents %d) : %d', $type, $supporters, $value), [], 'debug');
             }
         }
     } else {
-        if ($debug) echo sprintf("%s : controller_id is NULL <br>", $type);
+        game_error_log(__FUNCTION__, sprintf('%s : controller_id is NULL', $type), [], 'debug');
         $value += getConfig($pdo, "noController{$type}Bonus");
     }
 
-    // Turns / Age for locations 
+    // Turns / Age for locations
     if ($location_id !== NUll) {
         $turnMultiplier = floatval(getConfig($pdo, "base{$type}AddTurns"));
-        if ($debug) echo sprintf("turnMultiplier : %f<br>", $turnMultiplier);
+        game_error_log(__FUNCTION__, sprintf('turnMultiplier : %f', $turnMultiplier), [], 'debug');
         if ($turnMultiplier !== 0) {
             $maxTurnBonus = (int)getConfig($pdo, "maxBonus{$type}Turns");
-            if ($debug) echo sprintf("maxTurnBonus : %d<br>", $maxTurnBonus);
+            game_error_log(__FUNCTION__, sprintf('maxTurnBonus : %d', $maxTurnBonus), [], 'debug');
             $mechanics = getMechanics($pdo);
             $turn_number = $mechanics['turncounter'];
 
@@ -547,55 +585,55 @@ function calculateControllerValue($pdo, $type, $zone_id, $controller_id = null, 
                 $bonus = ceil($turnDiff * $turnMultiplier);
                 if ($maxTurnBonus > 0) $bonus = min($bonus, $maxTurnBonus);
                 $value += $bonus;
-                if ($debug) echo sprintf("%s (+turns) : %d<br>", $type, $value);
+                game_error_log(__FUNCTION__, sprintf('%s (+turns) : %d', $type, $value), [], 'debug');
             }
         }
     }
 
-    if ($debug) echo sprintf("%s pre-rules value : %d<br>", $type, $value);
+    game_error_log(__FUNCTION__, sprintf('%s pre-rules value : %d', $type, $value), [], 'debug');
     $value = applyZoneRules($pdo, $type, $zone_id, $controller_id, $value);
-    if ($debug) echo sprintf("%s final value : %d</p>", $type, $value);
+    game_error_log(__FUNCTION__, sprintf('%s final value : %d', $type, $value), [], 'debug');
     return $value;
 }
 
 /**
- * Calls the calculateSecretLocationDiscoveryDiff function with the 'DiscoveryDiff' type
+ * Calls the calculateControllerValue function with the 'DiscoveryDiff' type
  *
- * @param PDO $pdo
- * @param int $zone_id
- * @param int|null $location_id
- * @param int|null $controller_id
+ * @param PDO $pdo : database connection
+ * @param int $zone_id : zone id
+ * @param int|null $location_id : location id (optional)
+ * @param int|null $controller_id : controller id (optional)
  *
- * @return int $value
+ * @return int $value : computed discovery difficulty
  */
-function calculateSecretLocationDiscoveryDiff($pdo, $zone_id, $location_id = null, $controller_id = null ) {
+function calculateSecretLocationDiscoveryDiff(PDO $pdo, int $zone_id, int|null $location_id = null, int|null $controller_id = null): int {
     return calculateControllerValue($pdo, 'DiscoveryDiff', $zone_id, $controller_id, $location_id);
 }
 
 /**
  * Calls the calculateControllerValue function with the 'Defence' type
  *
- * @param PDO $pdo
- * @param int $controller_id
- * @param int $zone_id
- * @param int $location_id
+ * @param PDO $pdo : database connection
+ * @param int $zone_id : zone id
+ * @param int $location_id : location id
+ * @param int|null $controller_id : controller id (optional)
  *
- * @return int $value
+ * @return int $value : computed defence value
  */
-function calculateSecretLocationDefence($pdo, $zone_id, $location_id, $controller_id = null) {
+function calculateSecretLocationDefence(PDO $pdo, int $zone_id, int $location_id, int|null $controller_id = null): int {
     return calculateControllerValue($pdo, 'Defence', $zone_id, $controller_id, $location_id);
 }
 
 /**
  * Calls the calculateControllerValue function with the 'Attack' type
  *
- * @param PDO $pdo
- * @param int $controller_id
- * @param int $zone_id
+ * @param PDO $pdo : database connection
+ * @param int $zone_id : zone id
+ * @param int|null $controller_id : controller id (optional)
  *
- * @return int $value
+ * @return int $value : computed attack value
  */
-function calculatecontrollerAttack($pdo, $zone_id, $controller_id = null) {
+function calculatecontrollerAttack(PDO $pdo, int $zone_id, int|null $controller_id = null): int {
     return calculateControllerValue($pdo, 'Attack', $zone_id, $controller_id);
 }
 
@@ -615,6 +653,9 @@ function calculatecontrollerAttack($pdo, $zone_id, $controller_id = null) {
  * @return string HTML — '' when both sections empty
  */
 function showZoneAgents(PDO $pdo, int $controller_id, int $zone_id, array $mechanics, array $controllerWorkers): string {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['zone_id' => $zone_id, 'mechanics' => $mechanics, 'controllerWorkers' => $controllerWorkers], 'debug');
+
     $turn_number = (int)$mechanics['turncounter'];
     $friendlies = [];
     $doubles = [];
@@ -694,6 +735,9 @@ function showZoneAgents(PDO $pdo, int $controller_id, int $zone_id, array $mecha
  * @return string $text
  */
 function showcontrollerKnownSecrets(PDO $pdo, int $controller_id, int $zone_id): string {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controller_id : ' . $controller_id, ['zone_id' => $zone_id], 'debug');
+
     $returnText = '';
     $prefix = $_SESSION['GAME_PREFIX'];
     // Bases owned by this controller in the zone
@@ -818,6 +862,9 @@ function showcontrollerKnownSecrets(PDO $pdo, int $controller_id, int $zone_id):
  *  ]
  */
 function listControllerKnownLocations(PDO $gameReady, int $controllerId, bool $limitByDestroyed = false, bool $limitByReparable = false, bool $excludeOwnLocations = false, bool $excludePendingAttacks = false): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controllerId : ' . $controllerId, ['limitByDestroyed' => $limitByDestroyed, 'limitByReparable' => $limitByReparable, 'excludeOwnLocations' => $excludeOwnLocations, 'excludePendingAttacks' => $excludePendingAttacks], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $sql = sprintf("
         SELECT
@@ -886,6 +933,9 @@ function listControllerKnownLocations(PDO $gameReady, int $controllerId, bool $l
  * @return array|null array of controllers know locations
  */
 function listControllerLinkedLocations(PDO $gameReady, int $controllerId): array|null {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with controllerId : ' . $controllerId, [], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $sql = "
         SELECT
@@ -896,7 +946,7 @@ function listControllerLinkedLocations(PDO $gameReady, int $controllerId): array
             l.name AS location_name,
             l.description AS location_description,
             l.hidden_description AS location_hidden_description,
-            l.can_be_destroyed AS location_can_be_destroyed 
+            l.can_be_destroyed AS location_can_be_destroyed
         FROM {$prefix}locations l
         JOIN {$prefix}zones z ON l.zone_id = z.id
         WHERE l.controller_id = :controller_id
@@ -944,12 +994,17 @@ function listControllerLinkedLocations(PDO $gameReady, int $controllerId): array
 
 /**
  * Update the location
- * 
+ *
  * @param PDO $pdo : database connection
  * @param array $location : location data
  * @param array $activate_json : activate json data
+ *
+ * @return bool : true on success (row updated), false when nothing to update or on SQL failure
  */
-function updateLocation($pdo, $location, $activate_json) {
+function updateLocation(PDO $pdo, array $location, array $activate_json): bool {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START', ['location' => $location, 'activate_json' => $activate_json], 'debug');
+
     // Extract the update_location data
     $update_location_data = $activate_json['update_location'];
 
@@ -1023,7 +1078,7 @@ function updateLocation($pdo, $location, $activate_json) {
             return true;
         }
     } catch (PDOException $e) {
-        echo __FUNCTION__."(): UPDATE locations Failed: " . $e->getMessage()."<br />";
+        game_error_log(__FUNCTION__, 'UPDATE locations failed', ['location_id' => $location['id'] ?? null, 'error' => $e->getMessage()]);
     }
     return false;
 }
@@ -1043,7 +1098,10 @@ function updateLocation($pdo, $location, $activate_json) {
  *
  * @return int  Value after summing every matching rule's value_delta.
  */
-function applyZoneRules($pdo, $type, $zone_id, $controller_id, $value) {
+function applyZoneRules(PDO $pdo, string $type, int $zone_id, int|null $controller_id, int $value): int {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with type : ' . $type, ['zone_id' => $zone_id, 'controller_id' => $controller_id], 'debug');
+
     if ($controller_id === null) {
         return $value;
     }
@@ -1107,8 +1165,20 @@ function applyZoneRules($pdo, $type, $zone_id, $controller_id, $value) {
 /**
  * Specific-zone rule: fires once if the named zone's holder matches the condition.
  * No adjacency requirement; the rule can reference any zone in the game.
+ *
+ * @param PDO $pdo : database connection
+ * @param string $name : target zone name to look up
+ * @param string $condition : 'held_by_actor' | 'not_held_by_actor'
+ * @param int $delta : value_delta applied when condition matches
+ * @param int $controller_id : actor whose ownership the condition tests
+ * @param int $zone_id : source zone (for log context, not the lookup target)
+ *
+ * @return int : $delta on match, 0 otherwise
  */
-function applyZoneRuleSpecific($pdo, $name, $condition, $delta, $controller_id, $zone_id) {
+function applyZoneRuleSpecific(PDO $pdo, string $name, string $condition, int $delta, int $controller_id, int $zone_id): int {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with name : ' . $name, ['condition' => $condition, 'zone_id' => $zone_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     try {
         $lookup = $pdo->prepare("SELECT holder_controller_id FROM {$prefix}zones WHERE name = :name LIMIT 1");
@@ -1133,8 +1203,20 @@ function applyZoneRuleSpecific($pdo, $name, $condition, $delta, $controller_id, 
 /**
  * Iterator rule: for each zone in the porting zone's adjacent_zones list,
  * apply delta if the condition matches. Deltas accumulate across matches.
+ *
+ * @param PDO $pdo : database connection
+ * @param string $adjacent_zones_csv : comma-separated list of zone ids
+ * @param string $condition : 'held_by_actor' | 'not_held_by_actor'
+ * @param int $delta : value_delta applied per matching adjacent zone
+ * @param int $controller_id : actor whose ownership the condition tests
+ * @param int $zone_id : source zone (for log context)
+ *
+ * @return int : sum of deltas for all matching adjacents (0 if none)
  */
-function applyZoneRuleAdjacent($pdo, $adjacent_zones_csv, $condition, $delta, $controller_id, $zone_id) {
+function applyZoneRuleAdjacent(PDO $pdo, string $adjacent_zones_csv, string $condition, int $delta, int $controller_id, int $zone_id): int {
+    // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
+    game_error_log(__FUNCTION__, 'START with condition : ' . $condition, ['zone_id' => $zone_id], 'debug');
+
     $prefix = $_SESSION['GAME_PREFIX'];
     $adjacentIds = [];
     foreach (explode(',', (string)$adjacent_zones_csv) as $part) {


### PR DESCRIPTION
Ferme #90.

## Résumé

Route tous les chemins d'erreur PHP (PDO catches, echo Failed/Error, native error_log) vers le helper `game_error_log()` qui écrit dans un fichier log dédié, plus un viewer admin.

3 pièces livrées :
1. **Infra** — `base/errorLog.php` (helper), `base/admin_logs.php` (viewer avec filtres + purge + download), pytest fixture qui fail les tests sur nouveaux `[ERROR]` (UI-only via HTTP)
2. **Pattern v2 canonical** — typed signature + PHPDoc + opt-in DEBUG_LOG_SECTIONS + START event + optional DONE + Dynamic DB-config unlock, documenté dans les rules du sprint
3. **Refactor** — 23 fichiers PHP passés au v2

## Refactor par fichier

| Fichier | Fonctions | Catches | game_error_log |
|---|---|---|---|
| BDD/db_connector.php | 11 | 18 | 29 |
| workers/functions.php | 25 | 25 | 97 |
| controllers/functions.php | 22 | 23 | 63 |
| zones/functions.php | 19 | 10 | 55 |
| powers/functions.php | 14 | 5 | 29 |
| workers/action.php | 0 | 1 | 1 |
| workers/massAction.php | 0 | 1 | 4 |
| workers/newPerfectWorker.php | 0 | 1 | 1 |
| controllers/action.php | 0 | 1 | 6 |
| controllers/view.php | 0 | 1 | 1 |
| base/basePHP.php | 2 | 2 | 5 |
| connection/loginForm.php | 1 | 2 | 5 |
| index.php | 1 | 1 | 2 |
| mechanics/* (8 fichiers) | 32 | 30 | 104 |
| ressources/functions.php | 18 | 5 | 12 |

## Fixes secondaires

- `getConfig` missing-key coercion aligné sur les 3 copies (`$val !== false ? (string) : NULL`)
- `getSearcherComparisons` fail-safe : `array|false` return + `is_array` check dans `investigateMechanic` (propagate error to endTurn)
- Perf regression fixée sur `canStartFirstCome` / `canStartRecrutement` (DB reads eager en debug log arg)
- Log-level correctness sur soft-fail vs hard-fail catches
- `workers/massAction.php` SQL leak info supprimé (dev-echo dropped)

## Test plan

- [x] Full pytest suite green sur chaque batch (v11 → v18 : 528/528 chaque fois)
- [x] Fixture pytest UI-only `_assert_no_new_game_log_errors` valide chaque test contre le log admin viewer
- [x] Sonnet reviews adversariales sur chaque fichier (model bias mitigation)
- [x] Test manuel du log viewer (filtres, purge avec modal, download RAW)
- [x] Test manuel du bouton "Écrire Error test" dans admin_logs.php

## Notes

- 36 commits, ~4 semaines de sprint
- Meta-rule créée mid-sprint : `feedback_rules_check_before_action` (pause avant action significative)
- v2 canonical documenté dans `feedback_function_debug_prelude.md` (2026-07-20 lock)