### PR TITLE
fix : suppress known forward-ref warnings + test coverage (#103)

### DIFF
--- a/BDD/db_connector.php
+++ b/BDD/db_connector.php
@@ -360,10 +360,11 @@ function resolveControllerOriginZones(PDO $pdo, string $controllersCsvPath): int
  * @param string $csvFile : absolute path to CSV file
  * @param string $tableName : target table name (without prefix)
  * @param array $columns : column headers as declared in the CSV; may include lookup and linkTable_ specs
+ * @param array $knownForwardRefs : columns whose FK lookup is expected to fail on first pass (later resolved by a post-load fixup like resolveControllerOriginZones). Warning is suppressed for these ; value silently stays NULL.
  *
  * @return bool : true on success, false when the file is missing or a fatal PDO exception was caught
  */
-function loadCSVFile(PDO $pdo, string $csvFile, string $tableName, array $columns): bool
+function loadCSVFile(PDO $pdo, string $csvFile, string $tableName, array $columns, array $knownForwardRefs = []): bool
 {
     // $GLOBALS['DEBUG_LOG_SECTIONS'][] = __FUNCTION__;  // uncomment to log DEBUG events from this function
     game_error_log(__FUNCTION__, 'START with tableName : ' . $tableName, ['csvFile' => $csvFile, 'columns' => $columns], 'debug');
@@ -574,9 +575,12 @@ function loadCSVFile(PDO $pdo, string $csvFile, string $tableName, array $column
                     if (isset($lookupCaches[$dbCol][$lookupValue])) {
                         $values[] = $lookupCaches[$dbCol][$lookupValue];
                     } else {
-                        if ($lookupValue !== '') {
+                        if ($lookupValue !== '' && !in_array($col, $knownForwardRefs, true)) {
                             echo "Warning: Lookup value '{$lookupValue}' not found for {$col} in row " . ($rowCount + 1) . ".<br />";
                             echo "from: " . var_export($rowData, true) . "<br />";
+                        } elseif ($lookupValue !== '') {
+                            // Known forward-ref : a post-load fixup will resolve this ; keep silent but log for audit.
+                            game_error_log(__FUNCTION__, 'Forward-ref skipped', ['tableName' => $tableName, 'col' => $col, 'lookupValue' => $lookupValue, 'row' => $rowCount + 1], 'debug');
                         }
                         $values[] = null;
                     }
@@ -885,7 +889,10 @@ function gameReady(): PDO|null
                             echo 'Start <br />';
 
                             if (in_array($fileName, ['power_types', 'factions', 'players', 'controllers', 'player_controller', 'ressources_config', 'controller_ressources', 'locations', 'artefacts', 'worker_origins', 'worker_names', 'config', 'zones'])) {
-                                loadCSVFile($pdo, $csvFile, $fileName, $columns);
+                                // controllers.origin_zone_id references zones which load AFTER controllers ;
+                                // the resolveControllerOriginZones post-load fixup runs before locations to fill it in.
+                                $knownForwardRefs = ($fileName === 'controllers') ? ['zones__name->origin_zone_id'] : [];
+                                loadCSVFile($pdo, $csvFile, $fileName, $columns, $knownForwardRefs);
                             } else {
                                 // For base and zones, they contain complex SQL with subqueries
                                 // CSV support for these would require more complex handling

--- a/tests/test_admin_csv_load_e2e.py
+++ b/tests/test_admin_csv_load_e2e.py
@@ -34,6 +34,18 @@ def table_row_count(table_name):
     return count
 
 
+def null_column_count(table_name: str, column: str) -> int:
+    """Count rows in a prefixed table where the given column IS NULL."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        f"SELECT COUNT(*) as c FROM `{GAME_PREFIX}{table_name}` WHERE `{column}` IS NULL"
+    )
+    count = cursor.fetchone()["c"]
+    conn.close()
+    return count
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -245,6 +257,15 @@ class TestCSVLoadViaAdmin:
         assert "<b>Warning</b>" not in page_html, \
             "PHP warnings found on page after Japon1555CSV reset"
 
+        # Issue #103 : the controllers CSV has forward-refs to zones (loaded later).
+        # The loader must NOT emit a "Warning: Lookup value not found" for the
+        # zones__name->origin_zone_id column — resolveControllerOriginZones
+        # fixes it up after zones are loaded.
+        assert "Warning: Lookup value" not in page_html, (
+            "Issue #103 regression : forward-reference warnings should be "
+            "suppressed for known-forward-ref columns"
+        )
+
         # Verify CSV load success messages with exact row counts
         zones_n = csv_row_count("setupJapon1555CSV_zones.csv")
         assert "setupJapon1555CSV_worker_origins.csv loaded successfully (13 rows)" in page_html, \
@@ -279,6 +300,13 @@ class TestCSVLoadViaAdmin:
         assert table_row_count("workers") == 9, \
             "Japon1555CSV advanced should create exactly 9 workers"
 
+        # Issue #103 : after the resolveControllerOriginZones post-load fixup,
+        # every controller must have its origin_zone_id populated.
+        assert null_column_count("controllers", "origin_zone_id") == 0, (
+            "Issue #103 regression : controllers with NULL origin_zone_id "
+            "after Japon1555CSV load — resolveControllerOriginZones fixup broken"
+        )
+
         # Verify page header reflects Japon1555 scenario
         safe_goto(logged_in_page, f"{base_url}/base/accueil.php")
         logged_in_page.wait_for_load_state("networkidle")
@@ -306,6 +334,13 @@ class TestCSVLoadViaAdmin:
         # No PHP warnings should appear on the page
         assert "<b>Warning</b>" not in page_html, \
             "PHP warnings found on page after Vampire1966CSV reset"
+
+        # Issue #103 : forward-reference warnings must be suppressed for
+        # controllers.origin_zone_id (resolved by post-load fixup).
+        assert "Warning: Lookup value" not in page_html, (
+            "Issue #103 regression : forward-reference warnings should be "
+            "suppressed for known-forward-ref columns"
+        )
 
         # Verify CSV load success messages with exact row counts
         assert "setupVampire1966CSV_worker_origins.csv loaded successfully (12 rows)" in page_html, \
@@ -339,6 +374,13 @@ class TestCSVLoadViaAdmin:
         # Workers from advanced.csv (3 rows × 1 worker each)
         assert table_row_count("workers") == 3, \
             "Vampire1966CSV advanced should create exactly 3 workers"
+
+        # Issue #103 : after the resolveControllerOriginZones post-load fixup,
+        # every controller must have its origin_zone_id populated.
+        assert null_column_count("controllers", "origin_zone_id") == 0, (
+            "Issue #103 regression : controllers with NULL origin_zone_id "
+            "after Vampire1966CSV load — resolveControllerOriginZones fixup broken"
+        )
 
         # Verify page header reflects Vampire1966 scenario
         safe_goto(logged_in_page, f"{base_url}/base/accueil.php")


### PR DESCRIPTION
Closes #103.

## Résumé

Le chargement CSV `controllers` référence `zones__name->origin_zone_id`, mais zones charge APRES controllers dans le pipeline (\`db_connector.php\` load order). Le FK lookup échoue au premier passage → warning bruyant sur la page admin.php. Un fixup post-zones (\`resolveControllerOriginZones\`) UPDATE ensuite `origin_zone_id` pour chaque controller — donc la NULL est transitoire. Les warnings sont du bruit design, pas de bugs.

## A. Suppression des warnings known-forward-ref

- `loadCSVFile()` gains un param optionnel `$knownForwardRefs = []` — liste de colonnes CSV dont le lookup FK est attendu échouer sur le premier passage
- Le echo warning est skip pour ces cols ; un `game_error_log('debug')` remplace pour audit trail
- Le caller (admin.php load loop) passe `['zones__name->origin_zone_id']` pour la table `controllers`

## B. Test coverage post-fixup

Ajout de :
- Helper `null_column_count(table, column)` dans `tests/test_admin_csv_load_e2e.py`
- 2 assertions inline sur `test_full_reset_japon1555_csv` + `test_full_reset_vampire1966_csv` :
  1. `"Warning: Lookup value"` absent de la load output (A regression guard)
  2. `controllers.origin_zone_id` NULL count == 0 (fixup regression guard)

## Test plan

- [x] Local pytest full : **528/528 pass** en 30:03
- [x] `php -l BDD/db_connector.php` clean
- [x] Manual verify : Japon1555CSV load → 0 warnings, 11 controllers with populated origin_zone_id
- [ ] CI green sur les 2 matrix shards

## Notes

- Pattern est extensible : d'autres forward-refs pourront rejoindre `$knownForwardRefs` si de nouveaux fixups post-load émergent
- Les tests couvrent Japon1555CSV + Vampire1966CSV (les 2 scenarios impactés). TestConfig n'est pas touché (pas de forward-ref origin_zone_id)