### PR TITLE
test : @pytest.mark.db markers + Pattern A/C/H refactors (#99)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  test-shard:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -41,3 +41,16 @@ jobs:
       - name: Capture docker logs on failure
         if: failure()
         run: docker compose logs --tail=200
+
+  test:
+    runs-on: ubuntu-latest
+    needs: test-shard
+    if: always()
+    steps:
+      - name: Aggregate shard results
+        run: |
+          if [ "${{ needs.test-shard.result }}" != "success" ]; then
+            echo "One or more test shards failed (result=${{ needs.test-shard.result }})"
+            exit 1
+          fi
+          echo "All test shards passed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2]
     steps:
       - uses: actions/checkout@v5
 
@@ -31,8 +35,8 @@ jobs:
       - name: Install Playwright Chromium
         run: playwright install --with-deps chromium
 
-      - name: Run pytest
-        run: pytest tests/ -v
+      - name: Run pytest (group ${{ matrix.group }} of 2)
+        run: pytest tests/ -v --splits 2 --group ${{ matrix.group }}
 
       - name: Capture docker logs on failure
         if: failure()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-split
 pymysql
 pytest-playwright
 playwright

--- a/tests/test_hidden_zones_e2e.py
+++ b/tests/test_hidden_zones_e2e.py
@@ -283,6 +283,42 @@ def _row_form_locator(page, zone_id):
     )
 
 
+def _row_locator_by_name(page, zone_name):
+    """UI-only row lookup by the visible zone name column."""
+    return page.locator(
+        f"tr:has(td:text-is('{zone_name}'))"
+    )
+
+
+def _ui_reset_zone_row(page, base_url, zone_name):
+    """UI-only reset: navigate to management_zones.php and submit the row
+    for `zone_name` with claimer / holder / adjacent_zones / zone_rules
+    cleared AND is_hidden unchecked. Leaves the browser on the reloaded page."""
+    ensure_gm_login(page, base_url)
+    safe_goto(page, f"{base_url}/zones/management_zones.php")
+    page.wait_for_load_state("load")
+    form = _row_locator_by_name(page, zone_name)
+    form.locator("textarea[name='zone_rules']").fill("")
+    form.locator("input[name='adjacent_zones']").fill("")
+    form.locator("select[name='claimer_id']").select_option("")
+    form.locator("select[name='holder_id']").select_option("")
+    hidden_box = form.locator("input[type='checkbox'][name='is_hidden']")
+    if hidden_box.is_checked():
+        hidden_box.uncheck()
+    form.locator("button[type='submit']").click()
+    page.wait_for_load_state("load")
+
+
+def _ui_seed_is_hidden(page, base_url, zone_name):
+    """UI-only seed: after a reset, tick the row's is_hidden checkbox
+    and submit so the row's is_hidden lands at 1. Leaves the browser on
+    the reloaded page."""
+    form = _row_locator_by_name(page, zone_name)
+    form.locator("input[type='checkbox'][name='is_hidden']").check()
+    form.locator("button[type='submit']").click()
+    page.wait_for_load_state("load")
+
+
 @pytest.fixture(scope="session")
 def base_url():
     return PHP_BASE_URL
@@ -338,49 +374,53 @@ class TestIsHiddenSchemaAndAdmin:
 
     def test_check_is_hidden_persists_to_db(self, page: Page, base_url):
         """Ticking the row's is_hidden checkbox and submitting must
-        write `is_hidden=1` to the DB."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        assert _get_zone_row(zoneId)["is_hidden"] == 0, (
-            "Pre-condition failed: is_hidden should be 0 after reset"
+        persist as checked — verified via the form's re-rendered
+        checkbox state."""
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        assert not form.locator(
+            "input[type='checkbox'][name='is_hidden']"
+        ).is_checked(), (
+            "Pre-condition failed: is_hidden checkbox should be unchecked "
+            "after reset"
         )
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
         form.locator("input[type='checkbox'][name='is_hidden']").check()
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        stored = _get_zone_row(zoneId)["is_hidden"]
-        assert stored == 1, (
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        stored_checked = form.locator(
+            "input[type='checkbox'][name='is_hidden']"
+        ).is_checked()
+        assert stored_checked, (
             f"After checked-checkbox submit, is_hidden for {_TARGET_ZONE} "
-            f"should be 1; got {stored!r}"
+            f"should be checked; got is_checked={stored_checked!r}"
         )
 
     def test_uncheck_is_hidden_persists_to_db(self, page: Page, base_url):
-        """Pre-seed is_hidden=1, load form, leave checkbox UNCHECKED,
-        submit; is_hidden must persist as 0."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        _set_is_hidden(zoneId, 1)
-        assert _get_zone_row(zoneId)["is_hidden"] == 1, (
-            "Pre-condition failed: is_hidden should be 1 after seed"
+        """Pre-seed is_hidden checked via UI, load form, uncheck box,
+        submit; the re-rendered checkbox must be unchecked."""
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        _ui_seed_is_hidden(page, base_url, _TARGET_ZONE)
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        assert form.locator(
+            "input[type='checkbox'][name='is_hidden']"
+        ).is_checked(), (
+            "Pre-condition failed: is_hidden should be checked after seed"
         )
 
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
         # Uncheck the pre-checked box to simulate the admin clearing it.
         form.locator("input[type='checkbox'][name='is_hidden']").uncheck()
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        stored = _get_zone_row(zoneId)["is_hidden"]
-        assert stored == 0, (
-            f"Unchecked-checkbox submit must persist is_hidden=0; "
-            f"got {stored!r}"
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        stored_checked = form.locator(
+            "input[type='checkbox'][name='is_hidden']"
+        ).is_checked()
+        assert not stored_checked, (
+            f"Unchecked-checkbox submit must persist as unchecked; "
+            f"got is_checked={stored_checked!r}"
         )
 
     def test_is_hidden_regression_with_claimer_update(
@@ -388,28 +428,43 @@ class TestIsHiddenSchemaAndAdmin:
     ):
         """Regression guard: with the new checkbox in place, a POST
         that changes claimer_id while leaving the pre-checked is_hidden
-        alone must update the claimer AND keep is_hidden=1."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        _set_is_hidden(zoneId, 1)
-        alphaId = _get_controller_id_by_lastname("Alpha")
+        alone must update the claimer AND keep is_hidden checked."""
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        _ui_seed_is_hidden(page, base_url, _TARGET_ZONE)
 
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
+        # Pick an Alpha-lastname claimer option by its visible label
+        # (the select's option text is `firstname lastname`).
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        option_texts = form.locator(
+            "select[name='claimer_id'] option"
+        ).all_text_contents()
+        alpha_label = next(
+            (t.strip() for t in option_texts if t.strip().endswith("Alpha")),
+            None,
+        )
+        assert alpha_label, (
+            f"No Alpha-lastname option in claimer select; "
+            f"options seen: {option_texts!r}"
+        )
         # Leave the pre-checked box alone; only change claimer.
-        form.locator("select[name='claimer_id']").select_option(str(alphaId))
+        form.locator("select[name='claimer_id']").select_option(label=alpha_label)
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        row = _get_zone_row(zoneId)
-        assert row["claimer_controller_id"] == alphaId, (
-            "Claimer update did not persist alongside the is_hidden field"
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        selected_claimer = form.locator(
+            "select[name='claimer_id'] option:checked"
+        ).text_content().strip()
+        assert selected_claimer == alpha_label, (
+            f"Claimer update did not persist alongside the is_hidden field. "
+            f"Expected {alpha_label!r}, got {selected_claimer!r}"
         )
-        assert row["is_hidden"] == 1, (
+        stored_checked = form.locator(
+            "input[type='checkbox'][name='is_hidden']"
+        ).is_checked()
+        assert stored_checked, (
             "Regression: is_hidden was cleared by an unrelated claimer "
-            f"update; got {row['is_hidden']!r}"
+            f"update; got is_checked={stored_checked!r}"
         )
 
 

--- a/tests/test_hidden_zones_e2e.py
+++ b/tests/test_hidden_zones_e2e.py
@@ -347,6 +347,7 @@ class TestIsHiddenSchemaAndAdmin:
     presence, checkbox presence, tick/untick persistence, and the
     claimer-update regression guard."""
 
+    @pytest.mark.db
     def test_is_hidden_column_exists_in_zones_schema(self, page: Page, base_url):
         """After loading TestConfig, DESCRIBE zones must include an
         `is_hidden` column (D89.1 Option A: BOOL DEFAULT FALSE)."""
@@ -468,6 +469,7 @@ class TestIsHiddenSchemaAndAdmin:
         )
 
 
+@pytest.mark.db
 class TestHiddenZoneVisibility:
     """Runtime visibility of `is_hidden=1` zones: only the holder /
     claimer controller and GM see them; other non-privileged
@@ -602,6 +604,7 @@ class TestHiddenZoneVisibility:
         )
 
 
+@pytest.mark.db
 class TestBasePlacementGuard:
     """A crafted `createBase` GET against a hidden zone must be refused
     unless the caller is holder / claimer / GM. Non-holder Alpha is
@@ -726,6 +729,7 @@ class TestShikokuTakedasHiddenZone:
         Japon1555 zone names themselves contain `(...)`."""
         return page.locator("div.section.zones h3.title").all_text_contents()
 
+    @pytest.mark.db
     def test_kai_zone_exists_in_japon1555_scenario(
         self, page: Page, base_url
     ):

--- a/tests/test_ressource_gain_e2e.py
+++ b/tests/test_ressource_gain_e2e.py
@@ -28,6 +28,7 @@ from conftest import (
 )
 from helpers import (
     DB_AVAILABLE, end_turn, load_minimal_data, load_scenario_via_admin, safe_goto,
+    ui_turn_counter,
     register_php_error_listener, assert_no_collected_php_errors,
 )
 
@@ -192,20 +193,6 @@ def _ui_set_controller_ressource(page, controller_ressource_id, amount, amount_s
             "update_ressource": "1",
         },
     )
-
-
-def _ui_current_turn(page):
-    """Parse the current turncounter from the page header, rendered by
-    base/baseHTML.php as `<gameTitle> : <timeValue> <turncounter>`.
-    Assumes the browser is already logged in ; navigates to accueil.php
-    if the caller hasn't already loaded a page with the header."""
-    if not page.url.startswith(PHP_BASE_URL):
-        safe_goto(page, f"{PHP_BASE_URL}/base/accueil.php")
-        page.wait_for_load_state("load")
-    text = page.locator("div.header").first.text_content() or ""
-    m = _re.search(r'(\d+)', text)
-    assert m, f"No turncounter integer in header text: {text!r}"
-    return int(m.group(1))
 
 
 def _ui_read_amount(page, controller_id, ressource_name):
@@ -594,7 +581,7 @@ class TestRessourceGainUnlockTurnSkipsBeforeThreshold:
         gold_config_id = _ui_resolve_ressource_config_id(page, "Gold")
         alpha_gold_rc_id = _ui_resolve_controller_ressource_id(page, "Alpha", "Gold")
         zone_id = _ui_resolve_zone_id(page, "Alpha-Investigation")
-        locked_unlock_turn = _ui_current_turn(page) + 1
+        locked_unlock_turn = ui_turn_counter(page) + 1
 
         _ui_set_controller_ressource(page, alpha_gold_rc_id, amount=0)
         _ui_set_zone_holder(page, zone_id, alpha_id)
@@ -641,7 +628,7 @@ class TestRessourceGainUnlockTurnFiresAtThreshold:
         gold_config_id = _ui_resolve_ressource_config_id(page, "Gold")
         alpha_gold_rc_id = _ui_resolve_controller_ressource_id(page, "Alpha", "Gold")
         zone_id = _ui_resolve_zone_id(page, "Alpha-Investigation")
-        threshold_unlock_turn = _ui_current_turn(page)
+        threshold_unlock_turn = ui_turn_counter(page)
 
         _ui_set_controller_ressource(page, alpha_gold_rc_id, amount=0)
         _ui_set_zone_holder(page, zone_id, alpha_id)

--- a/tests/test_ressource_gain_e2e.py
+++ b/tests/test_ressource_gain_e2e.py
@@ -40,14 +40,6 @@ def _db_conn():
     )
 
 
-def _current_turn():
-    conn = _db_conn(); cur = conn.cursor()
-    cur.execute(f"SELECT turncounter FROM `{GAME_PREFIX}mechanics` LIMIT 1")
-    row = cur.fetchone()
-    cur.close(); conn.close()
-    return int(row['turncounter'])
-
-
 @pytest.fixture(scope="session")
 def base_url():
     return PHP_BASE_URL
@@ -200,6 +192,20 @@ def _ui_set_controller_ressource(page, controller_ressource_id, amount, amount_s
             "update_ressource": "1",
         },
     )
+
+
+def _ui_current_turn(page):
+    """Parse the current turncounter from the page header, rendered by
+    base/baseHTML.php as `<gameTitle> : <timeValue> <turncounter>`.
+    Assumes the browser is already logged in ; navigates to accueil.php
+    if the caller hasn't already loaded a page with the header."""
+    if not page.url.startswith(PHP_BASE_URL):
+        safe_goto(page, f"{PHP_BASE_URL}/base/accueil.php")
+        page.wait_for_load_state("load")
+    text = page.locator("div.header").first.text_content() or ""
+    m = _re.search(r'(\d+)', text)
+    assert m, f"No turncounter integer in header text: {text!r}"
+    return int(m.group(1))
 
 
 def _ui_read_amount(page, controller_id, ressource_name):
@@ -588,7 +594,7 @@ class TestRessourceGainUnlockTurnSkipsBeforeThreshold:
         gold_config_id = _ui_resolve_ressource_config_id(page, "Gold")
         alpha_gold_rc_id = _ui_resolve_controller_ressource_id(page, "Alpha", "Gold")
         zone_id = _ui_resolve_zone_id(page, "Alpha-Investigation")
-        locked_unlock_turn = _current_turn() + 1
+        locked_unlock_turn = _ui_current_turn(page) + 1
 
         _ui_set_controller_ressource(page, alpha_gold_rc_id, amount=0)
         _ui_set_zone_holder(page, zone_id, alpha_id)
@@ -635,7 +641,7 @@ class TestRessourceGainUnlockTurnFiresAtThreshold:
         gold_config_id = _ui_resolve_ressource_config_id(page, "Gold")
         alpha_gold_rc_id = _ui_resolve_controller_ressource_id(page, "Alpha", "Gold")
         zone_id = _ui_resolve_zone_id(page, "Alpha-Investigation")
-        threshold_unlock_turn = _current_turn()
+        threshold_unlock_turn = _ui_current_turn(page)
 
         _ui_set_controller_ressource(page, alpha_gold_rc_id, amount=0)
         _ui_set_zone_holder(page, zone_id, alpha_id)

--- a/tests/test_spend_ressources_insufficient_stock_e2e.py
+++ b/tests/test_spend_ressources_insufficient_stock_e2e.py
@@ -168,6 +168,7 @@ def _controller_ids(browser):
 # createBase
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestBuildBaseInsufficientStock:
     """createBase must abort cleanly when stock < base_building_cost: no new
     locations row, no ressource decrement, notification rendered."""
@@ -244,6 +245,7 @@ class TestBuildBaseInsufficientStock:
 # moveBase
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestMoveBaseInsufficientStock:
     """moveBase must abort cleanly when stock < base_moving_cost: locations
     row stays in original zone, no ressource decrement, notification rendered."""
@@ -325,6 +327,7 @@ class TestMoveBaseInsufficientStock:
 # repairLocation
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestRepairLocationInsufficientStock:
     """repairLocation must abort cleanly when stock < location_repaire_cost:
     locations row unchanged, no ressource decrement, notification rendered."""

--- a/tests/test_transformation_unlock_rules_e2e.py
+++ b/tests/test_transformation_unlock_rules_e2e.py
@@ -191,6 +191,7 @@ def _click_transform_via_get(browser, base_url, worker_lastname, power_name,
 # Direct controller_has_ressource gate
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestRessourceGate:
     """Direct check controller_has_ressource: power visible iff controller has
     at least the required amount."""
@@ -231,6 +232,7 @@ class TestRessourceGate:
 # consume opt-out semantics (default-deduct)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestConsumeBehavior:
     """Default behaviour: rule deducts unless explicit consume:false."""
 
@@ -278,6 +280,7 @@ class TestConsumeBehavior:
 # OR composition: zone-or-pay
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestORComposition:
     """First-match-wins on OR with cheaper-branch-first ordering: the zone
     branch is consulted first; if it matches, no deduction. Otherwise the
@@ -339,6 +342,7 @@ class TestORComposition:
 # direct + OR composition + cross-resource warning
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestDirectAndORComposition:
     """A rule can have both direct controller_has_ressource AND an OR
     branch carrying its own cost. Direct takes precedence; cross-resource
@@ -418,6 +422,7 @@ class TestMalformedAmount:
 # Commit-time re-validation closes the display-vs-commit security gap
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestCommitRevalidation:
     """A crafted GET that bypasses the form must be rejected at commit if
     the chosen power's rule no longer passes (or the worker is not in the
@@ -541,6 +546,7 @@ class TestCommitRevalidation:
 # Privileged admin path bypasses re-validation AND cost
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestAdminBypass:
     """gm has is_privileged → re-validation block short-circuited.
     Crafted GET that would 'plus disponible' for a player succeeds for gm,
@@ -591,6 +597,7 @@ class TestAdminBypass:
 # The escape hatch is intended for pure admin (no faction in session).
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class TestGmAsFactionEntersNormalPath:
     """Discovered on Japon1555 playtest : gm acting as Chōsokabe triggered
     a `consume: true` transform without paying the cost. Root cause : both

--- a/tests/test_unlock_turn_random_pick_e2e.py
+++ b/tests/test_unlock_turn_random_pick_e2e.py
@@ -154,6 +154,7 @@ def _advance_one_turn(browser):
 # Turn 0 — gated power excluded, baseline appears
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class Test01ExcludedAtTurnZero:
     """`unlock_turn: 2` means locked at turns 0..1. At turn 0 the gated
     power must never appear; a baseline ungated power must appear."""
@@ -186,6 +187,7 @@ class Test01ExcludedAtTurnZero:
 # Turn 1 — gated power still excluded
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class Test02ExcludedAtTurnOne:
     """Boundary case: turn 1 is one below the unlock_turn=2 threshold,
     so exclusion still holds."""
@@ -214,6 +216,7 @@ class Test02ExcludedAtTurnOne:
 # Turn 2 — gated power eligible (inclusive threshold)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class Test03EligibleAtThreshold:
     """At turn 2 (== unlock_turn value), the gated power becomes eligible."""
 
@@ -241,6 +244,7 @@ class Test03EligibleAtThreshold:
 # Turn 3 — eligibility holds above threshold
 # ---------------------------------------------------------------------------
 
+@pytest.mark.db
 class Test04EligibleAboveThreshold:
     """Above unlock_turn, eligibility holds — no regression at turn 3."""
 

--- a/tests/test_vampire_anchor_zones_e2e.py
+++ b/tests/test_vampire_anchor_zones_e2e.py
@@ -168,6 +168,7 @@ def _db():
     )
 
 
+@pytest.mark.db
 class TestPossessionORShape:
     """Regression on Vampire1966CSV's Possession power. Pre-fix the
     on_transformation.OR was a single object, which PHP iterated as

--- a/tests/test_zones_management_zones_e2e.py
+++ b/tests/test_zones_management_zones_e2e.py
@@ -32,14 +32,10 @@ Run:
 """
 import json
 
-import pymysql
 import pytest
 from playwright.sync_api import Page
 
-from conftest import (
-    GAME_PREFIX, MYSQL_HOST, MYSQL_PORT, MYSQL_USER, MYSQL_PASSWORD, MYSQL_DB,
-    PHP_BASE_URL, ensure_gm_login,
-)
+from conftest import PHP_BASE_URL, ensure_gm_login
 from helpers import (
     DB_AVAILABLE, load_minimal_data, load_scenario_via_admin, safe_goto,
 )
@@ -48,117 +44,6 @@ from helpers import (
 _TARGET_ZONE = "Zeta-Unclaimed"
 _VALID_JSON_STR = '{"Claim":{"zone_name":"Foo","value_delta":1}}'
 _INVALID_JSON_STR = "not json {"
-
-
-def _db_conn():
-    return pymysql.connect(
-        host=MYSQL_HOST, port=MYSQL_PORT, user=MYSQL_USER,
-        password=MYSQL_PASSWORD, database=MYSQL_DB,
-        charset="utf8mb4", cursorclass=pymysql.cursors.DictCursor,
-    )
-
-
-def _get_zone_id(zone_name):
-    """Return the id of the zone with the given name from the DB."""
-    conn = _db_conn()
-    cur = conn.cursor()
-    cur.execute(
-        f"SELECT id FROM `{GAME_PREFIX}zones` WHERE name=%s LIMIT 1",
-        (zone_name,),
-    )
-    row = cur.fetchone()
-    cur.close()
-    conn.close()
-    assert row, f"Zone {zone_name!r} not found in TestConfig"
-    return int(row["id"])
-
-
-def _get_zone_row(zone_id):
-    """Return {zone_rules, adjacent_zones, claimer_controller_id,
-    holder_controller_id} for a zone id."""
-    conn = _db_conn()
-    cur = conn.cursor()
-    cur.execute(
-        f"SELECT zone_rules, adjacent_zones, claimer_controller_id, "
-        f"       holder_controller_id "
-        f"FROM `{GAME_PREFIX}zones` WHERE id=%s",
-        (zone_id,),
-    )
-    row = cur.fetchone()
-    cur.close()
-    conn.close()
-    return row
-
-
-def _get_controller_id_by_lastname(lastname):
-    """Return a controller id by lastname (used for the claimer regression)."""
-    conn = _db_conn()
-    cur = conn.cursor()
-    cur.execute(
-        f"SELECT id FROM `{GAME_PREFIX}controllers` WHERE lastname=%s LIMIT 1",
-        (lastname,),
-    )
-    row = cur.fetchone()
-    cur.close()
-    conn.close()
-    assert row, f"Controller lastname={lastname!r} not found"
-    return int(row["id"])
-
-
-def _set_zone_rules(zone_id, value):
-    """Direct DB write of `zone_rules` (raw string or None)."""
-    conn = _db_conn()
-    cur = conn.cursor()
-    cur.execute(
-        f"UPDATE `{GAME_PREFIX}zones` SET zone_rules=%s WHERE id=%s",
-        (value, zone_id),
-    )
-    conn.commit()
-    cur.close()
-    conn.close()
-
-
-def _set_adjacent_zones(zone_id, value):
-    """Direct DB write of `adjacent_zones` (raw string)."""
-    conn = _db_conn()
-    cur = conn.cursor()
-    cur.execute(
-        f"UPDATE `{GAME_PREFIX}zones` SET adjacent_zones=%s WHERE id=%s",
-        (value, zone_id),
-    )
-    conn.commit()
-    cur.close()
-    conn.close()
-
-
-def _reset_zone(zone_id):
-    """Wipe zone_rules + claimer + holder + adjacent_zones on the target
-    row so each test starts from a known baseline."""
-    conn = _db_conn()
-    cur = conn.cursor()
-    cur.execute(
-        f"UPDATE `{GAME_PREFIX}zones` "
-        f"SET zone_rules=NULL, claimer_controller_id=NULL, "
-        f"    holder_controller_id=NULL, adjacent_zones='' "
-        f"WHERE id=%s",
-        (zone_id,),
-    )
-    conn.commit()
-    cur.close()
-    conn.close()
-
-
-def _row_form_locator(page, zone_id):
-    """Return the row locator for the zone whose hidden zone_id matches.
-
-    Uses `tr:has(...)` rather than `form:has(...)` because the page uses
-    the standard `<tr> <form>...</form> </tr>` pattern (matching
-    ressources/management.php). Chromium's HTML5 parser DOM-evicts the
-    <form> element in that pattern, so form-scoped locators return no
-    matches; scoping by the enclosing <tr> is the reliable path."""
-    return page.locator(
-        f"tr:has(input[name='zone_id'][value='{zone_id}'])"
-    )
 
 
 def _row_locator_by_name(page, zone_name):
@@ -282,27 +167,37 @@ class TestZoneRulesAdminEdit:
 
     def test_empty_textarea_sets_null(self, page: Page, base_url):
         """Pre-seeding zone_rules to a valid JSON and then submitting
-        the row's form with the textarea cleared must NULL the column."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        _set_zone_rules(zoneId, _VALID_JSON_STR)
-        assert _get_zone_row(zoneId)["zone_rules"] is not None, (
-            "Pre-condition failed: zone_rules should be seeded before submit"
+        the row's form with the textarea cleared must NULL the column —
+        verified via the textarea's `data-value-is-null` attribute set
+        by management_zones.php from the PHP `=== null` check."""
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        # Seed via UI submit
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        form.locator("textarea[name='zone_rules']").fill(_VALID_JSON_STR)
+        form.locator("button[type='submit']").click()
+        page.wait_for_load_state("load")
+
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        seed_null_attr = form.locator(
+            "textarea[name='zone_rules']"
+        ).get_attribute("data-value-is-null")
+        assert seed_null_attr == "false", (
+            "Pre-condition failed: zone_rules should be non-null after "
+            f"seed; data-value-is-null={seed_null_attr!r}"
         )
 
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
         # `fill('')` empties the textarea to simulate the admin clearing it.
         form.locator("textarea[name='zone_rules']").fill("")
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        stored = _get_zone_row(zoneId)["zone_rules"]
-        assert stored is None, (
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        stored_null_attr = form.locator(
+            "textarea[name='zone_rules']"
+        ).get_attribute("data-value-is-null")
+        assert stored_null_attr == "true", (
             "Empty textarea submit must NULL zone_rules; "
-            f"found {stored!r}"
+            f"data-value-is-null={stored_null_attr!r}"
         )
 
     def test_claimer_holder_update_still_works_alongside_zone_rules(
@@ -414,29 +309,38 @@ class TestAdjacentZonesAdminEdit:
         self, page: Page, base_url
     ):
         """Pre-seed adjacent_zones to `1,2,3`, then submit with the
-        textarea cleared. Result must be an empty string, NOT NULL —
-        the column is TEXT with an empty-string default."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        _set_adjacent_zones(zoneId, "1,2,3")
-        assert _get_zone_row(zoneId)["adjacent_zones"] == "1,2,3", (
-            "Pre-condition failed: adjacent_zones seeded to '1,2,3'"
+        input cleared. Result must be an empty string, NOT NULL — the
+        column is TEXT with an empty-string default. Verified via the
+        input's `data-value-is-null='false'` attribute (PHP `=== null`
+        check exposes the DB-level distinction between `""` and NULL)."""
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        # Seed via UI submit
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        form.locator("input[name='adjacent_zones']").fill("1,2,3")
+        form.locator("button[type='submit']").click()
+        page.wait_for_load_state("load")
+
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        seeded = form.locator("input[name='adjacent_zones']").input_value()
+        assert seeded == "1,2,3", (
+            f"Pre-condition failed: adjacent_zones should be '1,2,3' "
+            f"after seed; got {seeded!r}"
         )
 
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
         form.locator("input[name='adjacent_zones']").fill("")
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        stored = _get_zone_row(zoneId)["adjacent_zones"]
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        input_locator = form.locator("input[name='adjacent_zones']")
+        stored = input_locator.input_value()
+        is_null_attr = input_locator.get_attribute("data-value-is-null")
         assert stored == "", (
-            "Empty textarea submit must store '' (empty string), NOT NULL "
-            f"and not the pre-seed. Got {stored!r}"
+            "Empty input submit must store '' (empty string), NOT the "
+            f"pre-seed. Got {stored!r}"
         )
-        assert stored is not None, (
+        assert is_null_attr == "false", (
             "adjacent_zones must NOT be NULL — it is a TEXT column with "
-            "empty-string semantics on clear."
+            f"empty-string semantics on clear. data-value-is-null="
+            f"{is_null_attr!r}"
         )

--- a/tests/test_zones_management_zones_e2e.py
+++ b/tests/test_zones_management_zones_e2e.py
@@ -161,6 +161,29 @@ def _row_form_locator(page, zone_id):
     )
 
 
+def _row_locator_by_name(page, zone_name):
+    """UI-only row lookup by the visible zone name column."""
+    return page.locator(
+        f"tr:has(td:text-is('{zone_name}'))"
+    )
+
+
+def _ui_reset_zone_row(page, base_url, zone_name):
+    """UI-only reset: navigate to management_zones.php and submit the row
+    for `zone_name` with claimer / holder / adjacent_zones / zone_rules
+    cleared. Leaves the browser on the reloaded page. Preserves is_hidden."""
+    ensure_gm_login(page, base_url)
+    safe_goto(page, f"{base_url}/zones/management_zones.php")
+    page.wait_for_load_state("load")
+    form = _row_locator_by_name(page, zone_name)
+    form.locator("textarea[name='zone_rules']").fill("")
+    form.locator("input[name='adjacent_zones']").fill("")
+    form.locator("select[name='claimer_id']").select_option("")
+    form.locator("select[name='holder_id']").select_option("")
+    form.locator("button[type='submit']").click()
+    page.wait_for_load_state("load")
+
+
 @pytest.fixture(scope="session")
 def base_url():
     return PHP_BASE_URL
@@ -203,21 +226,19 @@ class TestZoneRulesAdminEdit:
 
     def test_valid_json_persists_to_db(self, page: Page, base_url):
         """Filling the row's textarea with valid JSON and submitting
-        must write the JSON to `zones.zone_rules` in the DB."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
+        must write the JSON to `zones.zone_rules` — verified via the
+        form's own re-rendered textarea value."""
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        form = _row_locator_by_name(page, _TARGET_ZONE)
         form.locator("textarea[name='zone_rules']").fill(_VALID_JSON_STR)
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        stored = _get_zone_row(zoneId)["zone_rules"]
-        assert stored is not None, (
-            f"After valid-JSON submit, zone_rules for {_TARGET_ZONE} "
-            f"is still NULL"
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        stored = form.locator("textarea[name='zone_rules']").input_value()
+        assert stored != "", (
+            f"After valid-JSON submit, zone_rules textarea for "
+            f"{_TARGET_ZONE} is still empty"
         )
         # Accept either the exact string or a json.loads-equal value —
         # the handler re-encodes via json_encode which can reorder keys
@@ -236,15 +257,13 @@ class TestZoneRulesAdminEdit:
     def test_invalid_json_rejected_no_db_write(self, page: Page, base_url):
         """Submitting a broken JSON string must NOT write to the DB and
         must render a red error message reusing `$update_msg`."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        assert _get_zone_row(zoneId)["zone_rules"] is None, (
-            "Pre-condition failed: zone_rules should be NULL after reset"
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        pre = form.locator("textarea[name='zone_rules']").input_value()
+        assert pre == "", (
+            f"Pre-condition failed: zone_rules textarea should be empty "
+            f"after reset, got {pre!r}"
         )
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
         form.locator("textarea[name='zone_rules']").fill(_INVALID_JSON_STR)
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
@@ -254,10 +273,11 @@ class TestZoneRulesAdminEdit:
             "Expected an error message with `color: red` after invalid "
             "JSON submit — none rendered"
         )
-        stored = _get_zone_row(zoneId)["zone_rules"]
-        assert stored is None, (
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        stored = form.locator("textarea[name='zone_rules']").input_value()
+        assert stored == "", (
             f"Invalid-JSON submit must NOT have written zone_rules; "
-            f"found {stored!r}"
+            f"textarea shows {stored!r}"
         )
 
     def test_empty_textarea_sets_null(self, page: Page, base_url):
@@ -292,29 +312,45 @@ class TestZoneRulesAdminEdit:
         that changes claimer_id while leaving the textarea at its
         prefilled value must still update the claimer AND must NOT
         disturb the existing zone_rules payload."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        _set_zone_rules(zoneId, _VALID_JSON_STR)
-        alphaId = _get_controller_id_by_lastname("Alpha")
-
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
-        # Read the textarea's prefill so the POST re-submits it unchanged
-        # (mirrors how the admin would leave it alone in the UI). This
-        # call fails in RED because the textarea does not yet exist.
-        prefill = form.locator("textarea[name='zone_rules']").input_value()
-        form.locator("select[name='claimer_id']").select_option(str(alphaId))
+        # UI reset then seed zone_rules via a submit (the same UI path
+        # a normal admin would use).
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        form.locator("textarea[name='zone_rules']").fill(_VALID_JSON_STR)
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        row = _get_zone_row(zoneId)
-        assert row["claimer_controller_id"] == alphaId, (
-            "Claimer update did not persist alongside the zone_rules field"
+        # Pick an Alpha-lastname claimer option by its visible label
+        # (the select's option text is `firstname lastname`).
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        option_texts = form.locator(
+            "select[name='claimer_id'] option"
+        ).all_text_contents()
+        alpha_label = next(
+            (t.strip() for t in option_texts if t.strip().endswith("Alpha")),
+            None,
         )
-        stored = row["zone_rules"]
-        assert stored is not None, (
+        assert alpha_label, (
+            f"No Alpha-lastname option in claimer select; "
+            f"options seen: {option_texts!r}"
+        )
+        # Read the textarea's prefill so the POST re-submits it unchanged
+        # (mirrors how the admin would leave it alone in the UI).
+        prefill = form.locator("textarea[name='zone_rules']").input_value()
+        form.locator("select[name='claimer_id']").select_option(label=alpha_label)
+        form.locator("button[type='submit']").click()
+        page.wait_for_load_state("load")
+
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        selected_claimer = form.locator(
+            "select[name='claimer_id'] option:checked"
+        ).text_content().strip()
+        assert selected_claimer == alpha_label, (
+            f"Claimer update did not persist alongside the zone_rules field."
+            f" Expected {alpha_label!r}, got {selected_claimer!r}"
+        )
+        stored = form.locator("textarea[name='zone_rules']").input_value()
+        assert stored != "", (
             "Regression: zone_rules was cleared by an unrelated claimer update"
         )
         assert json.loads(stored) == json.loads(_VALID_JSON_STR), (
@@ -343,37 +379,32 @@ class TestAdjacentZonesAdminEdit:
         )
 
     def test_adjacent_zones_persists_to_db(self, page: Page, base_url):
-        """Filling the row's adjacent_zones textarea with `2,4` and
-        submitting must write exactly `2,4` to the DB column."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
+        """Filling the row's adjacent_zones input with `2,4` and
+        submitting must persist exactly `2,4` — verified via the form's
+        re-rendered input value."""
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        form = _row_locator_by_name(page, _TARGET_ZONE)
         form.locator("input[name='adjacent_zones']").fill("2,4")
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        stored = _get_zone_row(zoneId)["adjacent_zones"]
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        stored = form.locator("input[name='adjacent_zones']").input_value()
         assert stored == "2,4", (
             f"Expected adjacent_zones='2,4' after submit; got {stored!r}"
         )
 
     def test_adjacent_zones_trimmed_on_submit(self, page: Page, base_url):
         """Leading/trailing whitespace around the input must be trimmed
-        before storing. `  2,4  ` -> `2,4` in the DB."""
-        zoneId = _get_zone_id(_TARGET_ZONE)
-        _reset_zone(zoneId)
-        ensure_gm_login(page, base_url)
-        safe_goto(page, f"{base_url}/zones/management_zones.php")
-        page.wait_for_load_state("load")
-        form = _row_form_locator(page, zoneId)
+        before storing. `  2,4  ` -> `2,4` (verified via form re-render)."""
+        _ui_reset_zone_row(page, base_url, _TARGET_ZONE)
+        form = _row_locator_by_name(page, _TARGET_ZONE)
         form.locator("input[name='adjacent_zones']").fill("  2,4  ")
         form.locator("button[type='submit']").click()
         page.wait_for_load_state("load")
 
-        stored = _get_zone_row(zoneId)["adjacent_zones"]
+        form = _row_locator_by_name(page, _TARGET_ZONE)
+        stored = form.locator("input[name='adjacent_zones']").input_value()
         assert stored == "2,4", (
             f"Expected trimmed adjacent_zones='2,4' after submit; "
             f"got {stored!r}"

--- a/zones/management_zones.php
+++ b/zones/management_zones.php
@@ -122,10 +122,10 @@ require_once '../base/baseHTML.php';
             </td>
             <td data-field="adjacent_zones"><?= htmlspecialchars($adjacentNames) ?></td>
             <td>
-                <input type="text" name="adjacent_zones" size="20" value="<?= htmlspecialchars($zone['adjacent_zones'] ?? '') ?>">
+                <input type="text" name="adjacent_zones" data-value-is-null="<?= $zone['adjacent_zones'] === null ? 'true' : 'false' ?>" size="20" value="<?= htmlspecialchars($zone['adjacent_zones'] ?? '') ?>">
             </td>
             <td>
-                <textarea name="zone_rules" rows="4" cols="60"><?= htmlspecialchars($zone['zone_rules'] ?? '') ?></textarea>
+                <textarea name="zone_rules" data-value-is-null="<?= $zone['zone_rules'] === null ? 'true' : 'false' ?>" rows="4" cols="60"><?= htmlspecialchars($zone['zone_rules'] ?? '') ?></textarea>
             </td>
             <td>
                 <input type="checkbox" name="is_hidden" value="1" <?= !empty($zone['is_hidden']) ? 'checked' : '' ?>>


### PR DESCRIPTION
Closes #99.

## Résumé

Sprint #99 — tests use `pymysql` without `@pytest.mark.db` marker breaking Demo (UI_ONLY=1).

- **12 tests refactored to UI-only** (Pattern A form re-render + Pattern C data-attribute + Pattern H header parse)
- **35 tests marked `@pytest.mark.db`** where UI-only would need >1 PHP line change
- **1 PHP line change** on `zones/management_zones.php` (data-value-is-null attribute for NULL vs "" distinction)
- **8 unused DB helpers deleted** from test_zones_management_zones_e2e.py post-refactor

## Commits (6)
- `a659ff2` File 1 Pattern A (5 tests)
- `b32a8b4` File 2 Pattern A (3 tests)
- `5eba157` File 1 Pattern C (2 tests + PHP data-attr)
- `39142b3` transformation_unlock @db bulk (17 tests)
- `a94874f` ressource_gain Pattern H (2 tests)
- `ab6373a` bulk @db on 4 remaining files (18 tests) + Pattern H fix

## Test plan

- [x] Local pytest v99 final : 528/528 pass in 24:27 on `ab6373a`
- [x] Sonnet reviews per batch : all SHIP
- [x] Demo run (UI_ONLY=1) to verify 35 @db tests skip correctly + 12 refactored tests pass UI-only
- [x] CI green

## Known follow-ups

1. `_require_db` autouse fixture in some files skips ALL tests when local MySQL unreachable — systemic pre-existing gap, not blocking on this PR
2. `worker_powers` DELETE has no admin UI — 17 transformation_unlock tests stay @db until such UI is built